### PR TITLE
Limit visibility of Patrons link to system admins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Changelog
 
-### December 16, 2021
+### v0.0.8
+
+#### Updated
+
+- Limited visibility of Patrons link in header to system administrators.
+
+### v0.0.7
 
 #### Updated
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -111,7 +111,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
       { label: "Lists", href: "lists/" },
       { label: "Lanes", href: "lanes/", auth: isLibraryManager },
       { label: "Dashboard", href: "dashboard/" },
-      { label: "Patrons", href: "patrons/", auth: isLibraryManager },
+      { label: "Patrons", href: "patrons/", auth: isSystemAdmin },
     ];
     // Links that will be rendered in a Link router component and are sitewide.
     const sitewideLinkItems = [

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -107,9 +107,9 @@ describe("Header", () => {
       expect(navItems.length).to.equal(0);
     });
 
-    it("shows sitewide links, non-catalog library links, patron manager link, and system configuration link for library manager", () => {
+    it("shows sitewide links, non-catalog library links, and system configuration link for library manager", () => {
       let links = wrapper.find(Link);
-      expect(links.length).to.equal(5);
+      expect(links.length).to.equal(4);
 
       const listsLink = links.at(0);
       expect(listsLink.prop("to")).to.equal("/admin/web/lists/nypl");
@@ -123,11 +123,7 @@ describe("Header", () => {
       expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard/nypl");
       expect(dashboardLink.children().text()).to.equal("Dashboard");
 
-      const patronManagerLink = links.at(3);
-      expect(patronManagerLink.prop("to")).to.equal("/admin/web/patrons/nypl");
-      expect(patronManagerLink.children().text()).to.equal("Patrons");
-
-      let settingsLink = links.at(4);
+      let settingsLink = links.at(3);
       expect(settingsLink.prop("to")).to.equal("/admin/web/config/");
       expect(settingsLink.children().text()).to.equal("System Configuration");
 
@@ -180,12 +176,13 @@ describe("Header", () => {
           expect(link.children().text()).to.not.equal("Patrons");
         });
       });
-      it("shows Patron Manager link for library manager", () => {
+      it("does not show Patron Manager link for library manager", () => {
         wrapper.setContext({ library: () => "nypl", admin: libraryManager });
         const links = wrapper.find(Link);
-        expect(links.length).to.equal(5);
-        const patronManagerLink = links.at(3);
-        expect(patronManagerLink.children().text()).to.equal("Patrons");
+        expect(links.length).to.equal(4);
+        links.forEach((link) => {
+          expect(link.children().text()).to.not.equal("Patrons");
+        });
       });
       it("shows Patron Manager link for system admin", () => {
         wrapper.setContext({ library: () => "nypl", admin: systemAdmin });
@@ -207,7 +204,7 @@ describe("Header", () => {
       it("does not show Troubleshooting link for library manager", () => {
         wrapper.setContext({ library: () => "nypl", admin: libraryManager });
         const links = wrapper.find(Link);
-        expect(links.length).to.equal(5);
+        expect(links.length).to.equal(4);
         links.forEach((link) => {
           expect(link.children().text()).to.not.equal("Troubleshooting");
         });


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This makes the Patrons link in the header only visible to users who are system administrators. Users who are only library managers no longer see the link.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Patrons link is only used to reset Adobe IDs, and may be confusing to most users, including library managers. This makes the link only visible to system administrators, who will probably know how to use it.

Notion: https://www.notion.so/lyrasis/Hide-Patrons-tab-from-the-Collection-Manager-for-administrator-and-user-accounts-eb4c97f5380e4c20b40a761a702766a1

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by logging in as a system administrator, and verifying that the Patrons link is visible; and logging in as a user who is not a system administrator, and verifying that the Patrons link does not appear.

Unit tests have been updated to verify that the link is rendered for system administrators, but not library managers.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
