### PR TITLE
Refactor CustomListEditor and related components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.0.11
+
+#### Fixed
+
+- When editing lists, the Save and Cancel buttons are now correctly disabled when a new list is opened, before any changes have been made.
+
 ### v0.0.10
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "draft-convert": "^2.1.5",
         "draft-js": "0.11.7",
         "font-awesome": "^4.6.3",
+        "immer": "^9.0.15",
         "isomorphic-fetch": "^3.0.0",
         "library-simplified-reusable-components": "1.3.18",
         "numeral": "^2.0.6",
@@ -6659,6 +6660,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/immutable": {
@@ -21126,6 +21136,11 @@
       "version": "4.0.6",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immer": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
     },
     "immutable": {
       "version": "3.7.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "draft-convert": "^2.1.5",
     "draft-js": "0.11.7",
     "font-awesome": "^4.6.3",
+    "immer": "^9.0.15",
     "isomorphic-fetch": "^3.0.0",
     "library-simplified-reusable-components": "1.3.18",
     "numeral": "^2.0.6",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -941,13 +941,33 @@ describe("actions", () => {
   describe("fetchMoreCustomListEntries", () => {
     it("dispatches request and load", async () => {
       const dispatch = stub();
+
+      const getState = stub().returns({
+        editor: {
+          customListDetails: {
+            data: {
+              nextPageUrl: "url",
+            },
+            isFetchingMoreEntries: false,
+          },
+        },
+      });
+
       const customListDetailsData = {
         title: "custom list",
       };
       fetcher.testData = customListDetailsData;
       fetcher.resolve = true;
 
-      const data = await actions.fetchMoreCustomListEntries("url")(dispatch);
+      // FIXME: This is a bit of a hack that requires knowing that the implementation of
+      // fetchMoreCustomListEntries calls dispatch internally on another action creator.
+      // These tests should all be refactored at some point to account for this case.
+      const outerDispatch = (action) => action(dispatch);
+
+      const data = await actions.fetchMoreCustomListEntries()(
+        outerDispatch,
+        getState
+      );
 
       expect(dispatch.callCount).to.equal(3);
       expect(dispatch.args[0][0].type).to.equal(

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -1,446 +1,180 @@
 import * as React from "react";
+import { Button, Panel } from "library-simplified-reusable-components";
+import { CollectionData } from "opds-web-client/lib/interfaces";
+
 import {
   LanguagesData,
   LibraryData,
   CollectionData as AdminCollectionData,
 } from "../interfaces";
-import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
-import TextWithEditMode from "./TextWithEditMode";
-import EditableInput from "./EditableInput";
-import CustomListEntriesEditor, { Entry } from "./CustomListEntriesEditor";
-import CustomListSearch from "./CustomListSearch";
-import SearchIcon from "./icons/SearchIcon";
-import { Button, Panel, Form } from "library-simplified-reusable-components";
-import { browserHistory } from "react-router";
 
-export interface CustomListEditorProps extends React.Props<CustomListEditor> {
+import {
+  CustomListEditorProperties,
+  CustomListEditorEntriesData,
+  CustomListEditorSearchParams,
+} from "../reducers/customListEditor";
+
+import CustomListEntriesEditor from "./CustomListEntriesEditor";
+import CustomListSearch from "./CustomListSearch";
+import EditableInput from "./EditableInput";
+import TextWithEditMode from "./TextWithEditMode";
+
+type CustomListEditorProps = {
+  collections?: AdminCollectionData[];
+  entries?: CustomListEditorEntriesData;
+  entryPoints?: string[];
+  isFetchingMoreCustomListEntries: boolean;
+  isFetchingMoreSearchResults: boolean;
+  isModified?: boolean;
+  isValid?: boolean;
   languages: LanguagesData;
   library: LibraryData;
-  list?: CollectionData;
   listId?: string | number;
-  listCollections?: AdminCollectionData[];
-  collections?: AdminCollectionData[];
-  responseBody?: string;
+  properties?: CustomListEditorProperties;
+  searchParams?: CustomListEditorSearchParams;
   searchResults?: CollectionData;
-  editCustomList: (data: FormData, listId?: string) => Promise<void>;
-  search: (url: string) => Promise<CollectionData>;
-  loadMoreSearchResults: (url: string) => Promise<CollectionData>;
-  loadMoreEntries: (url: string) => Promise<CollectionData>;
-  isFetchingMoreSearchResults: boolean;
-  isFetchingMoreCustomListEntries: boolean;
-  entryPoints?: string[];
-  entryCount?: string;
   startingTitle?: string;
-}
+  addAllEntries?: () => void;
+  addEntry?: (id: string) => void;
+  deleteAllEntries?: () => void;
+  deleteEntry?: (id: string) => void;
+  loadMoreEntries: () => void;
+  loadMoreSearchResults: () => void;
+  reset?: () => void;
+  save: () => void;
+  search: () => void;
+  toggleCollection?: (id: number) => void;
+  updateProperty?: (name: string, value) => void;
+  updateSearchParam?: (name: string, value) => void;
+};
 
-export interface CustomListEditorState {
-  title: string;
-  entries: Entry[];
-  collections?: AdminCollectionData[];
-  entryPointSelected?: string;
-}
+const CustomListEditor = ({
+  collections,
+  entries,
+  entryPoints,
+  isFetchingMoreCustomListEntries,
+  isFetchingMoreSearchResults,
+  isModified,
+  isValid,
+  languages,
+  library,
+  listId,
+  properties,
+  searchParams,
+  searchResults,
+  startingTitle,
+  addAllEntries,
+  addEntry,
+  deleteAllEntries,
+  deleteEntry,
+  loadMoreEntries,
+  loadMoreSearchResults,
+  reset,
+  save,
+  search,
+  toggleCollection,
+  updateProperty,
+  updateSearchParam,
+}: CustomListEditorProps) => {
+  const { collections: listCollections, name } = properties;
 
-/** Right panel of the lists page for editing a single list. */
-export default class CustomListEditor extends React.Component<
-  CustomListEditorProps,
-  CustomListEditorState
-> {
-  static listener;
-  constructor(props) {
-    super(props);
-    this.state = {
-      title: this.props.list && this.props.list.title,
-      entries: (this.props.list && this.props.list.books) || [],
-      collections: this.props.listCollections || [],
-      entryPointSelected: "all",
-    };
+  return (
+    <div className="custom-list-editor">
+      <div className="custom-list-editor-header">
+        <div className="edit-custom-list-title">
+          <fieldset className="save-or-edit">
+            <legend className="visuallyHidden">List name</legend>
 
-    this.changeTitle = this.changeTitle.bind(this);
-    this.changeEntries = this.changeEntries.bind(this);
-    this.save = this.save.bind(this);
-    this.reset = this.reset.bind(this);
-    this.search = this.search.bind(this);
-    this.changeEntryPoint = this.changeEntryPoint.bind(this);
-    this.getEntryPointsElms = this.getEntryPointsElms.bind(this);
-  }
-
-  render(): JSX.Element {
-    const listId = this.props.listId;
-    const listTitle =
-      this.props.list && this.props.list.title ? this.props.list.title : "";
-    const nextPageUrl = this.props.list && this.props.list.nextPageUrl;
-    const crawlable = `${listTitle ? `lists/${listTitle}/` : ""}crawlable`;
-    const opdsFeedUrl = `${this.props.library?.short_name}/${crawlable}`;
-    const hasChanges = this.hasChanges();
-    // The "save this list" button should be disabled if there are no changes
-    // or if the list's title is empty.
-    const disableSave = !hasChanges || !this.isValid();
-    return (
-      <div className="custom-list-editor">
-        <div className="custom-list-editor-header">
-          <div className="edit-custom-list-title">
-            <fieldset className="save-or-edit">
-              <legend className="visuallyHidden">List name</legend>
-              <TextWithEditMode
-                text={listTitle}
-                placeholder="list title"
-                onUpdate={this.changeTitle}
-                ref="listTitle"
-                aria-label="Enter a title for this list"
-                disableIfBlank={true}
-              />
-            </fieldset>
-            {listId && <h4>ID-{listId}</h4>}
-          </div>
-          <div className="save-or-cancel-list">
-            <Button
-              callback={this.save}
-              disabled={disableSave}
-              content="Save this list"
+            <TextWithEditMode
+              text={name}
+              placeholder="list title"
+              onUpdate={(title) => updateProperty?.("name", title)}
+              aria-label="Enter a title for this list"
+              disableIfBlank={true}
             />
-            {hasChanges && (
-              <Button
-                className="inverted"
-                callback={this.reset}
-                content="Cancel Changes"
-              />
-            )}
-          </div>
+          </fieldset>
+
+          {listId && <h4>ID-{listId}</h4>}
         </div>
-        <div className="custom-list-editor-body">
-          <section>
-            {this.props.collections && this.props.collections.length > 0 && (
-              <div className="custom-list-filters">
-                <Panel
-                  headerText="Add from collections"
-                  id="add-from-collections"
-                  content={
-                    <div className="collections">
-                      <div>
-                        Automatically add new books from these collections to
-                        this list:
-                      </div>
-                      {this.props.collections.map((collection) => (
-                        <EditableInput
-                          key={collection.id}
-                          type="checkbox"
-                          name="collection"
-                          checked={this.hasCollection(collection)}
-                          label={collection.name}
-                          value={String(collection.id)}
-                          onChange={() => {
-                            this.changeCollection(collection);
-                          }}
-                        />
-                      ))}
-                    </div>
-                  }
-                />
-              </div>
-            )}
-            <CustomListSearch
-              search={this.search}
-              entryPoints={this.props.entryPoints}
-              getEntryPointsElms={this.getEntryPointsElms}
-              startingTitle={this.props.startingTitle}
-              library={this.props.library}
-              languages={this.props.languages}
-            />
-          </section>
-          <CustomListEntriesEditor
-            searchResults={this.props.searchResults}
-            entries={this.props.list && this.props.list.books}
-            nextPageUrl={nextPageUrl}
-            loadMoreSearchResults={this.props.loadMoreSearchResults}
-            loadMoreEntries={this.props.loadMoreEntries}
-            onUpdate={this.changeEntries}
-            isFetchingMoreSearchResults={this.props.isFetchingMoreSearchResults}
-            isFetchingMoreCustomListEntries={
-              this.props.isFetchingMoreCustomListEntries
-            }
-            ref="listEntries"
-            opdsFeedUrl={opdsFeedUrl}
-            entryCount={this.props.entryCount}
-            listId={this.props.listId}
+
+        <div className="save-or-cancel-list">
+          <Button
+            callback={save}
+            disabled={!isModified || !isValid}
+            content="Save this list"
+          />
+
+          <Button
+            className="inverted"
+            callback={reset}
+            disabled={!isModified}
+            content="Cancel Changes"
           />
         </div>
       </div>
-    );
-  }
 
-  componentDidMount() {
-    CustomListEditor.listener = browserHistory.listen((location) => {
-      this.setState({ title: "", entries: [], collections: [] });
-    });
-  }
-  componentWillUnmount() {
-    CustomListEditor.listener();
-  }
+      <div className="custom-list-editor-body">
+        <section>
+          {collections?.length > 0 && (
+            <div className="custom-list-filters">
+              <Panel
+                headerText="Add from collections"
+                id="add-from-collections"
+                content={
+                  <div className="collections">
+                    <div>
+                      Automatically add new books from these collections to this
+                      list:
+                    </div>
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    // Note: This gets called after performing a search, at which point the
-    // state of the component can already have updates that need to be taken
-    // into account.
-    if (!nextProps.list && !this.props.list) {
-      this.setState({ entries: [], collections: [] });
-    } else if (nextProps.list && nextProps.listId !== this.props.listId) {
-      // Update the state with the next list to edit.
-      this.setState({
-        title: nextProps.list && nextProps.list.title,
-        entries: (nextProps.list && nextProps.list.books) || [],
-        collections: (nextProps.list && nextProps.listCollections) || [],
-      });
-    } else if (
-      nextProps.list &&
-      nextProps.list.books &&
-      nextProps.list.books.length !== this.state.entries.length
-    ) {
-      let collections = this.state.collections;
-      if (
-        (!this.props.list || !this.props.listCollections) &&
-        nextProps.list &&
-        nextProps.listCollections
-      ) {
-        collections = nextProps.listCollections;
-      }
-      const title = this.state.title ? this.state.title : nextProps.list.title;
-      this.setState({
-        title,
-        entries: nextProps.list.books,
-        collections: collections,
-      });
-    } else if (
-      (!this.props.list || !this.props.listCollections) &&
-      nextProps.list &&
-      nextProps.listCollections
-    ) {
-      this.setState({
-        title: this.state.title,
-        entries: this.state.entries,
-        collections: nextProps.listCollections,
-      });
-    }
-  }
+                    {collections.map(({ id, name }) => (
+                      <EditableInput
+                        key={id}
+                        type="checkbox"
+                        name="collection"
+                        checked={listCollections.includes(id)}
+                        label={name}
+                        value={id}
+                        onChange={(id) => toggleCollection?.(parseInt(id))}
+                      />
+                    ))}
+                  </div>
+                }
+              />
+            </div>
+          )}
 
-  /**
-   * Determines if the list being edited is valid. The list is considered valid if:
-   * - The title is not empty
-   * - At least one collection is selected, or at least one book has been added
-   *
-   * @returns true if the list is valid, false otherwise
-   */
-  isValid(): boolean {
-    const { collections, entries, title } = this.state;
+          <CustomListSearch
+            searchParams={searchParams}
+            updateSearchParam={updateSearchParam}
+            search={search}
+            entryPoints={entryPoints}
+            startingTitle={startingTitle}
+            library={library}
+            languages={languages}
+          />
+        </section>
 
-    return !!(title && (collections?.length || entries?.length));
-  }
-
-  hasChanges(): boolean {
-    let titleChanged =
-      this.props.list && this.props.list.title !== this.state.title;
-    let entriesChanged =
-      this.props.list &&
-      !!this.props.list.books &&
-      this.props.list.books.length !== this.state.entries?.length;
-    // If the current list is new then this.props.list will be undefined, but
-    // the state for the entries or title can be populated so there's a need to check.
-    if (!this.props.list) {
-      titleChanged = this.state.title && this.state.title !== "";
-      entriesChanged = this.state.entries?.length > 0;
-    }
-
-    if (!entriesChanged) {
-      const propsIds = ((this.props.list && this.props.list.books) || [])
-        .map((entry) => entry.id)
-        .sort();
-      const stateIds = this.state.entries?.map((entry) => entry.id).sort();
-      for (let i = 0; i < propsIds.length; i++) {
-        if (propsIds[i] !== stateIds[i]) {
-          entriesChanged = true;
-          break;
-        }
-      }
-    }
-    let collectionsChanged = false;
-    if (
-      this.props.listCollections &&
-      this.props.listCollections.length !== this.state.collections?.length
-    ) {
-      collectionsChanged = true;
-    } else {
-      const propsIds = (this.props.listCollections || [])
-        .map((collection) => collection.id)
-        .sort();
-      const stateIds = (this.state.collections || [])
-        .map((collection) => collection.id)
-        .sort();
-      for (let i = 0; i < propsIds.length; i++) {
-        if (propsIds[i] !== stateIds[i]) {
-          collectionsChanged = true;
-          break;
-        }
-      }
-    }
-    const hasChanges = titleChanged || entriesChanged || collectionsChanged;
-    return hasChanges;
-  }
-
-  changeTitle(title: string) {
-    this.setState({
-      title,
-      entries: this.state.entries,
-      collections: this.state.collections,
-    });
-  }
-
-  changeEntries(entries: Entry[]) {
-    this.setState({
-      entries,
-      title: this.state.title,
-      collections: this.state.collections,
-    });
-  }
-
-  hasCollection(collection: AdminCollectionData): boolean {
-    const { collections } = this.state;
-
-    return !!(
-      collections &&
-      collections.find((candidate) => candidate.id === collection.id)
-    );
-  }
-
-  changeCollection(collection: AdminCollectionData) {
-    const hasCollection = this.hasCollection(collection);
-    let newCollections;
-    if (hasCollection) {
-      newCollections = this.state.collections.filter(
-        (stateCollection) => stateCollection.id !== collection.id
-      );
-    } else {
-      newCollections = this.state.collections.slice(0);
-      newCollections.push(collection);
-    }
-    this.setState({
-      title: this.state.title,
-      entries: this.state.entries,
-      collections: newCollections,
-    });
-  }
-
-  changeEntryPoint(entryPointSelected: string) {
-    this.setState({
-      title: this.state.title,
-      entries: this.state.entries,
-      collections: this.state.collections,
-      entryPointSelected,
-    });
-  }
-
-  save() {
-    const data = new (window as any).FormData();
-    if (this.props.list) {
-      data.append("id", this.props.listId);
-    }
-    const title = (this.refs["listTitle"] as TextWithEditMode).getText();
-    data.append("name", title);
-    const entries = (this.refs[
-      "listEntries"
-    ] as CustomListEntriesEditor).getEntries();
-    data.append("entries", JSON.stringify(entries));
-    const deletedEntries = (this.refs[
-      "listEntries"
-    ] as CustomListEntriesEditor).getDeleted();
-    data.append("deletedEntries", JSON.stringify(deletedEntries));
-    const collections = this.state.collections.map(
-      (collection) => collection.id
-    );
-    data.append("collections", JSON.stringify(collections));
-
-    this.props
-      .editCustomList(data, this.props.listId && String(this.props.listId))
-      .then(() => {
-        (this.refs["listEntries"] as CustomListEntriesEditor).clearState();
-        this.setState({ title: this.state.title, entries });
-
-        // If a new list was created, go to the new list's edit page.
-        if (!this.props.list && this.props.responseBody) {
-          window.location.href =
-            "/admin/web/lists/" +
-            this.props.library.short_name +
-            "/edit/" +
-            this.props.responseBody;
-        }
-      });
-  }
-
-  reset() {
-    (this.refs["listTitle"] as TextWithEditMode).reset();
-    (this.refs["listEntries"] as CustomListEntriesEditor).reset();
-    setTimeout(() => {
-      this.setState({
-        title: this.state.title,
-        entries: this.state.entries,
-        collections: this.props.listCollections || [],
-        entryPointSelected: "all",
-      });
-    }, 200);
-  }
-
-  getSearchQueries(sortBy: string, language: string) {
-    const entryPointSelected = this.state.entryPointSelected;
-    let query = "";
-    if (entryPointSelected && entryPointSelected !== "all") {
-      query += `&entrypoint=${encodeURIComponent(entryPointSelected)}`;
-    }
-    sortBy && (query += `&order=${encodeURIComponent(sortBy)}`);
-    language && (query += `&language=${[language]}`);
-    return query;
-  }
-
-  getEntryPointsElms(entryPoints) {
-    const entryPointsElms = [];
-    !entryPoints.includes("All") &&
-      entryPointsElms.push(
-        <EditableInput
-          key="all"
-          type="radio"
-          name="entry-points-selection"
-          checked={"all" === this.state.entryPointSelected}
-          label="All"
-          value="all"
-          onChange={() => this.changeEntryPoint("all")}
+        <CustomListEntriesEditor
+          searchResults={searchResults}
+          entries={entries.current}
+          loadMoreSearchResults={loadMoreSearchResults}
+          loadMoreEntries={loadMoreEntries}
+          isFetchingMoreSearchResults={isFetchingMoreSearchResults}
+          isFetchingMoreCustomListEntries={isFetchingMoreCustomListEntries}
+          opdsFeedUrl={`${library?.short_name}/${
+            name ? `lists/${name}/` : ""
+          }crawlable`}
+          entryCount={entries.currentTotalCount}
+          listId={listId}
+          addEntry={addEntry}
+          addAllEntries={addAllEntries}
+          deleteEntry={deleteEntry}
+          deleteAllEntries={deleteAllEntries}
         />
-      );
-    entryPoints.forEach((entryPoint) =>
-      entryPointsElms.push(
-        <EditableInput
-          key={entryPoint}
-          type="radio"
-          name="entry-points-selection"
-          checked={
-            entryPoint === this.state.entryPointSelected ||
-            entryPoint.toLowerCase() === this.state.entryPointSelected
-          }
-          label={entryPoint}
-          value={entryPoint}
-          onChange={() => this.changeEntryPoint(entryPoint)}
-        />
-      )
-    );
+      </div>
+    </div>
+  );
+};
 
-    return entryPointsElms;
-  }
-
-  /**
-   * search()
-   * Search for items along with an EntryPoint query and a default
-   * language query set to 'all', for librarians who may want to search
-   * for items without a language filter.
-   */
-  search(searchTerms: string, sortBy: string, language: string) {
-    const searchQueries = this.getSearchQueries(sortBy, language);
-    const url = `/${this.props.library.short_name}/search?q=${searchTerms}${searchQueries}`;
-    this.props.search(url);
-  }
-}
+export default CustomListEditor;

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -1,645 +1,328 @@
 import * as React from "react";
+import { Button } from "library-simplified-reusable-components";
+import CatalogLink from "opds-web-client/lib/components/CatalogLink";
+import { CollectionData } from "opds-web-client/lib/interfaces";
+import { getMedium, getMediumSVG } from "opds-web-client/lib/utils/book";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
-import { CollectionData, BookData } from "opds-web-client/lib/interfaces";
-import LoadButton from "./LoadButton";
+import { Entry } from "../reducers/customListEditor";
 import ApplyIcon from "./icons/ApplyIcon";
 import TrashIcon from "./icons/TrashIcon";
 import GrabIcon from "./icons/GrabIcon";
 import AddIcon from "./icons/AddIcon";
-import { Button } from "library-simplified-reusable-components";
-import { AudioHeadphoneIcon, BookIcon } from "@nypl/dgx-svg-icons";
-import CatalogLink from "opds-web-client/lib/components/CatalogLink";
-import { getMedium, getMediumSVG } from "opds-web-client/lib/utils/book";
-import EditableInput from "./EditableInput";
-import { formatString } from "../utils/sharedFunctions";
+import LoadButton from "./LoadButton";
 
-export interface Entry extends BookData {
-  medium?: string;
-}
-
-export interface CustomListEntriesEditorProps
-  extends React.Props<CustomListEntriesEditor> {
+export interface CustomListEntriesEditorProps {
   entries?: Entry[];
-  searchResults?: CollectionData;
-  loadMoreSearchResults: (url: string) => Promise<CollectionData>;
-  loadMoreEntries: (url: string) => Promise<CollectionData>;
-  onUpdate?: (entries: Entry[]) => void;
-  isFetchingMoreSearchResults: boolean;
+  entryCount?: number;
   isFetchingMoreCustomListEntries: boolean;
-  opdsFeedUrl?: string;
-  nextPageUrl?: string;
-  entryCount?: string;
+  isFetchingMoreSearchResults: boolean;
   listId?: string | number;
+  opdsFeedUrl?: string;
+  searchResults?: CollectionData;
+  addAllEntries?: () => void;
+  addEntry?: (id: string) => void;
+  deleteAllEntries?: () => void;
+  deleteEntry?: (id: string) => void;
+  loadMoreEntries: () => void;
+  loadMoreSearchResults: () => void;
 }
 
-export interface CustomListEntriesEditorState {
-  draggingFrom: string | null;
-  entries: Entry[];
-  deleted: Entry[];
-  added: Entry[];
-  totalVisibleEntries?: number;
-}
+const renderCatalogLink = (book, opdsFeedUrl) => {
+  const { title, url } = book;
 
-/** Drag and drop interface for adding books from search results to a custom list. */
-export default class CustomListEntriesEditor extends React.Component<
-  CustomListEntriesEditorProps,
-  CustomListEntriesEditorState
-> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      draggingFrom: null,
-      entries: this.props.entries || [],
-      deleted: [],
-      added: [],
-      totalVisibleEntries: this.props.entries ? this.props.entries.length : 0,
-    };
-
-    this.reset = this.reset.bind(this);
-    this.onDragStart = this.onDragStart.bind(this);
-    this.onDragEnd = this.onDragEnd.bind(this);
-    this.addAll = this.addAll.bind(this);
-    this.deleteAll = this.deleteAll.bind(this);
-    this.loadMore = this.loadMore.bind(this);
-    this.loadMoreEntries = this.loadMoreEntries.bind(this);
-    this.clearState = this.clearState.bind(this);
+  if (!url) {
+    return null;
   }
 
-  render(): JSX.Element {
-    const {
-      entries,
-      deleted,
-      added,
-      draggingFrom,
-      totalVisibleEntries,
-    } = this.state;
-    const {
-      searchResults,
-      isFetchingMoreSearchResults,
-      isFetchingMoreCustomListEntries,
-      nextPageUrl,
-      entryCount,
-    } = this.props;
-    let entryListDisplay = "No books in this list";
-    const totalEntriesServer = parseInt(entryCount, 10);
-    let displayTotal;
-    let entriesCount;
-    let booksText;
+  return (
+    <CatalogLink
+      collectionUrl={opdsFeedUrl}
+      bookUrl={url}
+      title={title}
+      target="_blank"
+      className="btn inverted left-align small top-align"
+    >
+      View details
+    </CatalogLink>
+  );
+};
 
-    if (totalVisibleEntries && totalEntriesServer) {
-      if (entries.length) {
-        entriesCount = totalEntriesServer - deleted.length + added.length;
-        displayTotal = `1 - ${entries.length} of ${entriesCount}`;
-        booksText = entriesCount === 1 ? "Book" : "Books";
-        entryListDisplay = `Displaying ${displayTotal} ${booksText}`;
-      } else if (totalEntriesServer - deleted.length !== 0) {
-        // The "delete all" button was clicked so there are no books
-        // in the visible list, but there could be more on the server.
-        entriesCount =
-          totalEntriesServer > deleted.length
-            ? totalEntriesServer - deleted.length
-            : 0;
-        displayTotal = `0 - 0 of ${entriesCount}`;
-        booksText = entriesCount === 1 ? "Book" : "Books";
-        entryListDisplay = `Displaying ${displayTotal} ${booksText}`;
-      }
-    } else {
-      // No existing entries in a list so it's a new list or all entries
-      // were recently deleted.
-      if (entries && entries.length) {
-        displayTotal = `1 - ${entries.length} of ${entries.length}`;
-        booksText = entries.length === 1 ? "Book" : "Books";
-        entryListDisplay = `Displaying ${displayTotal} ${booksText}`;
-      }
+const CustomListEntriesEditor = ({
+  entries,
+  entryCount,
+  isFetchingMoreCustomListEntries,
+  isFetchingMoreSearchResults,
+  listId,
+  opdsFeedUrl,
+  searchResults,
+  addAllEntries,
+  addEntry,
+  deleteAllEntries,
+  deleteEntry,
+  loadMoreEntries,
+  loadMoreSearchResults,
+}: CustomListEntriesEditorProps) => {
+  const [draggingFrom, setDraggingFrom] = React.useState(null);
+
+  React.useEffect(() => {
+    setDraggingFrom(null);
+  }, [listId, entries]);
+
+  React.useEffect(() => {
+    if (entries) {
+      document.getElementById("custom-list-entries-droppable")?.scrollTo(0, 0);
     }
-    const resultsToDisplay = searchResults && this.searchResultsNotInEntries();
-    return (
-      <DragDropContext
-        onDragStart={this.onDragStart}
-        onDragEnd={this.onDragEnd}
-      >
-        <div className="custom-list-drag-and-drop">
-          <div className="custom-list-search-results">
-            <div className="droppable-header">
-              <h4>Search Results</h4>
-              {searchResults && resultsToDisplay.length > 0 && (
-                <Button
-                  key="addAll"
-                  className="add-all-button"
-                  callback={this.addAll}
-                  content={
-                    <span>
-                      Add all to list
-                      <ApplyIcon />
-                    </span>
-                  }
-                />
-              )}
-            </div>
-            <Droppable
-              droppableId="search-results"
-              isDropDisabled={draggingFrom !== "custom-list-entries"}
-            >
-              {(provided, snapshot) => (
-                <ul
-                  ref={provided.innerRef}
-                  className={
-                    snapshot.isDraggingOver
-                      ? "droppable dragging-over"
-                      : "droppable"
-                  }
-                >
-                  {draggingFrom === "custom-list-entries" && (
-                    <p>Drag books here to remove them from the list.</p>
-                  )}
-                  {draggingFrom !== "custom-list-entries" &&
-                    searchResults &&
-                    resultsToDisplay.map((book, i) => (
-                      <Draggable key={book.id} draggableId={book.id}>
-                        {(provided, snapshot) => (
-                          <li>
-                            <div
-                              className={
-                                "search-result" +
-                                (snapshot.isDragging ? " dragging" : "")
-                              }
-                              ref={provided.innerRef}
-                              style={provided.draggableStyle}
-                              {...provided.dragHandleProps}
-                            >
-                              <GrabIcon />
-                              <div>
-                                <div className="title">{book.title}</div>
-                                <div className="authors">
-                                  {book.authors.join(", ")}
-                                </div>
-                              </div>
-                              {getMediumSVG(getMedium(book))}
-                              <div className="links">
-                                {this.getCatalogLink(book)}
-                                <Button
-                                  callback={() => {
-                                    this.add(book.id);
-                                  }}
-                                  className="right-align"
-                                  content={
-                                    <span>
-                                      Add to list
-                                      <AddIcon />
-                                    </span>
-                                  }
-                                />
-                              </div>
-                            </div>
-                            {provided.placeholder}
-                          </li>
-                        )}
-                      </Draggable>
-                    ))}
-                  {provided.placeholder}
-                </ul>
-              )}
-            </Droppable>
-            {searchResults && searchResults.nextPageUrl && (
-              <LoadButton
-                isFetching={isFetchingMoreSearchResults}
-                loadMore={this.loadMore}
-              />
-            )}
-          </div>
+  }, [entries]);
 
-          <div className="custom-list-entries">
-            <div className="droppable-header">
-              <h4>{entryListDisplay}</h4>
-              {entries && entries.length > 0 && (
-                <div>
-                  <span>Remove all currently visible items from list:</span>
-                  <Button
-                    className="danger delete-all-button top-align"
-                    callback={this.deleteAll}
-                    content={
-                      <span>
-                        Delete
-                        <TrashIcon />
-                      </span>
-                    }
-                  />
-                </div>
-              )}
-            </div>
-            <p>Drag search results here to add them to the list.</p>
-            <Droppable
-              droppableId="custom-list-entries"
-              isDropDisabled={draggingFrom !== "search-results"}
-            >
-              {(provided, snapshot) => (
-                <ul
-                  ref={provided.innerRef}
-                  id="custom-list-entries-droppable"
-                  className={
-                    snapshot.isDraggingOver
-                      ? " droppable dragging-over"
-                      : "droppable"
-                  }
-                >
-                  {entries &&
-                    entries.map((book, i) => (
-                      <Draggable key={book.id} draggableId={book.id}>
-                        {(provided, snapshot) => (
-                          <li>
-                            <div
-                              className={
-                                "custom-list-entry" +
-                                (snapshot.isDragging ? " dragging" : "")
-                              }
-                              ref={provided.innerRef}
-                              style={provided.draggableStyle}
-                              {...provided.dragHandleProps}
-                            >
-                              <GrabIcon />
-                              <div>
-                                <div className="title">{book.title}</div>
-                                <div className="authors">
-                                  {book.authors.join(", ")}
-                                </div>
-                              </div>
-                              {getMediumSVG(getMedium(book))}
-                              <div className="links">
-                                {this.getCatalogLink(book)}
-                                <Button
-                                  className="small right-align"
-                                  callback={() => {
-                                    this.delete(book.id);
-                                  }}
-                                  content={
-                                    <span>
-                                      Remove from list
-                                      <TrashIcon />
-                                    </span>
-                                  }
-                                />
-                              </div>
-                            </div>
-                            {provided.placeholder}
-                          </li>
-                        )}
-                      </Draggable>
-                    ))}
-                  {provided.placeholder}
-                </ul>
-              )}
-            </Droppable>
-            {nextPageUrl && (
-              <LoadButton
-                isFetching={isFetchingMoreCustomListEntries}
-                loadMore={this.loadMoreEntries}
-              />
-            )}
-          </div>
-        </div>
-      </DragDropContext>
-    );
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    let deleted = this.state.deleted;
-    let added = this.state.added;
-    const totalVisibleEntries = this.state.totalVisibleEntries;
-    // We need to reset the deleted and added entries if we are moving to a new list.
-    if (this.props.listId !== nextProps.listId) {
-      deleted = [];
-      added = [];
-      this.setState({
-        draggingFrom: null,
-        entries: nextProps.entries,
-        deleted: deleted,
-        added: added,
-        totalVisibleEntries: nextProps.entries && nextProps.entries.length,
-      });
+  const filteredSearchResults = React.useMemo(() => {
+    if (!searchResults?.books?.length) {
+      return [];
     }
 
-    if (nextProps.entries && nextProps.entries !== this.props.entries) {
-      let newEntries;
-      // If there are any deleted entries and the user loads more entries,
-      // we want to remove them from the entire combined list.
-      if (this.state.deleted.length) {
-        this.state.deleted.forEach((deleteEntry) => {
-          nextProps.entries.forEach((entry, i) => {
-            if (entry.id === deleteEntry.id) {
-              nextProps.entries.splice(i, 1);
-            }
-          });
-        });
-      }
-      newEntries = nextProps.entries;
+    const entryIds = entries.reduce((ids, entry) => {
+      ids[entry.id] = true;
 
-      // If there are any added entries and the user loads more entries,
-      // we want to added them back to the entire combined list.
-      if (this.state.added.length) {
-        newEntries = this.state.added.concat(nextProps.entries);
-      }
+      return ids;
+    }, {});
 
-      this.setState({
-        draggingFrom: null,
-        entries: newEntries,
-        deleted: deleted,
-        added: added,
-        totalVisibleEntries: newEntries.length,
-      });
+    return searchResults.books.filter((book) => !entryIds[book.id]);
+  }, [entries, searchResults]);
 
-      const droppableList = document.getElementById(
-        "custom-list-entries-droppable"
-      );
+  const handleDragStart = (event) => {
+    setDraggingFrom(event.source.droppableId),
+      document.body.classList.add("dragging");
+  };
 
-      if (droppableList) {
-        droppableList.scrollTo(0, 0);
-      }
-    }
-  }
-
-  getCatalogLink(book) {
-    if (!book.url) {
-      return null;
-    }
-    return (
-      <CatalogLink
-        collectionUrl={this.props.opdsFeedUrl}
-        bookUrl={book.url}
-        title={book.title}
-        target="_blank"
-        className="btn inverted left-align small top-align"
-      >
-        View details
-      </CatalogLink>
-    );
-  }
-
-  getMedium(book) {
-    return book.medium || book.raw["$"]["schema:additionalType"].value;
-  }
-
-  getLanguage(book) {
-    return book.language || "";
-  }
-
-  getMediumSVG(medium) {
-    if (!medium) {
-      return null;
-    }
-
-    const svgMediumTypes = {
-      "http://bib.schema.org/Audiobook": (
-        <AudioHeadphoneIcon ariaHidden className="draggable-item-icon" />
-      ),
-      "http://schema.org/EBook": (
-        <BookIcon ariaHidden className="draggable-item-icon" />
-      ),
-    };
-
-    return svgMediumTypes[medium] || null;
-  }
-
-  getEntries(): Entry[] {
-    return this.state.entries || [];
-  }
-
-  getDeleted(): Entry[] {
-    return this.state.deleted;
-  }
-
-  reset() {
-    this.setState({
-      draggingFrom: null,
-      entries: this.props.entries,
-      deleted: [],
-      added: [],
-      totalVisibleEntries: this.props.entries ? this.props.entries.length : 0,
-    });
-    if (this.props.onUpdate) {
-      this.props.onUpdate(this.props.entries || []);
-    }
-  }
-
-  searchResultsNotInEntries() {
-    const entryIds =
-      this.state.entries && this.state.entries.length
-        ? this.state.entries.map((entry) => entry.id)
-        : [];
-    const books =
-      this.props.searchResults.books && this.props.searchResults.books.length
-        ? this.props.searchResults.books.filter((book) => {
-            for (const entryId of entryIds) {
-              if (entryId === book.id) {
-                return false;
-              }
-            }
-            return true;
-          })
-        : [];
-    return books;
-  }
-
-  onDragStart(initial) {
-    document.body.classList.add("dragging");
-    const draggableId = initial.draggableId;
-    const type = initial.type;
-    const source = initial.source;
-
-    this.setState({
-      draggingFrom: source.droppableId,
-      entries: this.state.entries,
-      deleted: this.state.deleted,
-      added: this.state.added,
-    });
-  }
-
-  onDragEnd(result) {
-    const draggableId = result.draggableId;
-    const type = result.type;
-    const source = result.source;
-    const destination = result.destination;
+  const handleDragEnd = (event) => {
+    const { draggableId, source, destination } = event;
 
     if (
       source.droppableId === "search-results" &&
-      destination &&
-      destination.droppableId === "custom-list-entries"
+      destination?.droppableId === "custom-list-entries"
     ) {
-      this.add(draggableId);
+      addEntry?.(draggableId);
     } else if (
       source.droppableId === "custom-list-entries" &&
-      destination &&
-      destination.droppableId === "search-results"
+      destination?.droppableId === "search-results"
     ) {
-      this.delete(draggableId);
+      deleteEntry?.(draggableId);
     } else {
-      this.setState({
-        draggingFrom: null,
-        entries: this.state.entries,
-        deleted: this.state.deleted,
-        added: this.state.added,
-      });
+      setDraggingFrom(null);
     }
 
     document.body.classList.remove("dragging");
-  }
+  };
 
-  add(id: string) {
-    const entries = this.state.entries ? this.state.entries.slice(0) : [];
-    let entry;
-    for (const result of this.props.searchResults.books) {
-      if (result.id === id) {
-        const medium = getMedium(result);
-        const language = this.getLanguage(result);
-        entry = {
-          id: result.id,
-          title: result.title,
-          authors: result.authors,
-          url: result.url,
-          medium,
-          language,
-        };
-        entries.unshift(entry);
-      }
-    }
+  const visibleEntryCount = entries.length;
+  const startNum = visibleEntryCount > 0 ? 1 : 0;
+  const endNum = visibleEntryCount;
+  const booksText = entryCount === 1 ? "book" : "books";
 
-    const added = this.state.added.filter((entry) => entry.id !== id);
-    const inDeleted = this.state.deleted.filter((entry) => entry.id === id);
-    const deleted = this.state.deleted.filter((entry) => entry.id !== id);
-    const propEntries = this.props.entries
-      ? this.props.entries.filter((entry) => entry.id === id)
-      : [];
-    this.setState({
-      draggingFrom: null,
-      entries,
-      deleted,
-      added: propEntries.length ? added : added.concat([entry]),
-    });
-    if (this.props.onUpdate) {
-      this.props.onUpdate(entries);
-    }
-  }
+  const entryListDisplay =
+    entryCount > 0
+      ? `Displaying ${startNum} - ${endNum} of ${entryCount} ${booksText}`
+      : "No books in this list";
 
-  delete(id: string) {
-    let entries = this.state.entries.slice(0);
-    const deleted = this.state.deleted.filter((entry) => entry.id !== id);
-    const deletedEntry = this.state.entries.filter((entry) => entry.id === id);
-    const added = this.state.added.filter((entry) => entry.id !== id);
-    const inAdded =
-      this.props.entries && this.props.entries.length
-        ? this.props.entries.filter((entry) => entry.id === id)
-        : [];
-    entries = entries.filter((entry) => entry.id !== id);
-    this.setState({
-      draggingFrom: null,
-      entries,
-      deleted: inAdded.length ? deleted.concat(deletedEntry) : deleted,
-      added,
-    });
-    if (this.props.onUpdate) {
-      this.props.onUpdate(entries);
-    }
-  }
+  return (
+    <DragDropContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <div className="custom-list-drag-and-drop">
+        <div className="custom-list-search-results">
+          <div className="droppable-header">
+            <h4>Search Results</h4>
 
-  clearState() {
-    this.setState({
-      draggingFrom: null,
-      entries: this.state.entries,
-      deleted: [],
-      added: [],
-      totalVisibleEntries: this.state.entries ? this.state.entries.length : 0,
-    });
-    if (this.props.onUpdate) {
-      this.props.onUpdate(this.state.entries);
-    }
-  }
+            {filteredSearchResults.length > 0 && (
+              <Button
+                key="addAll"
+                className="add-all-button"
+                callback={addAllEntries}
+                content={
+                  <span>
+                    Add all to list
+                    <ApplyIcon />
+                  </span>
+                }
+              />
+            )}
+          </div>
 
-  addAll() {
-    const entries = [];
-    for (const result of this.searchResultsNotInEntries()) {
-      const medium = getMedium(result);
-      const language = this.getLanguage(result);
-      entries.push({
-        id: result.id,
-        title: result.title,
-        authors: result.authors,
-        url: result.url,
-        medium,
-        language,
-      });
-    }
-    const existingPropEntriesIds = this.props.entries
-      ? this.props.entries.map((entry) => entry.id)
-      : [];
-    const newEntriesIds = entries.map((entry) => entry.id);
-    const newlyAdded = entries.filter((book) => {
-      for (const newEntriesId of existingPropEntriesIds) {
-        if (newEntriesId === book.id) {
-          return false;
-        }
-      }
-      return true;
-    });
-    const deleted = this.state.deleted.filter((book) => {
-      for (const newEntriesId of newEntriesIds) {
-        if (newEntriesId === book.id) {
-          return false;
-        }
-      }
-      return true;
-    });
-    const added = this.state.added.concat(newlyAdded);
+          <Droppable
+            droppableId="search-results"
+            isDropDisabled={draggingFrom !== "custom-list-entries"}
+          >
+            {(provided, snapshot) => (
+              <ul
+                ref={provided.innerRef}
+                className={
+                  snapshot.isDraggingOver
+                    ? "droppable dragging-over"
+                    : "droppable"
+                }
+              >
+                {draggingFrom === "custom-list-entries" && (
+                  <p>Drag books here to remove them from the list.</p>
+                )}
 
-    for (const entry of this.state.entries) {
-      entries.push(entry);
-    }
+                {draggingFrom !== "custom-list-entries" &&
+                  filteredSearchResults.map((book) => (
+                    <Draggable key={book.id} draggableId={book.id}>
+                      {(provided, snapshot) => (
+                        <li>
+                          <div
+                            className={
+                              "search-result" +
+                              (snapshot.isDragging ? " dragging" : "")
+                            }
+                            ref={provided.innerRef}
+                            style={provided.draggableStyle}
+                            {...provided.dragHandleProps}
+                          >
+                            <GrabIcon />
 
-    this.setState({
-      draggingFrom: null,
-      entries,
-      deleted,
-      added,
-    });
-    if (this.props.onUpdate) {
-      this.props.onUpdate(entries);
-    }
-  }
+                            <div>
+                              <div className="title">{book.title}</div>
 
-  deleteAll() {
-    const entries = this.state.entries.slice(0);
-    const propEntriesId = this.props.entries
-      ? this.props.entries.map((entry) => entry.id)
-      : [];
-    const newlyDeleted = entries.filter((book) => {
-      for (const propEntryId of propEntriesId) {
-        if (propEntryId === book.id) {
-          return true;
-        }
-      }
-      return false;
-    });
+                              <div className="authors">
+                                {book.authors.join(", ")}
+                              </div>
+                            </div>
 
-    this.setState({
-      draggingFrom: null,
-      entries: [],
-      deleted: this.state.deleted.concat(newlyDeleted),
-      added: [],
-    });
-    if (this.props.onUpdate) {
-      this.props.onUpdate([]);
-    }
-  }
+                            {getMediumSVG(getMedium(book))}
 
-  loadMore() {
-    if (this.props.searchResults && !this.props.isFetchingMoreSearchResults) {
-      const nextPageUrl = this.props.searchResults.nextPageUrl;
-      this.props.loadMoreSearchResults(nextPageUrl);
-    }
-  }
+                            <div className="links">
+                              {renderCatalogLink(book, opdsFeedUrl)}
 
-  loadMoreEntries() {
-    if (this.props.entries && !this.props.isFetchingMoreCustomListEntries) {
-      const nextPageUrl = this.props.nextPageUrl;
-      this.props.loadMoreEntries(nextPageUrl);
-    }
-  }
-}
+                              <Button
+                                callback={() => addEntry?.(book.id)}
+                                className="right-align"
+                                content={
+                                  <span>
+                                    Add to list
+                                    <AddIcon />
+                                  </span>
+                                }
+                              />
+                            </div>
+                          </div>
+
+                          {provided.placeholder}
+                        </li>
+                      )}
+                    </Draggable>
+                  ))}
+
+                {provided.placeholder}
+              </ul>
+            )}
+          </Droppable>
+
+          {loadMoreSearchResults && (
+            <LoadButton
+              isFetching={isFetchingMoreSearchResults}
+              loadMore={loadMoreSearchResults}
+            />
+          )}
+        </div>
+
+        <div className="custom-list-entries">
+          <div className="droppable-header">
+            <h4>{entryListDisplay}</h4>
+
+            {entries?.length > 0 && (
+              <div>
+                <span>Remove all currently visible items from list:</span>
+
+                <Button
+                  className="danger delete-all-button top-align"
+                  callback={deleteAllEntries}
+                  content={
+                    <span>
+                      Delete
+                      <TrashIcon />
+                    </span>
+                  }
+                />
+              </div>
+            )}
+          </div>
+
+          <p>Drag search results here to add them to the list.</p>
+
+          <Droppable
+            droppableId="custom-list-entries"
+            isDropDisabled={draggingFrom !== "search-results"}
+          >
+            {(provided, snapshot) => (
+              <ul
+                ref={provided.innerRef}
+                id="custom-list-entries-droppable"
+                className={
+                  snapshot.isDraggingOver
+                    ? " droppable dragging-over"
+                    : "droppable"
+                }
+              >
+                {entries?.map((book) => (
+                  <Draggable key={book.id} draggableId={book.id}>
+                    {(provided, snapshot) => (
+                      <li>
+                        <div
+                          className={
+                            "custom-list-entry" +
+                            (snapshot.isDragging ? " dragging" : "")
+                          }
+                          ref={provided.innerRef}
+                          style={provided.draggableStyle}
+                          {...provided.dragHandleProps}
+                        >
+                          <GrabIcon />
+
+                          <div>
+                            <div className="title">{book.title}</div>
+
+                            <div className="authors">
+                              {book.authors.join(", ")}
+                            </div>
+                          </div>
+
+                          {getMediumSVG(getMedium(book))}
+
+                          <div className="links">
+                            {renderCatalogLink(book, opdsFeedUrl)}
+
+                            <Button
+                              className="small right-align"
+                              callback={() => deleteEntry?.(book.id)}
+                              content={
+                                <span>
+                                  Remove from list
+                                  <TrashIcon />
+                                </span>
+                              }
+                            />
+                          </div>
+                        </div>
+
+                        {provided.placeholder}
+                      </li>
+                    )}
+                  </Draggable>
+                ))}
+
+                {provided.placeholder}
+              </ul>
+            )}
+          </Droppable>
+
+          {loadMoreEntries && (
+            <LoadButton
+              isFetching={isFetchingMoreCustomListEntries}
+              loadMore={loadMoreEntries}
+            />
+          )}
+        </div>
+      </div>
+    </DragDropContext>
+  );
+};
+
+export default CustomListEntriesEditor;

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { stub, useFakeTimers } from "sinon";
+import { stub } from "sinon";
 
 import * as React from "react";
 import { mount } from "enzyme";
@@ -14,41 +14,15 @@ import { Button } from "library-simplified-reusable-components";
 
 describe("CustomListEditor", () => {
   let wrapper;
-  let editCustomList;
+  let reset;
+  let save;
   let search;
+  let toggleCollection;
   let loadMoreSearchResults;
   let loadMoreEntries;
+  let updateSearchParam;
   let childContextTypes;
   let fullContext;
-
-  const listData = {
-    id: "1",
-    url: "some url",
-    title: "list",
-    lanes: [],
-    books: [
-      {
-        id: "1",
-        title: "title 1",
-        authors: ["author 1"],
-        raw: {
-          $: { "schema:additionalType": { value: "http://schema.org/EBook" } },
-        },
-      },
-      {
-        id: "2",
-        title: "title 2",
-        authors: ["author 2a", "author 2b"],
-        raw: {
-          $: { "schema:additionalType": { value: "http://schema.org/EBook" } },
-        },
-      },
-    ],
-    navigationLinks: [],
-  };
-  const listCollections = [
-    { id: 2, name: "collection 2", protocol: "protocol" },
-  ];
 
   const searchResults = {
     id: "id",
@@ -80,6 +54,15 @@ describe("CustomListEditor", () => {
     },
   ];
 
+  const entries = {
+    baseline: [],
+    baselineTotalCount: 0,
+    added: {},
+    removed: {},
+    current: [],
+    currentTotalCount: 0,
+  };
+
   const entryPoints = ["Book", "Audio"];
 
   const library = {
@@ -97,17 +80,36 @@ describe("CustomListEditor", () => {
     fre: ["French"],
   };
 
+  const properties = {
+    name: "Listy McList",
+    collections: [2],
+  };
+
+  const searchParams = {
+    entryPoint: "All",
+    terms: "",
+    sort: null,
+    language: "all",
+  };
+
   beforeEach(() => {
-    editCustomList = stub().returns(
+    loadMoreEntries = stub();
+    loadMoreSearchResults = stub();
+    reset = stub();
+
+    save = stub().returns(
       new Promise<void>((resolve) => resolve())
     );
+
     search = stub();
-    loadMoreSearchResults = stub();
-    loadMoreEntries = stub();
+    toggleCollection = stub();
+    updateSearchParam = stub();
+
     childContextTypes = {
       pathFor: PropTypes.func.isRequired,
       router: PropTypes.object.isRequired,
     };
+
     fullContext = Object.assign(
       {},
       {
@@ -127,43 +129,52 @@ describe("CustomListEditor", () => {
 
     wrapper = mount(
       <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
         collections={collections}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
+        entries={entries}
         entryPoints={entryPoints}
+        isFetchingMoreCustomListEntries={false}
+        isFetchingMoreSearchResults={false}
+        isModified={true}
+        isValid={true}
+        languages={languages}
+        library={library}
+        listId="1"
+        properties={properties}
+        searchParams={searchParams}
+        searchResults={searchResults}
+        loadMoreEntries={loadMoreEntries}
+        loadMoreSearchResults={loadMoreSearchResults}
+        reset={reset}
+        save={save}
+        search={search}
+        toggleCollection={toggleCollection}
+        updateSearchParam={updateSearchParam}
       />,
       { context: fullContext, childContextTypes }
     );
   });
 
-  it("shows list title", () => {
+  it("shows the list title", () => {
     const title = wrapper.find(TextWithEditMode);
+
     expect(title.length).to.equal(1);
-    expect(title.props().text).to.equal("list");
+    expect(title.props().text).to.equal("Listy McList");
     expect(title.props().placeholder).to.equal("list title");
     expect(title.props().disableIfBlank).to.be.true;
   });
 
-  it("shows list id", () => {
+  it("shows the list id", () => {
     const listId = wrapper.find(".custom-list-editor-header h4");
+
     expect(listId.length).to.equal(1);
     expect(listId.text()).to.contain("1");
   });
 
-  it("shows entries editor with list entries and search results", () => {
+  it("shows an entries editor with list entries and search results", () => {
     const entriesEditor = wrapper.find(CustomListEntriesEditor);
+
     expect(entriesEditor.length).to.equal(1);
-    expect(entriesEditor.props().entries).to.equal(listData.books);
+    expect(entriesEditor.props().entries).to.equal(entries.current);
     expect(entriesEditor.props().searchResults).to.equal(searchResults);
     expect(entriesEditor.props().loadMoreSearchResults).to.equal(
       loadMoreSearchResults
@@ -177,679 +188,120 @@ describe("CustomListEditor", () => {
 
   it("shows collections", () => {
     const inputs = wrapper.find(EditableInput);
+
     expect(inputs.length).to.equal(9);
+
     expect(inputs.at(0).props().label).to.equal("collection 1");
-    expect(inputs.at(0).props().value).to.equal("1");
+    expect(inputs.at(0).props().value).to.equal(1);
     expect(inputs.at(0).props().checked).to.equal(false);
+
     expect(inputs.at(1).props().label).to.equal("collection 2");
-    expect(inputs.at(1).props().value).to.equal("2");
+    expect(inputs.at(1).props().value).to.equal(2);
     expect(inputs.at(1).props().checked).to.equal(true);
+
     expect(inputs.at(2).props().label).to.equal("collection 3");
-    expect(inputs.at(2).props().value).to.equal("3");
+    expect(inputs.at(2).props().value).to.equal(3);
     expect(inputs.at(2).props().checked).to.equal(false);
   });
 
   it("shows entry point options", () => {
     const inputs = wrapper.find(EditableInput);
+
     expect(inputs.at(3).props().label).to.equal("All");
-    expect(inputs.at(3).props().value).to.equal("all");
+    expect(inputs.at(3).props().value).to.equal("All");
     expect(inputs.at(3).props().checked).to.equal(true);
+
     expect(inputs.at(4).props().label).to.equal("Book");
     expect(inputs.at(4).props().value).to.equal("Book");
     expect(inputs.at(4).props().checked).to.equal(false);
+
     expect(inputs.at(5).props().label).to.equal("Audio");
     expect(inputs.at(5).props().value).to.equal("Audio");
     expect(inputs.at(5).props().checked).to.equal(false);
   });
 
-  it("saves list", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    const getTextStub = stub(TextWithEditMode.prototype, "getText").returns(
-      "new list title"
-    );
-    const newEntries = [{ id: "urn1" }, { id: "urn2" }];
-    wrapper.setState({ title: "new list title" });
-    const getEntriesStub = stub(
-      CustomListEntriesEditor.prototype,
-      "getEntries"
-    ).returns(newEntries);
-    const saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
-    saveButton.simulate("click");
-
-    expect(editCustomList.callCount).to.equal(1);
-    const formData = editCustomList.args[0][0];
-    expect(formData.get("id")).to.equal("1");
-    expect(formData.get("name")).to.equal("new list title");
-    expect(formData.get("entries")).to.equal(JSON.stringify(newEntries));
-    expect(formData.get("collections")).to.equal(JSON.stringify([2]));
-    const listId = editCustomList.args[0][1];
-    expect(listId).to.equal("1");
-
-    getTextStub.restore();
-    getEntriesStub.restore();
-  });
-
   it("enables the save button when the list has changes and is valid", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-
-    wrapper.instance().hasChanges = () => true;
-    wrapper.instance().isValid = () => true;
-
-    wrapper.setProps({});
-
     const saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
+
     expect(saveButton.props().disabled).to.equal(false);
   });
 
   it("disables the save button when the list does not have changes", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-
-    wrapper.instance().hasChanges = () => false;
-    wrapper.instance().isValid = () => true;
-
-    wrapper.setProps({});
+    wrapper.setProps({ isModified: false });
 
     const saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
+
+    expect(saveButton.length).to.equal(1);
     expect(saveButton.props().disabled).to.equal(true);
   });
 
   it("disables the save button when the list is invalid", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-
-    wrapper.instance().hasChanges = () => true;
-    wrapper.instance().isValid = () => false;
-
-    wrapper.setProps({});
+    wrapper.setProps({ isValid: false });
 
     const saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
+
+    expect(saveButton.length).to.equal(1);
     expect(saveButton.props().disabled).to.equal(true);
   });
 
-  it("navigates to edit page after a new list is created", async () => {
-    // Set window.location.href to be writable, jsdom doesn't normally allow changing it but browsers do.
-    // Start on the create page.
-    Object.defineProperty(window.location, "href", {
-      writable: true,
-      value: "/admin/web/lists/library/create",
-    });
-
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    const getTextStub = stub(TextWithEditMode.prototype, "getText").returns(
-      "new list title"
-    );
-    const newEntries = [{ id: "urn1" }, { id: "urn2" }];
-    const getEntriesStub = stub(
-      CustomListEntriesEditor.prototype,
-      "getEntries"
-    ).returns(newEntries);
+  it("calls save when the save button is clicked", () => {
     const saveButton = wrapper.find(".save-or-cancel-list").find(Button).at(0);
-    wrapper.setState({ title: "new list title", entries: newEntries });
+
+    expect(saveButton.length).to.equal(1);
+
     saveButton.simulate("click");
 
-    expect(editCustomList.callCount).to.equal(1);
-    getTextStub.restore();
-    getEntriesStub.restore();
-
-    wrapper.setProps({ responseBody: "5" });
-    // Let the call stack clear so the callback after editCustomList will run.
-    const pause = (): Promise<void> => {
-      return new Promise<void>((resolve) => setTimeout(resolve, 0));
-    };
-    await pause();
-    expect(window.location.href).to.contain("edit");
-    expect(window.location.href).to.contain("5");
+    expect(save.callCount).to.equal(1);
   });
 
-  it("cancels changes", () => {
-    const listTitleReset = stub(TextWithEditMode.prototype, "reset");
-    const listEntriesReset = stub(CustomListEntriesEditor.prototype, "reset");
-    this.clock = useFakeTimers();
+  it("disables the cancel button when the list does not have changes", () => {
+    wrapper.setProps({ isModified: false });
 
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        collections={collections}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
+    const cancelButton = wrapper
+      .find(".save-or-cancel-list")
+      .find(Button)
+      .at(1);
 
-    // the cancel button isn't shown when there are no changes.
-    let cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
-    expect(cancelButton.length).to.equal(0);
-
-    (wrapper.instance() as CustomListEditor).changeTitle("new name");
-    wrapper.update();
-
-    cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
     expect(cancelButton.length).to.equal(1);
-    cancelButton.simulate("click");
-    this.clock.tick(200);
+    expect(cancelButton.props().disabled).to.equal(true);
+  });
 
-    expect(listTitleReset.callCount).to.equal(1);
-    expect(listEntriesReset.callCount).to.equal(1);
+  it("calls reset when the cancel button is clicked", () => {
+    const cancelButton = wrapper
+      .find(".save-or-cancel-list")
+      .find(Button)
+      .at(1);
 
-    (wrapper.instance() as CustomListEditor).changeTitle(listData.title);
-    wrapper.update();
-    cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
-    expect(cancelButton.length).to.equal(0);
-
-    (wrapper.instance() as CustomListEditor).changeCollection(collections[0]);
-    // This is needed because we are testing the cancelButton again.
-    wrapper.update();
-
-    cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
     expect(cancelButton.length).to.equal(1);
+
     cancelButton.simulate("click");
-    this.clock.tick(200);
-    wrapper.update();
 
-    cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
-    expect(cancelButton.length).to.equal(0);
-
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        collections={collections}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    (wrapper.instance() as CustomListEditor).changeEntries([
-      { id: "1234", title: "a", authors: [] },
-    ]);
-    wrapper.update();
-
-    cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
-    expect(cancelButton.length).to.equal(1);
-    cancelButton.simulate("click");
-    this.clock.tick(200);
-
-    expect(listTitleReset.callCount).to.equal(3);
-    expect(listEntriesReset.callCount).to.equal(3);
-    cancelButton = wrapper.find(".save-or-cancel-list").find(Button).at(1);
-
-    (wrapper.instance() as CustomListEditor).changeEntries(listData.books);
-    wrapper.update();
-
-    const buttons = wrapper.find(".save-or-cancel-list").find(Button);
-    expect(buttons.length).to.equal(1);
-
-    listTitleReset.restore();
-    listEntriesReset.restore();
-    this.clock.restore();
+    expect(reset.callCount).to.equal(1);
   });
 
-  it("changes selected collections", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        collections={collections}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
+  it("calls toggleCollection when a collection checkbox is changed", () => {
+    const inputs = wrapper.find(".collections input");
 
-    let inputs = wrapper.find(EditableInput);
-    expect(inputs.at(0).props().checked).to.equal(false);
-    expect(inputs.at(1).props().checked).to.equal(true);
+    inputs.at(1).simulate("change");
 
-    inputs.at(0).props().onChange();
-    wrapper.update();
-    inputs = wrapper.find(EditableInput);
-    expect(inputs.at(0).props().checked).to.equal(true);
-    expect(inputs.at(1).props().checked).to.equal(true);
-
-    inputs.at(1).props().onChange();
-    wrapper.update();
-    inputs = wrapper.find(EditableInput);
-    expect(inputs.at(0).props().checked).to.equal(true);
-    expect(inputs.at(1).props().checked).to.equal(false);
+    expect(toggleCollection.callCount).to.equal(1);
+    expect(toggleCollection.args[0]).to.deep.equal([2]);
   });
 
-  it("has a search component", () => {
-    let search = wrapper.find(CustomListSearch);
-    expect(search.length).to.equal(1);
-    expect(search.props().entryPoints).to.eql(wrapper.props().entryPoints);
-    wrapper.setProps({ startingTitle: "test" });
-    search = wrapper.find(CustomListSearch);
-    expect(search.props().startingTitle).to.equal("test");
-    expect(search.prop("library")).to.eql(library);
-    expect(search.prop("languages")).to.eql(languages);
-  });
+  it("renders a CustomListSearch component", () => {
+    wrapper.setProps({ startingTitle: "Begin the Begin" });
 
-  it("searches for a language", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
+    const customListSearch = wrapper.find(CustomListSearch);
+
+    expect(customListSearch.length).to.equal(1);
+    expect(customListSearch.prop("entryPoints")).to.equal(entryPoints);
+    expect(customListSearch.prop("languages")).to.equal(languages);
+    expect(customListSearch.prop("library")).to.equal(library);
+    expect(customListSearch.prop("searchParams")).to.equal(searchParams);
+    expect(customListSearch.prop("startingTitle")).to.equal("Begin the Begin");
+    expect(customListSearch.prop("search")).to.equal(search);
+    expect(customListSearch.prop("updateSearchParam")).to.equal(
+      updateSearchParam
     );
-    const input = wrapper.find(".form-control") as any;
-    input.getDOMNode().value = "test";
-
-    let searchForm = wrapper.find("form");
-    searchForm.simulate("submit");
-    // The default language is "all"
-    expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("/library/search?q=test&language=all");
-
-    const select = wrapper.find(".search-options select") as any;
-    select.getDOMNode().value = "eng";
-    select.simulate("change");
-
-    searchForm = wrapper.find("form");
-    searchForm.simulate("submit");
-    expect(search.callCount).to.equal(2);
-    expect(search.args[1][0]).to.equal("/library/search?q=test&language=eng");
-  });
-
-  it("optionally searches a title passed as a prop", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        entryPoints={entryPoints}
-        startingTitle="test title"
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    const searchField = wrapper.find(".form-control");
-    expect(searchField.getDOMNode().value).to.equal("test title");
-    expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal(
-      "/library/search?q=test%20title&language=all"
-    );
-  });
-
-  it("searches with audiobooks selected", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        collections={collections}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    const textInput = wrapper.find(".form-control") as any;
-    textInput.getDOMNode().value = "harry potter";
-    const radioInput = wrapper.find(".entry-points-selection input") as any;
-    const bookInput = radioInput.at(1);
-    const searchForm = wrapper.find("form");
-
-    bookInput.checked = true;
-    bookInput.simulate("change");
-
-    searchForm.simulate("submit");
-
-    expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal(
-      "/library/search?q=harry%20potter&entrypoint=Book&language=all"
-    );
-  });
-
-  it("searches with ebook selected", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        collections={collections}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    const textInput = wrapper.find(".form-control") as any;
-    textInput.getDOMNode().value = "oliver twist";
-    const radioInput = wrapper.find(".entry-points-selection input") as any;
-    const audioInput = radioInput.at(2);
-    const searchForm = wrapper.find("form");
-
-    audioInput.checked = true;
-    audioInput.simulate("change");
-
-    searchForm.simulate("submit");
-
-    expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal(
-      "/library/search?q=oliver%20twist&entrypoint=Audio&language=all"
-    );
-  });
-
-  it("should keep the same state when the list prop gets updated", () => {
-    wrapper = mount(
-      <CustomListEditor
-        library={library}
-        languages={languages}
-        list={listData}
-        listId="1"
-        listCollections={listCollections}
-        searchResults={searchResults}
-        editCustomList={editCustomList}
-        search={search}
-        loadMoreSearchResults={loadMoreSearchResults}
-        loadMoreEntries={loadMoreEntries}
-        isFetchingMoreSearchResults={false}
-        isFetchingMoreCustomListEntries={false}
-        collections={collections}
-        entryPoints={entryPoints}
-      />,
-      { context: fullContext, childContextTypes }
-    );
-    const updatedList = { id: 2, name: "updated list", collections: [] };
-    const newList = Object.assign({}, updatedList, { books: [] });
-    const radioInput = wrapper.find(".entry-points-selection input") as any;
-    const audioInput = radioInput.at(2);
-    const textInput = wrapper.find(".form-control") as any;
-
-    textInput.getDOMNode().value = "oliver twist";
-    audioInput.checked = true;
-    audioInput.simulate("change");
-
-    expect(wrapper.props().list).to.deep.equal(listData);
-    expect(textInput.getDOMNode().value).to.equal("oliver twist");
-    expect(wrapper.state("entryPointSelected")).to.equal("Audio");
-
-    // Update the component with a new list.
-    wrapper.setProps({ identifier: "2", list: newList });
-
-    expect(wrapper.props().list).to.deep.equal(newList);
-    expect(textInput.getDOMNode().value).to.equal("oliver twist");
-    expect(wrapper.state("entryPointSelected")).to.equal("Audio");
-  });
-
-  describe("hasChanges", () => {
-    it("should update correctly", () => {
-      wrapper = mount(
-        <CustomListEditor
-          library={library}
-          languages={languages}
-          searchResults={searchResults}
-          editCustomList={editCustomList}
-          search={search}
-          loadMoreSearchResults={loadMoreSearchResults}
-          loadMoreEntries={loadMoreEntries}
-          isFetchingMoreSearchResults={false}
-          isFetchingMoreCustomListEntries={false}
-          entryPoints={entryPoints}
-        />,
-        { context: fullContext, childContextTypes }
-      );
-
-      let hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
-
-      expect(hasChanges).to.equal(false);
-
-      // A new list with a new title
-      wrapper.setState({ title: "Updated title" });
-      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
-
-      expect(hasChanges).to.equal(true);
-
-      // We decided to add an entry
-      (wrapper.instance() as CustomListEditor).changeEntries([
-        { id: "1234", title: "a", authors: [] },
-      ]);
-      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
-      expect(hasChanges).to.equal(true);
-
-      wrapper = mount(
-        <CustomListEditor
-          library={library}
-          languages={languages}
-          searchResults={searchResults}
-          editCustomList={editCustomList}
-          search={search}
-          loadMoreSearchResults={loadMoreSearchResults}
-          loadMoreEntries={loadMoreEntries}
-          isFetchingMoreSearchResults={false}
-          isFetchingMoreCustomListEntries={false}
-          entryPoints={entryPoints}
-        />,
-        { context: fullContext, childContextTypes }
-      );
-
-      (wrapper.instance() as CustomListEditor).changeEntries([
-        { id: "1234", title: "a", authors: [] },
-      ]);
-      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
-      expect(hasChanges).to.equal(true);
-
-      // Now add a title
-      wrapper.setState({ title: "Updated title" });
-      hasChanges = (wrapper.instance() as CustomListEditor).hasChanges();
-
-      expect(hasChanges).to.equal(true);
-    });
-  });
-
-  describe("isValid", () => {
-    it("should return false if the title is blank", () => {
-      wrapper.setState({
-        title: "",
-        entries: [{ id: "1234", title: "a", authors: [] }],
-        collections: [{ id: 2, name: "collection 2", protocol: "protocol" }],
-      });
-
-      expect(wrapper.instance().isValid()).to.be.false;
-    });
-
-    it("should return false if the title is null", () => {
-      wrapper.setState({
-        title: null,
-        entries: [{ id: "1234", title: "a", authors: [] }],
-        collections: [{ id: 2, name: "collection 2", protocol: "protocol" }],
-      });
-
-      expect(wrapper.instance().isValid()).to.be.false;
-    });
-
-    it("should return false if the title is undefined", () => {
-      wrapper.setState({
-        title: undefined,
-        entries: [{ id: "1234", title: "a", authors: [] }],
-        collections: [{ id: 2, name: "collection 2", protocol: "protocol" }],
-      });
-
-      expect(wrapper.instance().isValid()).to.be.false;
-    });
-
-    it("should return false if entries and collections are both null", () => {
-      wrapper.setState({
-        title: "List 1",
-        entries: null,
-        collections: null,
-      });
-
-      expect(wrapper.instance().isValid()).to.be.false;
-    });
-
-    it("should return false if entries and collections are both undefined", () => {
-      wrapper.setState({
-        title: "List 1",
-        entries: undefined,
-        collections: undefined,
-      });
-
-      expect(wrapper.instance().isValid()).to.be.false;
-    });
-
-    it("should return false if entries and collections are both empty", () => {
-      wrapper.setState({
-        title: "List 1",
-        entries: [],
-        collections: [],
-      });
-
-      expect(wrapper.instance().isValid()).to.be.false;
-    });
-
-    it("should return true if title is not blank and entries is not empty", () => {
-      wrapper.setState({
-        title: "List 1",
-        entries: [{ id: "1234", title: "a", authors: [] }],
-        collections: [],
-      });
-
-      expect(wrapper.instance().isValid()).to.be.true;
-    });
-
-    it("should return true if title is not blank and collections is not empty", () => {
-      wrapper.setState({
-        title: "List 1",
-        entries: [],
-        collections: [{ id: 2, name: "collection 2", protocol: "protocol" }],
-      });
-
-      expect(wrapper.instance().isValid()).to.be.true;
-    });
   });
 });

--- a/src/components/__tests__/CustomListSearch-test.tsx
+++ b/src/components/__tests__/CustomListSearch-test.tsx
@@ -7,6 +7,8 @@ import CustomListSearch from "../CustomListSearch";
 describe("CustomListSearch", () => {
   let wrapper;
   let search;
+  let updateSearchParam;
+
   const library = {
     uuid: "uuid",
     name: "name",
@@ -16,113 +18,209 @@ describe("CustomListSearch", () => {
     },
   };
 
+  const entryPoints = ["All", "Book", "Audio"];
+
+  const searchParams = {
+    entryPoint: "all",
+    terms: "foo bar",
+    sort: "title",
+    language: "English",
+  };
+
   const languages = {
     eng: ["English"],
     spa: ["Spanish", "Castilian"],
     fre: ["French"],
   };
+
   beforeEach(() => {
     search = stub();
+    updateSearchParam = stub();
+
     wrapper = mount(
       <CustomListSearch
-        search={search}
-        library={library}
+        entryPoints={entryPoints}
         languages={languages}
+        library={library}
+        search={search}
+        searchParams={searchParams}
+        updateSearchParam={updateSearchParam}
       />
     );
   });
-  it("searches", () => {
-    const input = wrapper.find(".form-control") as any;
-    input.getDOMNode().value = "test";
+
+  it("calls search when the form is submitted", () => {
     const searchForm = wrapper.find("form");
+
     searchForm.simulate("submit");
 
     expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("test");
-    expect(search.args[0][1]).to.be.null;
   });
-  it("sorts", () => {
-    const spySort = spy(wrapper.instance(), "sort");
-    wrapper.setProps({ sort: spySort });
-    expect(wrapper.state().sortBy).to.be.null;
+
+  it("renders a radio button for each entry point", () => {
+    const entryPointOptions = wrapper.find(".entry-points").find(".form-group");
+
+    expect(entryPointOptions.length).to.equal(3);
+
+    const all = entryPointOptions.at(0);
+
+    expect(all.text()).to.equal("All");
+
+    const allRadio = all.find("input");
+
+    expect(allRadio.props().type).to.equal("radio");
+    expect(allRadio.props().name).to.equal("entry-points-selection");
+    expect(allRadio.props().value).to.equal("All");
+    expect(allRadio.props().checked).to.be.true;
+
+    const book = entryPointOptions.at(1);
+
+    expect(book.text()).to.equal("Book");
+
+    const bookRadio = book.find("input");
+
+    expect(bookRadio.props().type).to.equal("radio");
+    expect(bookRadio.props().name).to.equal("entry-points-selection");
+    expect(bookRadio.props().value).to.equal("Book");
+    expect(bookRadio.props().checked).to.be.false;
+
+    const audio = entryPointOptions.at(2);
+
+    expect(audio.text()).to.equal("Audio");
+
+    const audioRadio = audio.find("input");
+
+    expect(audioRadio.props().type).to.equal("radio");
+    expect(audioRadio.props().name).to.equal("entry-points-selection");
+    expect(audioRadio.props().value).to.equal("Audio");
+    expect(audioRadio.props().checked).to.be.false;
+  });
+
+  it("calls updateSearchParam when an entry point radio button is changed", () => {
+    const sortOptions = wrapper.find(".entry-points").find(".form-group");
+    const audioRadio = sortOptions.at(2).find("input");
+
+    audioRadio.simulate("change");
+
+    expect(updateSearchParam.callCount).to.equal(1);
+    expect(updateSearchParam.args[0]).to.deep.equal(["entryPoint", "Audio"]);
+  });
+
+  it("renders a text input for the search terms", () => {
+    const input = wrapper.find(".form-control") as any;
+
+    expect(input.getDOMNode().value).equals("foo bar");
+  });
+
+  it("calls updateSearchParam when the value of the search terms input changes", () => {
+    const input = wrapper.find(".form-control") as any;
+
+    input.getDOMNode().value = "baz";
+    input.simulate("change");
+
+    expect(updateSearchParam.callCount).to.equal(1);
+    expect(updateSearchParam.args[0]).to.deep.equal(["terms", "baz"]);
+  });
+
+  it("renders a radio button for each sort option", () => {
     const sortOptions = wrapper.find(".search-options").find(".form-group");
+
     expect(sortOptions.length).to.equal(3);
 
     const relevance = sortOptions.at(0);
+
     expect(relevance.text()).to.equal("Relevance (default)");
+
     const relevanceRadio = relevance.find("input");
+
     expect(relevanceRadio.props().type).to.equal("radio");
     expect(relevanceRadio.props().name).to.be.null;
     expect(relevanceRadio.props().value).to.equal("");
-    expect(relevanceRadio.props().checked).to.be.true;
+    expect(relevanceRadio.props().checked).to.be.false;
 
     const title = sortOptions.at(1);
+
     expect(title.text()).to.equal("Title");
+
     const titleRadio = title.find("input");
+
     expect(titleRadio.props().type).to.equal("radio");
     expect(titleRadio.props().name).to.equal("title");
     expect(titleRadio.props().value).to.equal("title");
-    expect(titleRadio.props().checked).to.be.false;
+    expect(titleRadio.props().checked).to.be.true;
 
     const author = sortOptions.at(2);
+
     expect(author.text()).to.equal("Author");
+
     const authorRadio = author.find("input");
+
     expect(authorRadio.props().type).to.equal("radio");
     expect(authorRadio.props().name).to.equal("author");
     expect(authorRadio.props().value).to.equal("author");
     expect(authorRadio.props().checked).to.be.false;
+  });
 
-    titleRadio.simulate("change");
-    expect(spySort.callCount).to.equal(1);
-    expect(spySort.args[0][0]).to.equal("title");
-    expect(wrapper.state().sortBy).to.equal("title");
+  it("calls updateSearchParam when a sort radio button is changed", () => {
+    const sortOptions = wrapper.find(".search-options").find(".form-group");
+    const authorRadio = sortOptions.at(2).find("input");
 
     authorRadio.simulate("change");
-    expect(spySort.callCount).to.equal(2);
-    expect(spySort.args[1][0]).to.equal("author");
-    expect(wrapper.state().sortBy).to.equal("author");
 
-    relevanceRadio.simulate("change");
-    expect(spySort.callCount).to.equal(3);
-    expect(spySort.args[2][0]).to.be.null;
-    expect(wrapper.state().sortBy).to.be.null;
-
-    spySort.restore();
+    expect(updateSearchParam.callCount).to.equal(1);
+    expect(updateSearchParam.args[0]).to.deep.equal(["sort", "author"]);
   });
-  it("filters by language", () => {
+
+  it("renders a dropdown with an option for each language", () => {
     const languageFieldset = wrapper.find("fieldset").at(2);
+
     expect(languageFieldset.find("legend").text()).to.equal(
       "Filter by language:"
     );
+
     const languageMenu = languageFieldset.find("select");
     const options = languageMenu.find("option");
+
     expect(options.at(0).prop("value")).to.equal("all");
     expect(options.at(0).text()).to.equal("All");
+
     expect(options.at(1).prop("value")).to.equal("eng");
     expect(options.at(1).text()).to.equal("English");
+
     expect(options.at(2).prop("value")).to.equal("fre");
     expect(options.at(2).text()).to.equal("French");
+
     expect(options.at(3).prop("value")).to.equal("spa");
     expect(options.at(3).text()).to.equal("Spanish; Castilian");
+  });
+
+  it("calls updateSearchParam when the value of the language dropdown changes", () => {
+    const languageFieldset = wrapper.find("fieldset").at(2);
+    const languageMenu = languageFieldset.find("select");
 
     languageMenu.getDOMNode().value = "fre";
     languageMenu.simulate("change");
-    languageFieldset.closest("form").simulate("submit");
-    expect(search.callCount).to.equal(1);
-    expect(search.args[0][2]).to.equal("fre");
+
+    expect(updateSearchParam.callCount).to.equal(1);
+    expect(updateSearchParam.args[0]).to.deep.equal(["language", "fre"]);
   });
-  it("automatically searches if there is a startingTitle prop", () => {
-    const search = stub();
+
+  it("calls updateSearchParam and search when mounted if there is a startingTitle", () => {
     wrapper = mount(
       <CustomListSearch
-        startingTitle="test"
-        search={search}
-        library={library}
+        entryPoints={entryPoints}
         languages={languages}
+        library={library}
+        search={search}
+        searchParams={searchParams}
+        startingTitle="test"
+        updateSearchParam={updateSearchParam}
       />
     );
+
+    expect(updateSearchParam.callCount).to.equal(1);
+    expect(updateSearchParam.args[0]).to.deep.equal(["terms", "test"]);
+
     expect(search.callCount).to.equal(1);
-    expect(search.args[0][0]).to.equal("test");
-    expect(search.args[0][1]).to.be.null;
   });
 });

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -1,0 +1,1196 @@
+import { expect } from "chai";
+
+import reducer, {
+  getCustomListEditorFormData,
+  getCustomListEditorSearchUrl,
+  initialState,
+} from "../customListEditor";
+
+import ActionCreator from "../../actions";
+
+describe("custom list editor reducer", () => {
+  context("on OPEN_CUSTOM_LIST_EDITOR", () => {
+    const state = undefined;
+
+    const listData = {
+      custom_lists: [
+        {
+          collections: [
+            {
+              id: 16,
+              name: "TEST Baker & Taylor",
+              protocol: "Axis 360",
+            },
+          ],
+          entry_count: 150,
+          id: 17,
+          name: "Baker & Taylor Axis360 Test",
+        },
+        {
+          collections: [],
+          entry_count: 15,
+          id: 12,
+          name: "Cooking",
+        },
+        {
+          collections: [],
+          entry_count: 16,
+          id: 19,
+          name: "LCP PDF Test",
+        },
+      ],
+    };
+
+    it("sets the id, and obtains the name, collections, and baselineTotalCount from the list data", () => {
+      const nextState = reducer(state, {
+        type: ActionCreator.OPEN_CUSTOM_LIST_EDITOR,
+        id: "17",
+        data: listData,
+      });
+
+      expect(nextState.id).to.equal(17);
+      expect(nextState.entries.baselineTotalCount).to.equal(150);
+      expect(nextState.properties.current).to.deep.equal(
+        nextState.properties.baseline
+      );
+
+      expect(nextState.properties.baseline).to.deep.equal({
+        name: "Baker & Taylor Axis360 Test",
+        collections: [16],
+      });
+
+      expect(nextState.error).to.equal(null);
+    });
+
+    it("sets an error message when no list with the id in the action exists in the data", () => {
+      const nextState = reducer(state, {
+        type: ActionCreator.OPEN_CUSTOM_LIST_EDITOR,
+        id: "999",
+        data: listData,
+      });
+
+      expect(nextState.id).to.equal(999);
+      expect(nextState.error).to.equal("Custom list not found for ID: 999");
+    });
+
+    it("sets the id to null when the id in the action is null", () => {
+      const nextState = reducer(state, {
+        type: ActionCreator.OPEN_CUSTOM_LIST_EDITOR,
+        id: null,
+        data: listData,
+      });
+
+      expect(nextState.id).to.equal(null);
+      expect(nextState.error).to.equal(null);
+    });
+  });
+
+  context(`on ${ActionCreator.CUSTOM_LISTS}_${ActionCreator.LOAD}`, () => {
+    const listData = {
+      custom_lists: [
+        {
+          collections: [
+            {
+              id: 16,
+              name: "TEST Baker & Taylor",
+              protocol: "Axis 360",
+            },
+          ],
+          entry_count: 150,
+          id: 17,
+          name: "Baker & Taylor Axis360 Test",
+        },
+        {
+          collections: [],
+          entry_count: 15,
+          id: 12,
+          name: "Cooking",
+        },
+        {
+          collections: [
+            {
+              id: 14,
+              name: "New BiblioBoard Test",
+              protocol: "OPDS for Distributors",
+            },
+          ],
+          entry_count: 13337,
+          id: 18,
+          name: "New BiblioBoard",
+        },
+      ],
+    };
+
+    it("obtains the name, collections, and baselineTotalCount from the list data for the current id", () => {
+      const state = {
+        ...initialState,
+        id: 18,
+      };
+
+      const nextState = reducer(state, {
+        type: `${ActionCreator.CUSTOM_LISTS}_${ActionCreator.LOAD}`,
+        data: listData,
+      });
+
+      expect(nextState.id).to.equal(18);
+      expect(nextState.entries.baselineTotalCount).to.equal(13337);
+      expect(nextState.properties.current).to.deep.equal(
+        nextState.properties.baseline
+      );
+
+      expect(nextState.properties.baseline).to.deep.equal({
+        name: "New BiblioBoard",
+        collections: [14],
+      });
+
+      expect(nextState.error).to.equal(null);
+    });
+
+    it("sets an error message when no list with the current id exists in the data", () => {
+      const state = {
+        ...initialState,
+        id: 999,
+      };
+
+      const nextState = reducer(state, {
+        type: `${ActionCreator.CUSTOM_LISTS}_${ActionCreator.LOAD}`,
+        data: listData,
+      });
+
+      expect(nextState.error).to.equal("Custom list not found for ID: 999");
+    });
+  });
+
+  context(
+    `on ${ActionCreator.CUSTOM_LIST_DETAILS}_${ActionCreator.LOAD}`,
+    () => {
+      const listDetailsData = {
+        books: [
+          { id: "book1", title: "A Farewell to Arms" },
+          { id: "book2", title: "Little Women" },
+        ],
+      };
+
+      it("updates the baseline entries with the books in the list details data", () => {
+        const state = {
+          ...initialState,
+        };
+
+        const nextState = reducer(state, {
+          type: `${ActionCreator.CUSTOM_LIST_DETAILS}_${ActionCreator.LOAD}`,
+          data: listDetailsData,
+        });
+
+        expect(nextState.entries.baseline).to.deep.equal(listDetailsData.books);
+      });
+
+      it("applies the current delta to the books in the list details data", () => {
+        const state = {
+          ...initialState,
+          entries: {
+            ...initialState.entries,
+            baselineTotalCount: 5,
+            added: {
+              book90: { id: "book90", title: "Wuthering Heights" },
+              book91: { id: "book91", title: "Huckleberry Finn" },
+            },
+            removed: {
+              book1: true as true,
+            },
+          },
+        };
+
+        const nextState = reducer(state, {
+          type: `${ActionCreator.CUSTOM_LIST_DETAILS}_${ActionCreator.LOAD}`,
+          data: listDetailsData,
+        });
+
+        expect(nextState.entries.baseline).to.deep.equal(listDetailsData.books);
+
+        expect(nextState.entries.current).to.deep.equal([
+          { id: "book91", title: "Huckleberry Finn" },
+          { id: "book90", title: "Wuthering Heights" },
+          { id: "book2", title: "Little Women" },
+        ]);
+
+        expect(nextState.entries.currentTotalCount).to.equal(6); // 5 + 2 - 1
+      });
+    }
+  );
+
+  context(
+    `on ${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.LOAD}`,
+    () => {
+      const listDetailsData = {
+        books: [
+          { id: "book1", title: "A Farewell to Arms" },
+          { id: "book2", title: "Little Women" },
+        ],
+      };
+
+      it("appends the books in the list details data to the baseline entries", () => {
+        const state = {
+          ...initialState,
+          entries: {
+            ...initialState.entries,
+            baseline: [
+              { id: "book91", title: "Huckleberry Finn" },
+              { id: "book90", title: "Wuthering Heights" },
+            ],
+          },
+        };
+
+        const nextState = reducer(state, {
+          type: `${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.LOAD}`,
+          data: listDetailsData,
+        });
+
+        expect(nextState.entries.baseline).to.deep.equal([
+          { id: "book91", title: "Huckleberry Finn" },
+          { id: "book90", title: "Wuthering Heights" },
+          { id: "book1", title: "A Farewell to Arms" },
+          { id: "book2", title: "Little Women" },
+        ]);
+      });
+
+      it("applies the current delta to the new baseline entries", () => {
+        const state = {
+          ...initialState,
+          entries: {
+            ...initialState.entries,
+            baseline: [
+              { id: "book91", title: "Huckleberry Finn" },
+              { id: "book90", title: "Wuthering Heights" },
+            ],
+            baselineTotalCount: 4,
+            added: {
+              book98: { id: "book98", title: "The Bell Jar" },
+            },
+            removed: {
+              book1: true as true,
+              book90: true as true,
+            },
+          },
+        };
+
+        const nextState = reducer(state, {
+          type: `${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.LOAD}`,
+          data: listDetailsData,
+        });
+
+        expect(nextState.entries.current).to.deep.equal([
+          { id: "book98", title: "The Bell Jar" },
+          { id: "book91", title: "Huckleberry Finn" },
+          { id: "book2", title: "Little Women" },
+        ]);
+
+        expect(nextState.entries.currentTotalCount).to.equal(3); // 4 + 1 - 2
+      });
+    }
+  );
+
+  context("on UPDATE_CUSTOM_LIST_EDITOR_PROPERTY", () => {
+    const state = {
+      ...initialState,
+    };
+
+    it("updates the current properties with the name/value", () => {
+      const nextState = reducer(state, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_PROPERTY,
+        name: "name",
+        value: "Awesome List",
+      });
+
+      expect(nextState.properties.current.name).to.equal("Awesome List");
+    });
+
+    it("updates isValid and isModified", () => {
+      let nextState;
+
+      nextState = reducer(state, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_PROPERTY,
+        name: "name",
+        value: "Awesome List",
+      });
+
+      expect(nextState.isModified).to.equal(true);
+      expect(nextState.isValid).to.equal(false);
+
+      nextState = reducer(nextState, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_PROPERTY,
+        name: "collections",
+        value: [12],
+      });
+
+      expect(nextState.isModified).to.equal(true);
+      expect(nextState.isValid).to.equal(true);
+
+      nextState = reducer(nextState, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_PROPERTY,
+        name: "name",
+        value: "",
+      });
+
+      expect(nextState.isModified).to.equal(true);
+      expect(nextState.isValid).to.equal(false);
+
+      nextState = reducer(nextState, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_PROPERTY,
+        name: "collections",
+        value: [],
+      });
+
+      expect(nextState.isModified).to.equal(false);
+      expect(nextState.isValid).to.equal(false);
+    });
+  });
+
+  context("on TOGGLE_CUSTOM_LIST_EDITOR_COLLECTION", () => {
+    it("adds the id to the current collection property if it doesn't exist", () => {
+      const state = {
+        ...initialState,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.TOGGLE_CUSTOM_LIST_EDITOR_COLLECTION,
+        id: 13,
+      });
+
+      expect(nextState.properties.current.collections).to.deep.equal([13]);
+    });
+
+    it("removes the id from the current collection property if it exists", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            collections: [10, 11, 12],
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.TOGGLE_CUSTOM_LIST_EDITOR_COLLECTION,
+        id: 11,
+      });
+
+      expect(nextState.properties.current.collections).to.deep.equal([10, 12]);
+    });
+
+    it("updates isValid and isModified", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "List 1",
+            collections: [],
+          },
+        },
+        isValid: false,
+        isModified: false,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.TOGGLE_CUSTOM_LIST_EDITOR_COLLECTION,
+        id: 11,
+      });
+
+      expect(nextState.isValid).to.equal(true);
+      expect(nextState.isModified).to.equal(true);
+    });
+  });
+
+  context("on UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM", () => {
+    const state = {
+      ...initialState,
+    };
+
+    it("updates searchParams with the name/value", () => {
+      let nextState;
+
+      nextState = reducer(state, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM,
+        name: "entryPoint",
+        value: "Book",
+      });
+
+      expect(nextState.searchParams.entryPoint).to.equal("Book");
+
+      nextState = reducer(state, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM,
+        name: "terms",
+        value: "foo bar",
+      });
+
+      expect(nextState.searchParams.terms).to.equal("foo bar");
+
+      nextState = reducer(state, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM,
+        name: "sort",
+        value: "title",
+      });
+
+      expect(nextState.searchParams.sort).to.equal("title");
+
+      nextState = reducer(state, {
+        type: ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM,
+        name: "language",
+        value: "eng",
+      });
+
+      expect(nextState.searchParams.language).to.equal("eng");
+    });
+  });
+
+  context("on ADD_CUSTOM_LIST_EDITOR_ENTRY", () => {
+    const searchResultData = {
+      books: [
+        {
+          id: "book1",
+          title: "A Farewell to Arms",
+          authors: ["Ernest Hemingway"],
+          url: "http://some/url",
+          language: "english",
+        },
+        {
+          id: "book2",
+          title: "Little Women",
+          authors: ["Louisa May Alcott"],
+          url: "http://some/url",
+          language: "english",
+        },
+      ],
+    };
+
+    it("should add the book to entries added", () => {
+      const state = {
+        ...initialState,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book2",
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.added)
+        .to.have.property("book2")
+        .that.deep.equals({
+          id: "book2",
+          title: "Little Women",
+          authors: ["Louisa May Alcott"],
+          url: "http://some/url",
+          language: "english",
+          medium: "",
+        });
+    });
+
+    it("should not add the book to entries added if it already exists in entries baseline", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [{ id: "book2", title: "Little Women" }],
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book2",
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.added).not.to.have.property("book2");
+    });
+
+    it("should remove the book from entries removed, if it is present", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          removed: {
+            book2: true as true,
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book2",
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.removed).not.to.have.property("book2");
+    });
+
+    it("should apply the new delta to the baseline and update entries current", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          baselineTotalCount: 12,
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book2",
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.current).to.deep.equal([
+        {
+          id: "book2",
+          title: "Little Women",
+          authors: ["Louisa May Alcott"],
+          url: "http://some/url",
+          language: "english",
+          medium: "",
+        },
+        { id: "book91", title: "Huckleberry Finn" },
+        { id: "book90", title: "Wuthering Heights" },
+      ]);
+
+      expect(nextState.entries.currentTotalCount).to.equal(13); // 12 + 1
+    });
+
+    it("should update isValid and isModified", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "Awesome List",
+          },
+        },
+        isValid: false,
+        isModified: false,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book2",
+        data: searchResultData,
+      });
+
+      expect(nextState.isValid).to.equal(true);
+      expect(nextState.isModified).to.equal(true);
+    });
+  });
+
+  context("on ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES", () => {
+    const searchResultData = {
+      books: [
+        {
+          id: "book1",
+          title: "A Farewell to Arms",
+          authors: ["Ernest Hemingway"],
+          url: "http://some/url",
+          language: "english",
+        },
+        {
+          id: "book2",
+          title: "Little Women",
+          authors: ["Louisa May Alcott"],
+          url: "http://some/url",
+          language: "english",
+        },
+      ],
+    };
+
+    it("should add all books in the search results data to entries added", () => {
+      const state = {
+        ...initialState,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.added).to.deep.equal({
+        book1: {
+          id: "book1",
+          title: "A Farewell to Arms",
+          authors: ["Ernest Hemingway"],
+          url: "http://some/url",
+          language: "english",
+          medium: "",
+        },
+        book2: {
+          id: "book2",
+          title: "Little Women",
+          authors: ["Louisa May Alcott"],
+          url: "http://some/url",
+          language: "english",
+          medium: "",
+        },
+      });
+    });
+
+    it("should not add a book to entries added if it already exists in entries baseline", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [{ id: "book2", title: "Little Women" }],
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.added).to.have.property("book1");
+      expect(nextState.entries.added).not.to.have.property("book2");
+    });
+
+    it("should remove a book from entries removed, if it is present", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          removed: {
+            book2: true as true,
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.removed).not.to.have.property("book2");
+    });
+
+    it("should apply the new delta to the baseline and update entries current", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          baselineTotalCount: 12,
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+        data: searchResultData,
+      });
+
+      expect(nextState.entries.current).to.deep.equal([
+        {
+          id: "book2",
+          title: "Little Women",
+          authors: ["Louisa May Alcott"],
+          url: "http://some/url",
+          language: "english",
+          medium: "",
+        },
+        {
+          id: "book1",
+          title: "A Farewell to Arms",
+          authors: ["Ernest Hemingway"],
+          url: "http://some/url",
+          language: "english",
+          medium: "",
+        },
+        { id: "book91", title: "Huckleberry Finn" },
+        { id: "book90", title: "Wuthering Heights" },
+      ]);
+
+      expect(nextState.entries.currentTotalCount).to.equal(14); // 12 + 2
+    });
+
+    it("should update isValid and isModified", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "Awesome List",
+          },
+        },
+        isValid: false,
+        isModified: false,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+        data: searchResultData,
+      });
+
+      expect(nextState.isValid).to.equal(true);
+      expect(nextState.isModified).to.equal(true);
+    });
+  });
+
+  context("on DELETE_CUSTOM_LIST_EDITOR_ENTRY", () => {
+    it("should add the book to entries removed", () => {
+      const state = {
+        ...initialState,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book1",
+      });
+
+      expect(nextState.entries.removed)
+        .to.have.property("book1")
+        .that.equals(true);
+    });
+
+    it("should delete the book from entries added, if it is present", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          added: {
+            book1: {
+              id: "book1",
+              title: "A Farewell to Arms",
+              authors: ["Ernest Hemingway"],
+              url: "http://some/url",
+              language: "english",
+              medium: "",
+            },
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book1",
+      });
+
+      expect(nextState.entries.added).not.to.have.property("book1");
+      expect(nextState.entries.removed).not.to.have.property("book1");
+    });
+
+    it("should apply the new delta to the baseline and update entries current", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          baselineTotalCount: 12,
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book91",
+      });
+
+      expect(nextState.entries.current).to.deep.equal([
+        { id: "book90", title: "Wuthering Heights" },
+      ]);
+
+      expect(nextState.entries.currentTotalCount).to.equal(11); // 12 - 1
+    });
+
+    it("should update isValid and isModified", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          baseline: {
+            ...initialState.properties.baseline,
+            name: "Awesome List",
+          },
+          current: {
+            ...initialState.properties.current,
+            name: "Awesome List",
+          },
+        },
+        entries: {
+          ...initialState.entries,
+          baseline: [{ id: "book91", title: "Huckleberry Finn" }],
+          baselineTotalCount: 1,
+          current: [{ id: "book91", title: "Huckleberry Finn" }],
+          currentTotalCount: 1,
+        },
+        isValid: true,
+        isModified: false,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_CUSTOM_LIST_EDITOR_ENTRY,
+        id: "book91",
+      });
+
+      expect(nextState.isValid).to.equal(false);
+      expect(nextState.isModified).to.equal(true);
+    });
+  });
+
+  context("on DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES", () => {
+    it("should add all books in baseline entries to entries removed", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+      });
+
+      expect(nextState.entries.removed)
+        .to.have.property("book91")
+        .that.equals(true);
+      expect(nextState.entries.removed)
+        .to.have.property("book90")
+        .that.equals(true);
+    });
+
+    it("should empty entries added", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          added: {
+            book1: {
+              id: "book1",
+              title: "A Farewell to Arms",
+              authors: ["Ernest Hemingway"],
+              url: "http://some/url",
+              language: "english",
+              medium: "",
+            },
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+      });
+
+      expect(nextState.entries.added).to.deep.equal({});
+    });
+
+    it("should apply the new delta to the baseline and update entries current", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          baselineTotalCount: 12,
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+      });
+
+      expect(nextState.entries.current).to.have.length(0);
+      expect(nextState.entries.currentTotalCount).to.equal(10); // 12 - 2
+    });
+
+    it("should update isValid and isModified", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          baseline: {
+            ...initialState.properties.baseline,
+            name: "Awesome List",
+          },
+          current: {
+            ...initialState.properties.current,
+            name: "Awesome List",
+          },
+        },
+        entries: {
+          ...initialState.entries,
+          baseline: [{ id: "book91", title: "Huckleberry Finn" }],
+          baselineTotalCount: 1,
+          current: [{ id: "book91", title: "Huckleberry Finn" }],
+          currentTotalCount: 1,
+        },
+        isValid: true,
+        isModified: false,
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES,
+      });
+
+      expect(nextState.isValid).to.equal(false);
+      expect(nextState.isModified).to.equal(true);
+    });
+  });
+
+  context("on RESET_CUSTOM_LIST_EDITOR", () => {
+    it("should restore baseline properties", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          baseline: {
+            ...initialState.properties.baseline,
+            name: "Original Title",
+            collections: [1, 2],
+          },
+          current: {
+            ...initialState.properties.current,
+            name: "Something Else",
+            collections: [3],
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.RESET_CUSTOM_LIST_EDITOR,
+      });
+
+      expect(nextState.properties.current)
+        .to.have.property("name")
+        .that.equals("Original Title");
+
+      expect(nextState.properties.current)
+        .to.have.property("collections")
+        .that.deep.equals([1, 2]);
+    });
+
+    it("should clear entries added and removed", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          added: {
+            book90: { id: "book90", title: "Wuthering Heights" },
+            book91: { id: "book91", title: "Huckleberry Finn" },
+          },
+          removed: {
+            book1: true as true,
+          },
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.RESET_CUSTOM_LIST_EDITOR,
+      });
+
+      expect(nextState.entries.added).to.deep.equal({});
+      expect(nextState.entries.removed).to.deep.equal({});
+    });
+
+    it("should apply the new delta to the baseline and update entries current", () => {
+      const state = {
+        ...initialState,
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          baselineTotalCount: 12,
+          added: {
+            book2: {
+              id: "book2",
+              title: "Little Women",
+              authors: ["Louisa May Alcott"],
+              url: "http://some/url",
+              language: "english",
+              medium: "",
+            },
+          },
+          removed: {
+            book1: true as true,
+            book3: true as true,
+          },
+          current: [
+            { id: "book2", title: "Little Women" },
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          currentTotalCount: 11,
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.RESET_CUSTOM_LIST_EDITOR,
+      });
+
+      expect(nextState.entries.current).to.deep.equal([
+        { id: "book91", title: "Huckleberry Finn" },
+        { id: "book90", title: "Wuthering Heights" },
+      ]);
+
+      expect(nextState.entries.currentTotalCount).to.equal(12);
+    });
+
+    it("should update isValid and isModified", () => {
+      const state = {
+        ...initialState,
+        properties: {
+          ...initialState.properties,
+          baseline: {
+            ...initialState.properties.baseline,
+            name: "Original Title",
+            collections: [1, 2],
+          },
+          current: {
+            ...initialState.properties.current,
+            name: "Something Else",
+            collections: [],
+          },
+          isValid: false,
+          isModified: true,
+        },
+      };
+
+      const nextState = reducer(state, {
+        type: ActionCreator.RESET_CUSTOM_LIST_EDITOR,
+      });
+
+      expect(nextState.isValid).to.equal(true);
+      expect(nextState.isModified).to.equal(false);
+    });
+  });
+
+  context("getCustomListEditorFormData", () => {
+    it("should generate multipart form data from the current properties and entries", () => {
+      const state = {
+        ...initialState,
+        id: 123,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "My New List",
+            collections: [1, 2],
+          },
+        },
+        entries: {
+          ...initialState.entries,
+          baseline: [
+            { id: "book91", title: "Huckleberry Finn" },
+            { id: "book90", title: "Wuthering Heights" },
+          ],
+          current: [
+            { id: "book2", title: "Little Women" },
+            { id: "book91", title: "Huckleberry Finn" },
+          ],
+          removed: {
+            book90: true as true,
+          },
+        },
+      };
+
+      const formData = getCustomListEditorFormData(state);
+
+      expect(formData.get("id")).to.equal("123");
+      expect(formData.get("name")).to.equal("My New List");
+      expect(formData.get("collections")).to.equal("[1,2]");
+      expect(formData.get("entries")).to.equal(
+        '[{"id":"book2","title":"Little Women"},{"id":"book91","title":"Huckleberry Finn"}]'
+      );
+      expect(formData.get("deletedEntries")).to.equal(
+        '[{"id":"book90","title":"Wuthering Heights"}]'
+      );
+    });
+  });
+
+  context("getCustomListEditorSearchUrl", () => {
+    it("should generate a search url from the search params", () => {
+      const state = {
+        ...initialState,
+        searchParams: {
+          entryPoint: "Book",
+          terms: "foo bar baz",
+          sort: "title",
+          language: "eng",
+        },
+      };
+
+      const library = "lib";
+      const url = getCustomListEditorSearchUrl(state, library);
+
+      expect(url).to.equal(
+        "/lib/search?q=foo%20bar%20baz&entrypoint=Book&order=title&language=eng"
+      );
+    });
+
+    it('should omit the entrypoint param if it is "All"', () => {
+      const state = {
+        ...initialState,
+        searchParams: {
+          entryPoint: "All",
+          terms: "foo bar baz",
+          sort: "title",
+          language: "eng",
+        },
+      };
+
+      const library = "lib";
+      const url = getCustomListEditorSearchUrl(state, library);
+
+      expect(url).to.equal(
+        "/lib/search?q=foo%20bar%20baz&order=title&language=eng"
+      );
+    });
+
+    it("should omit the order param if sort is null", () => {
+      const state = {
+        ...initialState,
+        searchParams: {
+          entryPoint: "All",
+          terms: "foo bar baz",
+          sort: null,
+          language: "eng",
+        },
+      };
+
+      const library = "lib";
+      const url = getCustomListEditorSearchUrl(state, library);
+
+      expect(url).to.equal("/lib/search?q=foo%20bar%20baz&language=eng");
+    });
+
+    it("should omit the language param if language is null", () => {
+      const state = {
+        ...initialState,
+        searchParams: {
+          entryPoint: "All",
+          terms: "foo bar baz",
+          sort: null,
+          language: null,
+        },
+      };
+
+      const library = "lib";
+      const url = getCustomListEditorSearchUrl(state, library);
+
+      expect(url).to.equal("/lib/search?q=foo%20bar%20baz");
+    });
+  });
+});

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -1,0 +1,763 @@
+import produce from "immer";
+import { BookData } from "opds-web-client/lib/interfaces";
+import { getMedium } from "opds-web-client/lib/utils/book";
+import ActionCreator from "../actions";
+
+export interface Entry extends BookData {
+  medium?: string;
+}
+
+/**
+ * Information about the entries in a list that is being edited.
+ */
+export interface CustomListEditorEntriesData {
+  /**
+   * The visible entries in the list, when the last was last saved. This can be used to restore
+   * the editor to the last save point, and to detect changes since the last save. Note that this
+   * does not necessarily contain all of the entries, but only the entries in the pages that have
+   * been retrieved from the CM.
+   */
+  baseline: Entry[];
+
+  /**
+   * The total number of entries in the list, when the list was last saved. This can be used when
+   * restoring the editor to the last save point. This reflects the total number of entries in the
+   * list (as reported by the CM), not just the number of visible ones from the pages that have
+   * been retrieved. As such, it may be greater than baseline.length.
+   */
+  baselineTotalCount: number;
+
+  /**
+   * The entries that have been added to the list since the last save, keyed by id. This is stored
+   * as a delta, so that it can be reapplied to the baseline, if/when baseline is updated from the
+   * CM.
+   */
+  added: Record<string, Entry>;
+
+  /**
+   * The entries that have been removed from the list since the last save, keyed by id. This is
+   * stored as a delta, so that it can be reapplied to the baseline, if/when baseline is updated
+   * from the CM.
+   */
+  removed: Record<string, true>;
+
+  /**
+   * The currently visible entries in the list, computed by applying the delta to the baseline.
+   * This is purely derived from baseline, added, and removed, but is stored here as a convenience/
+   * optimization, so that view components will not need to perform a potentially expensive
+   * computation when rendering. Note that like baseline, this list contains only the entries in
+   * pages that have been retrieved from the CM (plus any entries added by the user since the last
+   * save), which is not necessarily all of the current entries in the list.
+   */
+  current: Entry[];
+
+  /**
+   * The current number of entries in the list, since the last save. This is derived from
+   * baselineTotalCount, added, and removed. It is stored here as a convenience, so that view
+   * components won't have to compute the value when rendering.
+   */
+  currentTotalCount: number;
+}
+
+/**
+ * Properties of the custom list.
+ */
+export interface CustomListEditorProperties {
+  /**
+   * The name (title) of the list.
+   */
+  name: string;
+
+  /**
+   * The ids of collections that should be used to automatically populate the list.
+   */
+  collections: (string | number)[];
+}
+
+/**
+ * Properties of the custom list, tracked since the last save.
+ */
+export interface CustomListEditorTrackedProperties {
+  /**
+   * The properties of the list, when the list was last saved. This can be used to restore the
+   * editor to the last save point, and to detect changes since the last save.
+   */
+  baseline: CustomListEditorProperties;
+
+  /**
+   * The current properties of the list, since the last save.
+   */
+  current: CustomListEditorProperties;
+}
+
+/**
+ * Search parameters.
+ */
+export interface CustomListEditorSearchParams {
+  /**
+   * The entry point of the search, e.g. ebooks, audiobooks.
+   */
+  entryPoint: string;
+
+  /**
+   * The terms to search for.
+   */
+  terms: string;
+
+  /**
+   * The desired sort order of search results.
+   */
+  sort: string;
+
+  /**
+   * The desired language of search results.
+   */
+  language: string;
+}
+
+/**
+ * The state of the custom list editor.
+ */
+export interface CustomListEditorState {
+  /**
+   * The id of the list being edited. This can be null, if this is a new list.
+   */
+  id: number;
+
+  /**
+   * The properties of the list.
+   */
+  properties: CustomListEditorTrackedProperties;
+
+  /**
+   * The parameters to use when searching on the custom list editor.
+   */
+  searchParams: CustomListEditorSearchParams;
+
+  /**
+   * The entries in the list.
+   */
+  entries: CustomListEditorEntriesData;
+
+  /**
+   * The validity of the list; true if the list is valid, false otherwise. This is derived from
+   * properties and entries. It is stored here as a convenience, so that view components won't need
+   * to compute the validity when rendering.
+   */
+  isValid: boolean;
+
+  /**
+   * The modified state of the list; true if the list has been changed since the last save, false
+   * otherwise. This is derived from properties and entries. It is stored here as a convenience, so
+   * that view components won't need to make the determination when rendering.
+   */
+  isModified: boolean;
+
+  /**
+   * An error message, if an error has occurred.
+   */
+  error: string;
+}
+
+/**
+ * The initial state. Provides defaults for a new list.
+ */
+export const initialState: CustomListEditorState = {
+  id: null,
+  properties: {
+    baseline: {
+      name: "",
+      collections: [],
+    },
+    current: {
+      name: "",
+      collections: [],
+    },
+  },
+  searchParams: {
+    entryPoint: "All",
+    terms: "",
+    sort: null,
+    language: "all",
+  },
+  entries: {
+    baseline: [],
+    baselineTotalCount: 0,
+    added: {},
+    removed: {},
+    current: [],
+    currentTotalCount: 0,
+  },
+  isValid: false,
+  isModified: false,
+  error: null,
+};
+
+/**
+ * Determines if a custom list editor contains valid current data, given its state. A list is valid
+ * if it has a name, and has either: at least one source collection, or at least one entry.
+ *
+ * @param state The custom list editor state
+ * @returns     true if the editor contains valid data, false otherwise
+ */
+const isValid = (state: CustomListEditorState): boolean => {
+  const { properties, entries } = state;
+  const { name, collections } = properties.current;
+  const { currentTotalCount } = entries;
+
+  return !!name && (collections.length > 0 || currentTotalCount > 0);
+};
+
+/**
+ * Determines if a custom list editor contains data has been modified since it was last saved,
+ * given its state.
+ *
+ * @param state The custom list editor state
+ * @returns     true if the editor has been modified since last save, false otherwise
+ */
+const isModified = (state: CustomListEditorState): boolean => {
+  const { properties, entries } = state;
+  const { added, removed } = entries;
+  const { baseline, current } = properties;
+
+  return (
+    Object.keys(added).length > 0 ||
+    Object.keys(removed).length > 0 ||
+    baseline.name !== current.name ||
+    baseline.collections.length !== current.collections.length ||
+    !baseline.collections.every((id) => current.collections.includes(id))
+  );
+};
+
+/**
+ * Validates the data in a custom list editor state, and checks if the data has been modified.
+ *
+ * @param state The custom list editor state
+ * @returns     A new custom list editor state, with the isValid and isModified properties updated
+ *              to reflect the data in the input state. All other properties of the returned state
+ *              are identical to the input state.
+ */
+const validateAndCheckModified = (
+  state: CustomListEditorState
+): CustomListEditorState => {
+  return produce(state, (draftState) => {
+    draftState.isValid = isValid(draftState);
+    draftState.isModified = isModified(draftState);
+  });
+};
+
+/**
+ * A decorator for an action handler that:
+ *
+ * - Applies the given handler to obtain a new state.
+ * - Validates the data in the new state, and checks if the data in the new state has been modified
+ *   since the last save.
+ * - Returns a new state, with the isValid and isModified properties updated to be correct for
+ *   the state returned by the given handler.
+ *
+ * This decorator should be applied to any handler that could plausibly affect whether or not the
+ * custom list editor data is valid or modified.
+ *
+ * @param handler The action handler to decorate. This can be any function that accepts a custom
+ *                list editor state and an action, and returns a new custom list editor state.
+ * @returns       The decorated action handler.
+ */
+const validatedHandler = (handler) => (state: CustomListEditorState, action?) =>
+  validateAndCheckModified(handler(state, action));
+
+/**
+ * Generates the initial state for a previously saved list.
+ *
+ * @param id   The id of the list.
+ * @param data The data received from a call to the custom_lists endpoint in the CM. This contains
+ *             basic information about all the lists in the library. If a list with the given id
+ *             exists in the data, the initial state is populated with the data for that list.
+ * @returns    The initial state for the list.
+ */
+const initialStateForList = (id: number, data): CustomListEditorState => {
+  let customList = null;
+  let error = null;
+
+  if (data && id !== null) {
+    customList = data.custom_lists.find((list) => list.id === id);
+
+    if (!customList) {
+      error = `Custom list not found for ID: ${id}`;
+    }
+  }
+
+  return produce(initialState, (draftState) => {
+    draftState.id = id;
+
+    if (customList) {
+      const initialProperties = {
+        name: customList.name,
+        collections: customList.collections.map((collection) => collection.id),
+      };
+
+      draftState.properties.baseline = initialProperties;
+      draftState.properties.current = initialProperties;
+
+      draftState.entries.baselineTotalCount = customList.entry_count;
+    }
+
+    draftState.error = error;
+  });
+};
+
+/**
+ * For a given custom list editor entries data, applies the added and removed deltas to the
+ * baseline entries. This mutates the input object: current is set to the result of applying the
+ * deltas to the baseline; currentTotalCount is set to the total count after applying the delta,
+ * calculated from baselineTotalCount.
+ *
+ * NB: Since this function mutates the input, it must only be used on a draft object, inside an
+ * immer produce recipe.
+ *
+ * @param entries The entries data to update.
+ */
+const applyEntriesDelta = (entries: CustomListEditorEntriesData) => {
+  const { baseline, baselineTotalCount, added, removed } = entries;
+
+  const addedEntries = Object.values(added);
+
+  // Show the most recently added entries at the top.
+  addedEntries.reverse();
+
+  entries.current = addedEntries.concat(
+    baseline.filter((entry) => !removed[entry.id])
+  );
+
+  const addedCount = addedEntries.length;
+  const removedCount = Object.keys(removed).length;
+  const currentCount = entries.current.length;
+
+  entries.currentTotalCount = Math.max(
+    baselineTotalCount + addedCount - removedCount,
+    currentCount
+  );
+};
+
+/**
+ * Handle the OPEN_CUSTOM_LIST_EDITOR action. This action is fired when a new custom list editor is
+ * opened, e.g. by clicking the Edit button on a list, or the Create button in the lists sidebar.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - id: The id of the list
+ *               - data: The data received from a call to the custom_lists endpoint in the CM.
+ *                       If present, this contains basic information about all the lists in the
+ *                       library. The id supplied in the action is expected to correspond to the id
+ *                       of a list that is present in the data. It is possible for this to be null,
+ *                       since the call to custom_lists may still be in flight when the editor is
+ *                       opened. If this occurs, the handler for the CUSTOM_LISTS_LOAD action will
+ *                       take care of updating the state when the data becomes available.
+ * @returns      The next state
+ */
+const handleCustomListEditorOpen = (
+  state: CustomListEditorState,
+  action
+): CustomListEditorState => {
+  const { id, data } = action;
+
+  return initialStateForList(id ? parseInt(id, 10) : null, data);
+};
+
+/**
+ * Handle the CUSTOM_LISTS_LOAD action. This action is fired when a call to the custom_lists
+ * endpoint in the CM completes.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - data: The data received from a call to the custom_lists endpoint in the CM.
+ *                       This contains basic information about all the lists in the library. The id
+ *                       stored in the current state, if it is not null, is expected to correspond
+ *                       to the id of a list that is present in the data.
+ * @returns      The next state
+ */
+const handleCustomListsLoad = (
+  state: CustomListEditorState,
+  action
+): CustomListEditorState => {
+  const { id } = state;
+  const { data } = action;
+
+  return initialStateForList(id, data);
+};
+
+/**
+ * Handle the CUSTOM_LIST_DETAILS_LOAD action. This action is fired when a call to the
+ * custom_list/{id} endpoint in the CM completes.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - data: The data received from a call to the custom_list/{id} endpoint in the CM.
+ *                       This contains a list of entries.
+ * @returns      The next state
+ */
+const handleCustomListDetailsLoad = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    return produce(state, (draftState) => {
+      const { entries } = draftState;
+
+      entries.baseline = action.data.books;
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+/**
+ * Handle the CUSTOM_LIST_DETAILS_MORE_LOAD action. This action is fired when a call to the
+ * custom_list/{id}?after={count} endpoint in the CM completes.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - data: The data received from a call to the custom_list/{id} endpoint in the CM.
+ *                       This contains a list of entries.
+ * @returns      The next state
+ */
+const handleCustomListDetailsMoreLoad = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    return produce(state, (draftState) => {
+      const { entries } = draftState;
+
+      entries.baseline = entries.baseline.concat(action.data.books);
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+/**
+ * Handle the UPDATE_CUSTOM_LIST_EDITOR_PROPERTY action. This action is fired when the user changes
+ * the value of a list property (e.g. name, collections) on the form.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - name:  The name of the property that was updated.
+ *               - value: The value of the property.
+ * @returns      The next state
+ */
+const handleUpdateCustomListEditorProperty = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    const { name, value } = action;
+
+    return produce(state, (draftState) => {
+      draftState.properties.current[name] = value;
+    });
+  }
+);
+
+/**
+ * Handle the TOGGLE_CUSTOM_LIST_EDITOR_COLLECTION action. This action is fired when the user
+ * clicks on a collection checkbox in the form.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - id:  The id of the collection to toggle.
+ * @returns      The next state
+ */
+const handleToggleCustomListEditorCollection = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    const { id } = action;
+
+    return produce(state, (draftState) => {
+      const { collections } = draftState.properties.current;
+      const index = collections.indexOf(id);
+
+      if (index < 0) {
+        collections.push(id);
+      } else {
+        collections.splice(index, 1);
+      }
+    });
+  }
+);
+
+/**
+ * Handle the UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM action. This action is fired when the user
+ * changes the value of a search parameter in the form.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - name:  The name of the search parameter that was updated.
+ *               - value: The value of the search parameter.
+ * @returns      The next state
+ */
+const handleUpdateCustomListEditorSearchParam = (
+  state: CustomListEditorState,
+  action
+): CustomListEditorState => {
+  const { name, value } = action;
+
+  return produce(state, (draftState) => {
+    draftState.searchParams[name] = value;
+  });
+};
+
+const bookToEntry = (book) => ({
+  id: book.id,
+  title: book.title,
+  authors: book.authors,
+  url: book.url,
+  medium: getMedium(book),
+  language: book.language || "",
+});
+
+/**
+ * Handle the ADD_CUSTOM_LIST_EDITOR_ENTRY action. This action is fired when the user adds a single
+ * book from the search results to the entry list.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - id:   The id of the book in the search results to add to the entries.
+ *               - data: The data received from a call to the search endpoint in the CM, which
+ *                       contains search results. The The id supplied in the action is expected to
+ *                       correspond to the id of a book that is present in the data.
+ * @returns      The next state
+ */
+const handleAddCustomListEditorEntry = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    const { id, data } = action;
+
+    return produce(state, (draftState) => {
+      const { entries } = draftState;
+      const { baseline, added, removed } = entries;
+
+      const inList = baseline.find((book) => book.id === id);
+
+      if (!inList) {
+        const bookToAdd = data.books.find((book) => book.id === id);
+        const isAdded = !!added[id];
+
+        if (bookToAdd && !isAdded) {
+          added[id] = bookToEntry(bookToAdd);
+        }
+      }
+
+      delete removed[id];
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+/**
+ * Handle the ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES action. This action is fired when the user adds
+ * all books from the search results to the entry list.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - data: The data received from a call to the search endpoint in the CM, which
+ *                       contains search results.
+ * @returns      The next state
+ */
+const handleAddAllCustomListEditorEntries = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    const { books } = action.data;
+
+    // Add the books in reverse order, so that they appear in the entry list in the same order as
+    // they appear in the search results.
+
+    books.reverse();
+
+    return produce(state, (draftState) => {
+      const { entries } = draftState;
+      const { baseline, added, removed } = entries;
+
+      const listIds = baseline.reduce((ids, book) => {
+        ids[book.id] = true;
+
+        return ids;
+      }, {});
+
+      books
+        .filter((book) => !listIds[book.id] && !added[book.id])
+        .map((book) => bookToEntry(book))
+        .forEach((entry) => (added[entry.id] = entry));
+
+      books.forEach((book) => delete removed[book.id]);
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+/**
+ * Handle the DELETE_CUSTOM_LIST_EDITOR_ENTRY action. This action is fired when the user removes a
+ * single book from the entry list.
+ *
+ * @param state  The current state
+ * @param action The action, which should contain the following properties:
+ *               - id: The id of the entry to remove.
+ * @returns      The next state
+ */
+const handleDeleteCustomListEditorEntry = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    const { id } = action;
+
+    return produce(state, (draftState) => {
+      const { entries } = draftState;
+      const { added, removed } = entries;
+
+      if (added[id]) {
+        delete added[id];
+      } else {
+        removed[id] = true;
+      }
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+/**
+ * Handle the DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES action. This action is fired when the user
+ * removes all books from the entry list.
+ *
+ * @param state  The current state
+ * @returns      The next state
+ */
+const handleDeleteAllCustomListEditorEntries = validatedHandler(
+  (state: CustomListEditorState): CustomListEditorState => {
+    return produce(state, (draftState) => {
+      const { entries } = draftState;
+      const { baseline, removed } = entries;
+
+      baseline.forEach((book) => {
+        removed[book.id] = true;
+      });
+
+      entries.added = {};
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+/**
+ * Handle the RESET_CUSTOM_LIST_EDITOR action. This action is fired when the user cancels unsaved
+ * changes in the editor form.
+ *
+ * @param state  The current state
+ * @returns      The next state
+ */
+const handleResetCustomListEditor = validatedHandler(
+  (state: CustomListEditorState): CustomListEditorState => {
+    return produce(state, (draftState) => {
+      const { properties, entries } = draftState;
+
+      properties.current = properties.baseline;
+
+      entries.added = {};
+      entries.removed = {};
+
+      applyEntriesDelta(entries);
+    });
+  }
+);
+
+export default (
+  state: CustomListEditorState = initialState,
+  action
+): CustomListEditorState => {
+  switch (action.type) {
+    case ActionCreator.OPEN_CUSTOM_LIST_EDITOR:
+      return handleCustomListEditorOpen(state, action);
+    case `${ActionCreator.CUSTOM_LISTS}_${ActionCreator.LOAD}`:
+      return handleCustomListsLoad(state, action);
+    case `${ActionCreator.CUSTOM_LIST_DETAILS}_${ActionCreator.LOAD}`:
+      return handleCustomListDetailsLoad(state, action);
+    case `${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.LOAD}`:
+      return handleCustomListDetailsMoreLoad(state, action);
+    case ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_PROPERTY:
+      return handleUpdateCustomListEditorProperty(state, action);
+    case ActionCreator.TOGGLE_CUSTOM_LIST_EDITOR_COLLECTION:
+      return handleToggleCustomListEditorCollection(state, action);
+    case ActionCreator.UPDATE_CUSTOM_LIST_EDITOR_SEARCH_PARAM:
+      return handleUpdateCustomListEditorSearchParam(state, action);
+    case ActionCreator.ADD_CUSTOM_LIST_EDITOR_ENTRY:
+      return handleAddCustomListEditorEntry(state, action);
+    case ActionCreator.ADD_ALL_CUSTOM_LIST_EDITOR_ENTRIES:
+      return handleAddAllCustomListEditorEntries(state, action);
+    case ActionCreator.DELETE_CUSTOM_LIST_EDITOR_ENTRY:
+      return handleDeleteCustomListEditorEntry(state, action);
+    case ActionCreator.DELETE_ALL_CUSTOM_LIST_EDITOR_ENTRIES:
+      return handleDeleteAllCustomListEditorEntries(state, action);
+    case ActionCreator.RESET_CUSTOM_LIST_EDITOR:
+      return handleResetCustomListEditor(state, action);
+    default:
+      return state;
+  }
+};
+
+/**
+ * Converts a custom list editor state to multipart form data, suitable for posting to the
+ * custom_list/{id} endpoint of the CM.
+ *
+ * @param state The custom list editor state
+ * @returns     A FormData object that represents the data in the custom list editor
+ */
+export const getCustomListEditorFormData = (
+  state: CustomListEditorState
+): FormData => {
+  const data = new (window as any).FormData();
+
+  const { id, properties, entries } = state;
+
+  if (id) {
+    data.append("id", id);
+  }
+
+  const { name, collections } = properties.current;
+
+  data.append("name", name);
+  data.append("collections", JSON.stringify(collections));
+
+  const { baseline, current, removed } = entries;
+
+  data.append("entries", JSON.stringify(current));
+
+  const entriesById = baseline.reduce((ids, entry) => {
+    ids[entry.id] = entry;
+
+    return ids;
+  }, {});
+
+  const deletedEntries = Object.keys(removed).map((id) => entriesById[id]);
+
+  data.append("deletedEntries", JSON.stringify(deletedEntries));
+
+  return data;
+};
+
+/**
+ * Converts search parameters in a custom list editor state to a search query URL.
+ *
+ * @param state   The custom list editor state
+ * @param library The short name of the library that contains the list being edited
+ * @returns
+ */
+export const getCustomListEditorSearchUrl = (
+  state: CustomListEditorState,
+  library: string
+): string => {
+  const { entryPoint, terms, sort, language } = state.searchParams;
+
+  const queryParams = [`q=${encodeURIComponent(terms)}`];
+
+  if (entryPoint !== "All") {
+    queryParams.push(`entrypoint=${encodeURIComponent(entryPoint)}`);
+  }
+
+  if (sort) {
+    queryParams.push(`order=${encodeURIComponent(sort)}`);
+  }
+
+  if (language) {
+    queryParams.push(`language=${encodeURIComponent(language)}`);
+  }
+
+  return `/${library}/search?${queryParams.join("&")}`;
+};

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -30,6 +30,7 @@ import customLists from "./customLists";
 import customListDetails, {
   FetchMoreCustomListDetails,
 } from "./customListDetails";
+import customListEditor, { CustomListEditorState } from "./customListEditor";
 import lanes from "./lanes";
 import laneVisibility from "./laneVisibility";
 import resetLanes from "./resetLanes";
@@ -106,6 +107,7 @@ export interface State {
   collectionLibraryRegistrations: FetchEditState<LibraryRegistrationsData>;
   customLists: FetchEditState<CustomListsData>;
   customListDetails: FetchMoreCustomListDetails<CollectionData>;
+  customListEditor: CustomListEditorState;
   collection: CollectionState;
   lanes: FetchEditState<LanesData>;
   laneVisibility: FetchEditState<void>;
@@ -150,6 +152,7 @@ export default combineReducers<State>({
   collectionLibraryRegistrations,
   customLists,
   customListDetails,
+  customListEditor,
   collection,
   lanes,
   laneVisibility,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "target": "es5",
     "outDir": "lib",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "rootDir": "src",
     "types": ["mocha", "node"],
     "jsx": "react"

--- a/tslint.json
+++ b/tslint.json
@@ -22,7 +22,8 @@
         ],
         "quotemark": [
             true,
-            "double"
+            "double",
+            "avoid-escape"
         ],
         "semicolon": true,
         "triple-equals": [


### PR DESCRIPTION
## Description

This refactors the `CustomListEditor`, `CustomListEntriesEditor`, and `CustomListSearch` components to:

- Make them stateless.†
- Remove data manipulation functions that are better implemented outside of the view layer.

The state that was being kept by these components is now lifted up into the Redux store. Several new action creators have been added to represent the actions users can perform on the custom list editor form. A new `customListEditor` reducer handles these actions, and updates the state accordingly. The view components are now pure functions that accept props (pulled from the Redux state), and return a rendered DOM.

† There is still one tiny bit of state in `CustomListEntriesEditor`, the source of a drag while a drag-and-drop is in progress. This can be moved later, if we ever need to generalize drag-and-drop.

This presentation contains an overview of the refactoring: https://docs.google.com/presentation/d/1v-0KdPXHT_fe6suydnUhTeY_NrVFt_lYqFLbPEH9JZc

## Motivation and Context

This greatly simplifies the view components, makes them more testable, and reduces the chance of introducing bugs. It was originally motivated by trying to fix the Save and Cancel buttons being enabled before any changes to a list had been made (https://www.notion.so/lyrasis/Custom-List-Manager-has-active-Save-Cancel-buttons-before-anything-has-been-changed-06ae75f1e064469da0e70bd662396059). This was caused by a confusing interaction between the props and state of `CustomListEditor`. Refactoring these components to remove state allows us to fix this issue, and makes it easier to add new features.

Notion: https://www.notion.so/lyrasis/Refactor-list-editing-components-to-be-stateless-1e9dbc5af08643b99867d4bdabdcb536

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
