### PR TITLE
Update sync for NYPL main branch change

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,8 +13,8 @@ jobs:
     env:
       REMOTE_ORG: NYPL-Simplified
       REMOTE_REPO: circulation-web
-      REMOTE_BRANCH: master
-      LOCAL_BRANCH: nypl/master
+      REMOTE_BRANCH: main
+      LOCAL_BRANCH: nypl/main
 
     steps:
     - name: Checkout local branch


### PR DESCRIPTION

## Description

Change source and target branches for sync of [Simplified circulation-web](http://github.com/NYPL-Simplified/circulation-web).

## Motivation and Context

NYPL has changed their primary [circulation-web](http://github.com/NYPL-Simplified/circulation-web) branch from `master` to `main`.
