### PR TITLE
Change button/link color to Palace dark blue.

### DIFF
--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -1,6 +1,6 @@
 .announcements-section {
   ul.announcements-ul {
-    border: 1px solid $blue-dark;
+    border: 1px solid $blue;
     padding: 16px 16px 6px 16px;
     list-style: none;
     > h4 {
@@ -11,7 +11,7 @@
       margin-bottom: 0;
     }
     > hr {
-      border-color: $blue-dark;
+      border-color: $blue;
       margin-top: 1vh;
     }
     .announcement {
@@ -30,8 +30,8 @@
         }
         span {
           padding: 16px 12px;
-          border-left: 1px solid $blue-dark;
-          border-right: 1px solid $blue-dark;
+          border-left: 1px solid $blue;
+          border-right: 1px solid $blue;
         }
         .dates {
           display: block;
@@ -43,14 +43,14 @@
       }
       hr {
         width: 96%;
-        border-color: $blue-dark;
+        border-color: $blue;
         margin: 0 auto;
       }
       .buttons {
         padding: 10px 8px 0 10px;
-        border-left: 1px solid $blue-dark;
-        border-right: 1px solid $blue-dark;
-        border-bottom: 1px solid $blue-dark;
+        border-left: 1px solid $blue;
+        border-right: 1px solid $blue;
+        border-bottom: 1px solid $blue;
       }
     }
   }

