### PR TITLE
Enable list save button when a collection is selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.0.10
+
+#### Fixed
+
+- When editing lists, the save button is now correctly enabled when a collection is selected, even if no books have been added.
+
 ### v0.0.9
 
 #### Updated


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

- Previously, when editing a list, the save button was only enabled when a book was added from a search. Now, the save button is enabled when either a source collection is selected, or a book is added from a search.

- The logic to determine if the save button should be enabled didn't really make sense to me -- possibly some stuff was left over from older versions, and isn't relevant now -- so I rewrote it to be much simpler.

- When writing new tests, I ran into some places where there were missing null checks on variables, so I fixed those.

Note: I don't like the implementation of the list editing component. It has a lot of internal state that makes it very hard to test without directly setting the state in tests, which breaks the encapsulation. I don't have time to refactor the component to be stateless now, but I'd like to in the future.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The implementation team sometimes needs to create lists that automatically add from collections, and do not specify any additional books from a search. This is a valid way to create a list, but the admin UI doesn't allow the list to be saved without having any books added from a search.

Notion: https://www.notion.so/lyrasis/Cannot-save-a-list-without-an-item-in-it-on-Collection-Manager-665bc3d28d9c451ba778ff0558f81133

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- In the admin UI, click on Lists in the header.
- Click Create New List in the left sidebar.
The save button should be disabled.
- Enter a title.
The save button should be disabled.
- Expand the Add from collections section.
- Check any collection.
The save button should be enabled.
- Uncheck the collection.
The save button should be disabled.
- In the Search for titles section, enter a search term, and click Search.
- Drag one of the results to the list on the right.
The save button should be enabled.
- Try various combinations of title, having/not having selected collections, and having/not having list items.
The save button should be enabled only when there is a non-blank title, and either a collection is selected, or a book is added.

Unit tests are included.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
