### PR TITLE
Move Dashboard to be the first link in the header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed Complaints tab from header and book details screen.
 - Added display of item count to system configuration lists.
 - Limited visibility of Patrons link in header to system administrators.
+- Moved Dashboard to be the first link in the header.
 
 ### v0.0.7
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -100,16 +100,18 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     let isSiteWide = !this.context.library || !currentLibrary;
     let isSomeLibraryManager = this.context.admin.isLibraryManagerOfSomeLibrary();
 
+    // Dashboard link that will be rendered in a Link router component.
+    const dashboardLinkItem = { label: "Dashboard", href: "dashboard/" };
+
     // Links that will be rendered in a NavItem Bootstrap component.
     const libraryNavItems = [
       { label: "Catalog", href: "%2Fgroups?max_cache_age=0" },
       { label: "Hidden Books", href: "%2Fadmin%2Fsuppressed" },
     ];
-    // Links that will be rendered in a Link router component and are library specific.
+    // Other links that will be rendered in a Link router component and are library specific.
     const libraryLinkItems = [
       { label: "Lists", href: "lists/" },
       { label: "Lanes", href: "lanes/", auth: isLibraryManager },
-      { label: "Dashboard", href: "dashboard/" },
       { label: "Patrons", href: "patrons/", auth: isSystemAdmin },
     ];
     // Links that will be rendered in a Link router component and are sitewide.
@@ -159,6 +161,11 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
         <Navbar.Collapse className="menu">
           {currentLibrary && (
             <Nav>
+              {this.renderLinkItem(
+                dashboardLinkItem,
+                currentPathname,
+                currentLibrary
+              )}
               {libraryNavItems.map((item) =>
                 this.renderNavItem(item, currentPathname, currentLibrary)
               )}

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -105,17 +105,17 @@ describe("Header", () => {
       let links = wrapper.find(Link);
       expect(links.length).to.equal(4);
 
-      const listsLink = links.at(0);
+      let dashboardLink = links.at(0);
+      expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard/nypl");
+      expect(dashboardLink.children().text()).to.equal("Dashboard");
+
+      const listsLink = links.at(1);
       expect(listsLink.prop("to")).to.equal("/admin/web/lists/nypl");
       expect(listsLink.children().text()).to.equal("Lists");
 
-      const lanesLink = links.at(1);
+      const lanesLink = links.at(2);
       expect(lanesLink.prop("to")).to.equal("/admin/web/lanes/nypl");
       expect(lanesLink.children().text()).to.equal("Lanes");
-
-      let dashboardLink = links.at(2);
-      expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard/nypl");
-      expect(dashboardLink.children().text()).to.equal("Dashboard");
 
       let settingsLink = links.at(3);
       expect(settingsLink.prop("to")).to.equal("/admin/web/config/");
@@ -137,13 +137,13 @@ describe("Header", () => {
       const links = wrapper.find(Link);
       expect(links.length).to.equal(3);
 
-      const listsLink = links.at(0);
-      expect(listsLink.prop("to")).to.equal("/admin/web/lists/nypl");
-      expect(listsLink.children().text()).to.equal("Lists");
-
-      const dashboardLink = links.at(1);
+      const dashboardLink = links.at(0);
       expect(dashboardLink.prop("to")).to.equal("/admin/web/dashboard/nypl");
       expect(dashboardLink.children().text()).to.equal("Dashboard");
+
+      const listsLink = links.at(1);
+      expect(listsLink.prop("to")).to.equal("/admin/web/lists/nypl");
+      expect(listsLink.children().text()).to.equal("Lists");
 
       const sysConfigLink = links.at(2);
       expect(sysConfigLink.prop("to")).to.equal("/admin/web/config/");


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This moves the Dashboard link in the header to be the first item, instead of being several items deep in the list.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, the Dashboard option is six items deep in the menu bar at the top. It would be much more obvious and convenient for library staff members if Dashboard is moved to be the first option in that list.

Notion: https://www.notion.so/lyrasis/Move-Dashboard-to-the-first-menu-option-available-in-the-tabs-at-the-top-of-screen-1d04bbefc4724b199e4391510b17c4fd

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by logging in as a system admin and a librarian, and verifying that Dashboard appears first in the header when a library is selected. When a library is not selected (e.g. on the System Configuration tab), there should be no change.

Unit tests have been updated to expect Dashboard to be the first link.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
