### PR TITLE
Fix styling issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v0.0.12
+
+#### Fixed
+
+- The screen no longer appears to be blank when the LastPass browser extension is enabled.
+- The advanced search input fields are now correctly aligned in Firefox.
+- Spurious bullets have been removed from the search result and list entry lists.
+
 ### v0.0.11
 
 #### Fixed

--- a/src/stylesheets/advanced_search.scss
+++ b/src/stylesheets/advanced_search.scss
@@ -6,6 +6,15 @@
       gap: 4px;
     }
 
+    .form-group {
+      display: inline-block;
+      margin: 0;
+
+      > div {
+        display: inline-block;
+      }
+    }
+
     input[type="text"] {
       width: 40em;
     }
@@ -14,6 +23,10 @@
       .form-group {
         margin: 5px 20px 0 2px;;
       }
+    }
+
+    .filter-op-value-inputs {
+      margin: 15px 0;
     }
   }
 

--- a/src/stylesheets/custom_list_entries_editor.scss
+++ b/src/stylesheets/custom_list_entries_editor.scss
@@ -46,6 +46,7 @@
     overflow-y: scroll;
     margin-bottom: 15px;
     height: 100%;
+    list-style: none;
 
     &.dragging-over {
       border-color: $pagetextcolor;

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -87,18 +87,25 @@ button.btn.inverted, a.btn.inverted {
   }
 }
 
-// body > div is the outer #opds-catalog div
-body > div > div:first-child {
-  position: relative;
-  min-height: 100vh;
-  block-size: fit-content;
-  &:not(.config) main {
-    padding-bottom: 56px;
-    max-height: 78.5%;
+body > div {
+  height: unset;
+}
+
+body > #opds-catalog {
+  height: 100%;
+
+  > div:first-child {
+    position: relative;
+    min-height: 100vh;
     block-size: fit-content;
-  }
-  &.config main {
-    block-size: fit-content;
+    &:not(.config) main {
+      padding-bottom: 56px;
+      max-height: 78.5%;
+      block-size: fit-content;
+    }
+    &.config main {
+      block-size: fit-content;
+    }
   }
 }
 

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -87,11 +87,14 @@ button.btn.inverted, a.btn.inverted {
   }
 }
 
+// Overwrite the rule from opds-web-client that sets all top-level divs to 100% height. This works
+// around the LastPass extension inserting a top-level div that then takes up the whole screen.
+
 body > div {
   height: unset;
 }
 
-body > #opds-catalog {
+body > div.palace {
   height: 100%;
 
   > div:first-child {


### PR DESCRIPTION
## Description

This fixes a few styling issues:

- When the LastPass browser extension is installed and enabled, a large block of whitespace appears at the top of the screen, making the content invisible without scrolling down. This started happening with a recent update to the LastPass extension, which inserts a top-level `div` in the web page being viewed. The CSS was not expecting this extra `div` to exist.
- The advanced search input fields were misaligned in Firefox.
- There were unnecessary bullets appearing on the list items in the search results and list entries.

## Motivation and Context

The admin UI appears to be completely broken in browsers where the LastPass extension is enabled. The UI is usable after scrolling down to make it visible, but it's hard to discover you have to do that.

Notion: https://www.notion.so/lyrasis/All-CMs-load-with-large-white-space-at-top-of-screen-on-Chrome-and-Edge-8b3e10a667be4783a4a7c18979968904

The other changes just make the UI look better.

## How Has This Been Tested?

- I looked at the UI in Chrome and Firefox, with the LastPass extension enabled, and checked various catalog and configuration screens to make sure the blank space is gone. 
- I checked that the UI still looks good with the LastPass extension disabled.
- I edited a list in Firefox, and verified that the fields in the advanced search section are correctly aligned.
- I did a search in the list editor, and verified that the results list does not have bullets, and that when books are dragged to the entries list, they also do not have bullets.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
