### PR TITLE
Prevent redundant /admin/libraries requests when opening config screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### December 14, 2021
+### December 16, 2021
 
 #### Updated
 
@@ -8,6 +8,7 @@
 - Updated node-sass and sass-loader dependency versions to reduce the number of high risk vulnerabilities.
 - Removed Analytics tab from System Configuration for librarians and library managers, and added Admins tab.
 - Relabeled "library manager" role to "administrator", and "librarian" role to "user".
+- Removed redundant requests to retrieve libraries when opening the system configuration screen.
 
 ### v0.5.5
 

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -115,8 +115,10 @@ export abstract class GenericEditableConfigList<
   }
 
   UNSAFE_componentWillMount() {
-    if (this.props.fetchData) {
-      this.props.fetchData();
+    const { fetchData, isFetching } = this.props;
+
+    if (fetchData && !isFetching) {
+      fetchData();
     }
   }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ import * as palaceLogoUrl from "../images/PalaceCollectionManagerLogo.svg";
 import title from "../utils/title";
 
 export interface HeaderStateProps {
+  isFetchingLibraries?: boolean;
   libraries?: LibraryData[];
 }
 
@@ -203,8 +204,10 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
   }
 
   UNSAFE_componentWillMount() {
-    if (this.props.fetchLibraries) {
-      this.props.fetchLibraries();
+    const { fetchLibraries, isFetchingLibraries } = this.props;
+
+    if (fetchLibraries && !isFetchingLibraries) {
+      fetchLibraries();
     }
   }
 
@@ -297,10 +300,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 
 function mapStateToProps(state, ownProps) {
   return {
-    libraries:
-      state.editor.libraries &&
-      state.editor.libraries.data &&
-      state.editor.libraries.data.libraries,
+    isFetchingLibraries: state.editor.libraries?.isFetching,
+    libraries: state.editor.libraries?.data?.libraries,
   };
 }
 

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -478,6 +478,26 @@ describe("EditableConfigList", () => {
     expect(editItem.callCount).to.equal(1);
   });
 
+  it("does not fetch data on mount if a fetch is already in progress", () => {
+    // Expect one pre-existing call to fetchData from the component mounted in beforeEach()...
+    expect(fetchData.callCount).to.equal(1);
+
+    wrapper = shallow(
+      <ThingEditableConfigList
+        data={thingsData}
+        fetchData={fetchData}
+        editItem={editItem}
+        deleteItem={deleteItem}
+        csrfToken="token"
+        isFetching
+      />,
+      { context: { admin: systemAdmin } }
+    );
+
+    // ...but no more!
+    expect(fetchData.callCount).to.equal(1);
+  });
+
   it("fetches data again on save", async () => {
     wrapper.setProps({ editOrCreate: "create" });
     const form = wrapper.find(ThingEditForm);

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -230,6 +230,19 @@ describe("Header", () => {
       expect(fetchLibraries.callCount).to.equal(1);
     });
 
+    it("does not fetch libraries on mount if a fetch is already in progress", () => {
+      const fetchLibraries = stub();
+
+      wrapper = shallow(
+        <Header fetchLibraries={fetchLibraries} isFetchingLibraries />,
+        {
+          context: { admin: libraryManager },
+        }
+      );
+
+      expect(fetchLibraries.callCount).to.equal(0);
+    });
+
     it("changes library", async () => {
       const libraries = [
         { short_name: "nypl", name: "NYPL" },


### PR DESCRIPTION
## Description

@jonathangreen observed that when opening the System Configuration screen, two simultaneous requests are sent to /admin/libraries. This ensures that only one request occurs.

This happens because the Header component wants to load the libraries to populate the library selection dropdown, and the Libraries list (which is the first tab, so automatically opens) also wants to load the libraries.

When a libraries fetch starts, the app state is updated, so this just adds checks to both the Header and Libraries components: If a fetch is in flight, another one is not started.

## Motivation and Context

This reduces load on the server, since the libraries request can be expensive to fulfill.

## How Has This Been Tested?

- Log in to the admin UI.
- Open the Network panel in the developer tools.
- Click on System Configuration.

Verify that:
- Only one request is made to /admin/libraries.
- The expected libraries appear in the Library Configuration list.
- The expected libraries appear in the Select a Library dropdown.

Click on other tabs, and verify that the lists loaded properly (because one of the code changes affects all editable lists).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
