### PR TITLE
Remove complaints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
-### December 16, 2021
+### v0.0.8
+
+#### Updated
+
+- Removed Complaints tab from header and book details screen.
+
+### v0.0.7
 
 #### Updated
 

--- a/src/components/BookDetailsTabContainer.tsx
+++ b/src/components/BookDetailsTabContainer.tsx
@@ -6,7 +6,6 @@ import { connect } from "react-redux";
 import BookDetailsEditor from "./BookDetailsEditor";
 import Classifications from "./Classifications";
 import BookCoverEditor from "./BookCoverEditor";
-import Complaints from "./Complaints";
 import CustomListsForBook from "./CustomListsForBook";
 import { BookData } from "../interfaces";
 import { TabContainer, TabContainerProps } from "./TabContainer";
@@ -67,15 +66,6 @@ export class BookDetailsTabContainer extends TabContainer<
         />
       );
     }
-    tabs["complaints"] = (
-      <Complaints
-        store={this.props.store}
-        csrfToken={this.props.csrfToken}
-        bookUrl={this.props.bookUrl}
-        book={this.props.bookData}
-        refreshCatalog={this.props.refreshCatalog}
-      />
-    );
     tabs["lists"] = (
       <CustomListsForBook
         store={this.props.store}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -103,7 +103,6 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     // Links that will be rendered in a NavItem Bootstrap component.
     const libraryNavItems = [
       { label: "Catalog", href: "%2Fgroups?max_cache_age=0" },
-      { label: "Complaints", href: "%2Fadmin%2Fcomplaints" },
       { label: "Hidden Books", href: "%2Fadmin%2Fsuppressed" },
     ];
     // Links that will be rendered in a Link router component and are library specific.

--- a/src/components/__tests__/BookDetailsTabContainer-test.tsx
+++ b/src/components/__tests__/BookDetailsTabContainer-test.tsx
@@ -43,13 +43,12 @@ describe("BookDetailsTabContainer", () => {
     expect(details).to.be.ok;
   });
 
-  it("shows details, edit, classifications, and complaints tabs", () => {
+  it("shows details, edit, and classifications tabs", () => {
     const links = wrapper.find("ul.nav-tabs").find("a");
     const linkTexts = links.map((link) => link.text());
     expect(linkTexts).to.contain("Details");
     expect(linkTexts).to.contain("Edit");
     expect(linkTexts).to.contain("Classifications");
-    expect(linkTexts).to.contain("Complaints");
   });
 
   it("only shows cover tab when the book data has a change cover link", () => {
@@ -81,11 +80,6 @@ describe("BookDetailsTabContainer", () => {
     expect(classifications.props().bookUrl).to.equal("book url");
   });
 
-  it("shows Complaints", () => {
-    const complaints = wrapper.find(Complaints);
-    expect(complaints.props().bookUrl).to.equal("book url");
-  });
-
   it("shows lists", () => {
     const lists = wrapper.find(CustomListsForBook);
     expect(lists.props().bookUrl).to.equal("book url");
@@ -100,14 +94,6 @@ describe("BookDetailsTabContainer", () => {
     expect(push.args[0][0]).to.equal(
       context.pathFor("collection url", "book url", label)
     );
-  });
-
-  it("shows complaints count", () => {
-    wrapper.setProps({ complaintsCount: 5 });
-
-    const links = wrapper.find("ul.nav-tabs").find("a");
-    const linkTexts = links.map((link) => link.text());
-    expect(linkTexts).to.contain("Complaints (5)");
   });
 
   it("clears book data when receiving new book url", () => {

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -86,19 +86,13 @@ describe("Header", () => {
     it("shows catalog links when there's a library", () => {
       let navItems = wrapper.find(NavItem);
 
-      expect(navItems.length).to.equal(3);
+      expect(navItems.length).to.equal(2);
 
       const mainNavItem = navItems.at(0);
       expect(mainNavItem.prop("href")).to.contain("/nypl%2Fgroups");
       expect(mainNavItem.children().text()).to.equal("Catalog");
 
-      const complaintsLink = navItems.at(1);
-      expect(complaintsLink.prop("href")).to.contain(
-        "/nypl%2Fadmin%2Fcomplaints"
-      );
-      expect(complaintsLink.children().text()).to.equal("Complaints");
-
-      const hiddenLink = navItems.at(2);
+      const hiddenLink = navItems.at(1);
       expect(hiddenLink.prop("href")).to.contain("/nypl%2Fadmin%2Fsuppressed");
       expect(hiddenLink.children().text()).to.equal("Hidden Books");
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This removes the Complaints tab from the header and the book details screen.

Before:
![complaints-before](https://user-images.githubusercontent.com/1395885/164566716-66bc3774-acaa-4207-8718-0ff9a92de8a8.png)

After:
![complaints-after](https://user-images.githubusercontent.com/1395885/164566728-adb69235-8a6c-4cd5-a4c0-26d9aedc5331.png)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are, at least temporarily, removing the "Report a Problem" feature from the apps so we need to remove the related Complaints feature from the Palace Manager Admin UI.

Notion: https://www.notion.so/lyrasis/Remove-Complaints-feature-from-Palace-Manager-Admin-UI-40d74cce55fc43e0900085cf83cb69c9

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by opening the Admin UI, and opening book details screens. The Complaints tab was verified to no longer appear in the header, nor in the book details. This is a view-only change -- actions and reducers that relate to complaints were not removed, to make it easy if we ever want to add this feature back -- so the impact is pretty limited.

Unit tests were updated to no longer expect the Complaints tabs to appear.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
