### PR TITLE
Remove circulation links from book details.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.0.9
+
+#### Updated
+
+- Removed circulation buttons (Borrow, Download, Read) from book details screen.
+
 ### v0.0.8
 
 #### Updated

--- a/src/components/BookDetails.tsx
+++ b/src/components/BookDetails.tsx
@@ -129,4 +129,8 @@ export default class BookDetails extends DefaultBookDetails<
 
     return distributor.value;
   }
+
+  circulationLinks() {
+    return null;
+  }
 }

--- a/src/components/__tests__/BookDetails-test.tsx
+++ b/src/components/__tests__/BookDetails-test.tsx
@@ -117,4 +117,9 @@ describe("BookDetails", () => {
     const distributor = wrapper.find(".distributed-by");
     expect(distributor.text()).to.equal("Distributed By: Overdrive");
   });
+
+  it("doesn't render any circulation link content", () => {
+    const circulationLinks = wrapper.find(".circulation-links");
+    expect(circulationLinks.text()).to.equal("");
+  });
 });

--- a/src/stylesheets/book_details_tab_container.scss
+++ b/src/stylesheets/book_details_tab_container.scss
@@ -44,8 +44,7 @@
           width: 60%;
           margin: auto;
           .circulation-links {
-            padding-bottom: 1em;
-            border-bottom: 1px solid $blue-dark;
+            margin: 0;
             .btn {
               color: $blue-dark;
               border-color: $blue-dark;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This removes the circulation links (Borrow, Download, Read buttons) from the book details page. The count of copies available is retained.

I previously mentioned making this change in a fork of [NYPL-Simplified/opds-web-client](https://github.com/NYPL-Simplified/opds-web-client), but I realized that there was a good way to do it in just this repo.

Screenshot:
![borrow-removed](https://user-images.githubusercontent.com/1395885/166333816-86a2f2e4-1394-4d20-9a34-a5a77ee2e39f.png)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This reduces unneeded complexity in the Admin UI, as there is no in-browser reader for EPUB books.

Notion: https://www.notion.so/lyrasis/Hide-Borrow-button-from-Admin-User-accounts-68fbcb4d0a3f44fc942a247a7bc08e40

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Open some book details, using users with different permission levels.
- Verify that for all books and all users, there is no "Borrow", "Download", or "Read" button above the number of copies available.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
