### PR TITLE
Avoid some columns collapsing when other columns contain long names/titles.

### DIFF
--- a/src/stylesheets/custom_lists_sidebar.scss
+++ b/src/stylesheets/custom_lists_sidebar.scss
@@ -1,4 +1,5 @@
 .custom-lists-sidebar {
+  min-width: 15em;
   border: 1px solid $gray;
   padding: 15px;
   margin: 7px 7px 15px 7px;

--- a/src/stylesheets/lane_editor.scss
+++ b/src/stylesheets/lane_editor.scss
@@ -81,6 +81,7 @@
 
   .available-lists, .current-lists {
     display: flex;
+    min-width: 20em;
     flex-direction: column;
     flex-basis: 44%;
     margin-top: 15px;
@@ -109,6 +110,7 @@
 
       .available-list, .current-list {
         display: flex;
+        min-width: 20em;
         flex-direction: row;
         justify-content: space-between;
         align-items: center;


### PR DESCRIPTION
## Description

Specifies minimum width for some CSS selectors to prevent columns collapsing when other columns contain long names/titles

## Motivation and Context

This is affecting the custom list manager for several of our libraries.

## How Has This Been Tested?

Manual testing by modifying values in the browser developer tools.

## Checklist:

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.