### PR TITLE
Update release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 12
+        registry-url: https://registry.npmjs.org/
 
     - name: Install locked dependencies 🔧
       run: npm ci
@@ -30,6 +31,6 @@ jobs:
       run: npm test
 
     - name: Publish 📚
-      run: npm publish
+      run: npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

NPM packages published to an org are by default private. We need to set a flag to make sure we have a public package.