### PR TITLE
Remove Admins tab for non-admin users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Updated
 
 - Removed circulation buttons (Borrow, Download, Read) from book details screen.
+- Removed Admins tab from System Configuration screen for non-admin users.
 
 ### v0.0.8
 

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -60,8 +60,8 @@ export default class ConfigTabContainer extends TabContainer<
     discovery: DiscoveryServices,
   };
 
-  LIBRARIAN_TABS = ["libraries", "individualAdmins"];
-  LIBRARY_MANAGER_TABS = this.LIBRARIAN_TABS;
+  LIBRARIAN_TABS = ["libraries"];
+  LIBRARY_MANAGER_TABS = [...this.LIBRARIAN_TABS, "individualAdmins"];
   SYSTEM_ADMIN_TABS = Object.keys(this.COMPONENT_CLASSES);
 
   DISPLAY_NAMES = {

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -180,14 +180,13 @@ describe("ConfigTabContainer", () => {
 
     it("shows tabs", () => {
       const links = wrapper.find("ul.nav-tabs").find("a");
-      expect(links.length).to.equal(2);
+      expect(links.length).to.equal(1);
       const linkTexts = links.map((link) => link.text());
       expect(linkTexts).to.contain("Libraries");
-      expect(linkTexts).to.contain("Admins");
     });
 
     it("shows components", () => {
-      const expectedComponentClasses = [Libraries, IndividualAdmins];
+      const expectedComponentClasses = [Libraries];
       for (const componentClass of expectedComponentClasses) {
         const component = wrapper.find(componentClass);
         expect(component.props().csrfToken).to.equal("token");
@@ -196,6 +195,7 @@ describe("ConfigTabContainer", () => {
       }
       const hiddenComponentClasses = [
         Collections,
+        IndividualAdmins,
         AdminAuthServices,
         PatronAuthServices,
         SitewideSettings,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This removes the Admins tab on the System Configuration screen for non-admin users. The CM no longer allows non-admin users to get the list of users, so there's nothing to see on that tab.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This completes the ticket to disallow non-admin users from being able to see other users on the system. The CM has been updated to enforce this in the back-end, and now the entire Admin tab is removed for non-admins, since no users would be visible anyway.

Notion: https://www.notion.so/lyrasis/Admin-UI-Remove-ability-for-library-Users-to-view-all-admins-in-a-Collection-Manager-13692816a3c84aefa0e9727d84fb65cf

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- As a library user (non-admin), open the System Configuration screen. Only the Libraries tab should be visible.
- As a library admin, open the System Configuration screen. The Libraries and Admins tabs should be visible, and clicking on the Admins tab should show a list of users.
- As a system admin, open the System Configuration screen. All tabs should be visible.

Unit tests have been updated.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