--- a/src/stylesheets/book_details_container.scss
+++ b/src/stylesheets/book_details_container.scss
@@ -9,7 +9,7 @@
     margin: 0 0 20px;
 
     svg {
-      fill: $blue;
+      fill: $blue-dark;
     }
   }
   .custom-list-for-book {
@@ -21,9 +21,9 @@
         border-radius: .25em;
         border: 1px solid darken($gray-tint, 5);
         padding-left: 8px;
-        color: $blue;
+        color: $blue-dark;
         &:hover {
-          color: $blue-dark;
+          color: $blue;
         }
       }
       .add-list-item-container {
@@ -49,11 +49,11 @@
           width: 100%;
           padding-bottom: 6px;
           margin-bottom: 8px;
-          border-bottom: 1px solid $blue;
+          border-bottom: 1px solid $blue-dark;
           font-weight: bold;
-          color: $blue;
+          color: $blue-dark;
           &:hover {
-            color: $blue-dark;
+            color: $blue;
           }
         }
         p {

--- a/src/stylesheets/book_details_tab_container.scss
+++ b/src/stylesheets/book_details_tab_container.scss
@@ -2,7 +2,7 @@
   .nav-tabs {
     li {
       a {
-        color: $blue;
+        color: $blue-dark;
         &:active,
         &:visited,
         &:hover {
@@ -45,15 +45,15 @@
           margin: auto;
           .circulation-links {
             padding-bottom: 1em;
-            border-bottom: 1px solid $blue;
+            border-bottom: 1px solid $blue-dark;
             .btn {
-              color: $blue;
-              border-color: $blue;
+              color: $blue-dark;
+              border-color: $blue-dark;
               background-color: $white;
               margin: 5px 10px;
               &:hover {
                 color: $white;
-                background-color: $blue;
+                background-color: $blue-dark;
               }
             }
           }

--- a/src/stylesheets/catalog_overrides.scss
+++ b/src/stylesheets/catalog_overrides.scss
@@ -1,11 +1,11 @@
 .collection-container {
   .book a {
-    color: $blue;
+    color: $blue-dark;
     .item-icon svg {
-      fill: $blue;
+      fill: $blue-dark;
     }
     &:hover {
-      color: $blue-dark;
+      color: $blue;
       .item-icon svg {
         fill: $blue-dark;
       }
@@ -15,14 +15,14 @@
     }
   }
   .more-link div {
-    color: $blue;
+    color: $blue-dark;
     svg {
-      fill: $blue;
+      fill: $blue-dark;
     }
     &:hover {
-      color: $blue-dark;
+      color: $blue;
       svg {
-        fill: $blue-dark;
+        fill: $blue;
       }
     }
   }

--- a/src/stylesheets/custom_list_editor.scss
+++ b/src/stylesheets/custom_list_editor.scss
@@ -113,7 +113,7 @@ fieldset.search-options.well {
   width: unset;
   padding-bottom: 20px;
   legend {
-    background-color: $blue;
+    background-color: $blue-dark;
   }
   ul, section {
     list-style: none;
@@ -121,23 +121,23 @@ fieldset.search-options.well {
     margin: auto;
     padding: 15px;
     border-radius: 4px 4px 0 0;
-    border-left: 1px solid $blue-dark;
-    border-right: 1px solid $blue-dark;
-    border-top: 1px solid $blue-dark;
+    border-left: 1px solid $blue;
+    border-right: 1px solid $blue;
+    border-top: 1px solid $blue;
     li .form-group {
       margin: 0;
     }
   }
   section {
-    border-bottom: 1px solid $blue-dark;
+    border-bottom: 1px solid $blue;
     border-radius: 4px;
   }
   p {
-    border-left: 1px solid $blue-dark;
-    border-right: 1px solid $blue-dark;
+    border-left: 1px solid $blue;
+    border-right: 1px solid $blue;
     margin: 0 auto;
     &:last-child {
-      border-bottom: 1px solid $blue-dark;
+      border-bottom: 1px solid $blue;
       border-radius: 0 0 4px 4px;
     }
     font-size: 14px;
@@ -165,10 +165,10 @@ fieldset.search-options.well {
         fill: $white;
       }
       &:not(:hover) {
-        background: $blue;
+        background: $blue-dark;
       }
       &:hover {
-        background: $blue-dark;
+        background: $blue;
       }
     }
   }

--- a/src/stylesheets/editor.scss
+++ b/src/stylesheets/editor.scss
@@ -25,7 +25,7 @@
         color: $white;
       }
       &:hover {
-        background: $blue;
+        background: $blue-dark;
         color: $white;
       }
     }

--- a/src/stylesheets/entry_points_container.scss
+++ b/src/stylesheets/entry_points_container.scss
@@ -4,16 +4,16 @@
   padding: 0 15px;
   .lane {
     a.title {
-      color: $blue;
+      color: $blue-dark;
       &:hover {
-        color: $blue-dark;
+        color: $blue;
       }
     }
     .lane-books-container {
       .scroll-button {
-        background: $blue;
+        background: $blue-dark;
         &:hover {
-          background: $blue-dark;
+          background: $blue;
           color: $white;
           transition: background .5s;
         }
@@ -37,9 +37,9 @@
   .entry-points-list {
     li {
       a {
-        color: $blue;
+        color: $blue-dark;
         svg {
-          fill: $blue;
+          fill: $blue-dark;
         }
         &:hover {
           color: $blue-dark;

--- a/src/stylesheets/facets.scss
+++ b/src/stylesheets/facets.scss
@@ -1,8 +1,8 @@
 .facet-group {
   a.facetLink {
-    color: $blue;
+    color: $blue-dark;
     &:hover {
-      color: $blue-dark;
+      color: $blue;
     }
   }
 }

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -36,10 +36,11 @@
 }
 
 .btn:not(.inverted), .btn.btn-default {
-  background: $blue;
+  background: $blue-dark;
   color: $white;
   &:hover {
     color: $white;
+    background: $blue;
   }
 }
 
@@ -51,23 +52,23 @@
 }
 
 button.btn.inverted, a.btn.inverted {
-  color: $blue;
-  border-color: $blue;
+  color: $blue-dark;
+  border-color: $blue-dark;
   &:hover {
     color: $white;
   }
   svg {
-    fill: $blue;
+    fill: $blue-dark;
   }
 }
 
 .breadcrumbs-or-search-wrapper {
   a {
     &:not(:hover) {
-      color: $blue;
+      color: $blue-dark;
     }
     &:hover {
-      color: $blue-dark;
+      color: $blue;
     }
   }
   .search {

--- a/src/stylesheets/header.scss
+++ b/src/stylesheets/header.scss
@@ -9,8 +9,8 @@
     & > button {
       color: $dark;
 
-      &:hover, &:focus {
-        color: $dark;
+      &:hover, &:active, &:focus {
+        @include headerNavLink;
       }
     }
   }

--- a/src/stylesheets/self_tests.scss
+++ b/src/stylesheets/self_tests.scss
@@ -1,9 +1,9 @@
 .tab-container {
   .nav {
     a {
-      color: $blue;
+      color: $blue-dark;
       &:hover {
-        color: $blue-dark;
+        color: $blue;
       }
     }
   }
@@ -15,9 +15,9 @@
         }
       }
       a {
-        color: $blue;
+        color: $blue-dark;
         &:hover {
-          color: $blue-dark;
+          color: $blue;
         }
       }
       .integration-selftests {

--- a/src/stylesheets/troubleshooting.scss
+++ b/src/stylesheets/troubleshooting.scss
@@ -162,7 +162,7 @@
           }
           &:hover:not(.active) {
             a {
-              background: $blue;
+              background: $blue-dark;
               color: $white;
             }
           }


### PR DESCRIPTION
## Description

This changes the button and link color to Palace dark blue, with a hover color that is a lighter shade of that blue. Previously, the normal color was the lighter shade, and the hover color was Palace dark blue.

<img src="https://user-images.githubusercontent.com/1395885/146317218-f62275cb-a39c-4ee5-a797-d5de813cf63d.png" height="200px" />
<img src="https://user-images.githubusercontent.com/1395885/146317396-7f894830-f102-44d9-b2d6-ee42112bc6f1.png" height="200px" />
<img src="https://user-images.githubusercontent.com/1395885/146317406-a80679bd-f2b2-4341-bda2-4f6761b20e84.png" height="200px" />
<img src="https://user-images.githubusercontent.com/1395885/146317413-a828b9cb-818f-4dbc-a122-17cdb0d3f2c3.png" height="200px" />

## Motivation and Context

This was requested to make the styling better match the Palace style guide.

See comments in this Notion ticket: https://www.notion.so/lyrasis/Update-CM-with-Brand-guidance-88976ea09252447998779b4bbeb2fdeb 

## How Has This Been Tested?

I browsed around the circulation-admin UI, verifying that buttons and links that are blue are normally dark, and become light when hovered over.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
