### PR TITLE
Add count to system configuration lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
-### December 16, 2021
+### v0.0.8
+
+#### Updated
+
+- Added display of item count to system configuration lists.
+
+### v0.0.7
 
 #### Updated
 

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -151,17 +151,20 @@ export abstract class GenericEditableConfigList<
         )}
         {this.props.isFetching && <LoadingIndicator />}
         {canListAllData && (
-          <div>
-            {(!this.limitOne ||
-              this.props.data[this.listDataKey].length === 0) &&
-              this.canCreate() && (
-                <a
-                  className="btn btn-default create-item"
-                  href={this.urlBase + "create"}
-                >
-                  Create new {this.itemTypeName}
-                </a>
-              )}
+          <div className="list-container">
+            <header>
+              {(!this.limitOne ||
+                this.props.data[this.listDataKey].length === 0) &&
+                this.canCreate() && (
+                  <a
+                    className="btn btn-default create-item"
+                    href={this.urlBase + "create"}
+                  >
+                    Create new {this.itemTypeName}
+                  </a>
+                )}
+              <div>{this.props.data[this.listDataKey].length} configured</div>
+            </header>
             <ul>
               {this.props.data[this.listDataKey].map((item, index) =>
                 this.renderLi(item, index)

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -274,6 +274,12 @@ describe("EditableConfigList", () => {
     expect(editLink.prop("href")).to.equal("/admin/things/edit/5");
   });
 
+  it("shows the count of things in the list", () => {
+    const things = wrapper.find(".list-container header div");
+    expect(things.length).to.equal(1);
+    expect(things.at(0).text()).to.equal("1 configured");
+  });
+
   it("updates thing list", () => {
     const newThing = { id: 6, label: "another thing" };
     const newThingsData = { things: [thingData, newThing] };

--- a/src/stylesheets/config_tab_container.scss
+++ b/src/stylesheets/config_tab_container.scss
@@ -37,6 +37,21 @@ $dangercolor: #D9534F;
       width: 73%;
       padding: 40px 50px;
 
+      .list-container {
+        max-width: 600px;
+
+        header {
+          display: flex;
+          align-items: baseline;
+          margin: 12px 0;
+
+          div {
+            flex: 1 1 auto;
+            text-align: right;
+          }
+        }
+      }
+
       ul:not(.input-list-ul):not(.announcements-ul) {
         padding-left: 10px;
         li:not(.panel):not(.announcement) {
@@ -44,7 +59,6 @@ $dangercolor: #D9534F;
           flex-direction: row;
           justify-content: space-between;
           align-items: center;
-          max-width: 600px;
           margin: 20px 0px;
           padding-bottom: 5px;
           border-bottom: 1px solid $pagetextcolor;
@@ -59,7 +73,7 @@ $dangercolor: #D9534F;
 
       a.btn-default, a.danger {
         display: unset;
-        margin: 12px 12px 12px 0;
+        margin: 0 12px 0 0;
         color: $pagecolor;
         svg {
           height: 0.7em;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

When editing lists of configuration items in the System Configuration tabs, the count of items in the list is now displayed. The count is shown above the list, on the same line as the Create New button.

Screenshots:

![library-count](https://user-images.githubusercontent.com/1395885/164578589-4094a8f7-f0bc-4aa6-9cec-7fe6b2b8bbe1.png)
![admin-count](https://user-images.githubusercontent.com/1395885/164578599-76721faf-050c-4853-baf9-9875b3299ff9.png)
![authentication-count](https://user-images.githubusercontent.com/1395885/164578606-7f3e74b1-cc35-4683-b0f6-b586e42604c4.png)
![collection-count](https://user-images.githubusercontent.com/1395885/164578610-92c908dc-c5a5-4199-9215-44d8e58d3c8c.png)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The number of configured libraries is commonly requested. Adding the count at the top of the Library Configuration screen in the CM saves time for the Implementation Team.

It seemed useful (or at least not harmful) to have counts on all the lists, so I added the count to the component used for all configuration lists, not just the library list.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested by clicking through all the System Configuration tabs, and validated that the count appears, and is correct. A unit test has been added to verify that a count is rendered on lists.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
