### PR TITLE
Allow Redux DevTools browser extension to be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ There are end-to-end tests that run on Nightwatch. This selenium-based test runn
 
 To set up credentials and run the tests, check out the [README](/tests/README.md) in `/tests/.
 
+## Debugging
+
+The [Redux DevTools browser extension](https://github.com/reduxjs/redux-devtools/tree/main/extension) may be used to easily inspect app states and state transitions.
+
 ## License
 
 ```

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,5 @@
 import {
+  compose,
   createStore,
   combineReducers,
   applyMiddleware,
@@ -14,8 +15,15 @@ const reducers: Reducer = combineReducers({
   catalog: catalogReducers,
 });
 
+const composeEnhancers =
+  window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] || compose;
+
 /** Build a redux store with reducers specific to the admin interface
     as well as reducers from opds-web-client. */
 export default function buildStore(initialState?: State): Store<State> {
-  return createStore(reducers, initialState, applyMiddleware(thunk));
+  return createStore(
+    reducers,
+    initialState,
+    composeEnhancers(applyMiddleware(thunk))
+  );
 }


### PR DESCRIPTION
## Description

This allows the [Redux DevTools browser extension](https://github.com/reduxjs/redux-devtools/tree/main/extension) to be used on the app. 

## Motivation and Context

This is very helpful for debugging, allowing state changes in the app to be easily inspected.

## How Has This Been Tested?

1. Install the Redux DevTools browser extension in Chrome or Firefox. 
2. Run the circulation-admin app.
3. Open the Redux tab in the browser's dev tools, and see that actions are logged as the app is used.

Also ensure that the app continues to run correctly in browsers that do not have the Redux DevTools extension installed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
