### PR TITLE
Save search parameters with auto-updating lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.2.1
+
+#### Fixed
+
+- The selected media type and sort order are now correctly saved with auto updating lists.
+
 ### v0.2.0
 
 #### Updated

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -370,7 +370,6 @@ describe("custom list editor reducer", () => {
         data: listData,
       });
 
-      expect(nextState.properties.current.autoUpdate).to.equal(true);
       expect(nextState.searchParams.current.entryPoint).to.equal("Audio");
       expect(nextState.searchParams.current.sort).to.equal("title");
     });

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -226,6 +226,13 @@ describe("custom list editor reducer", () => {
           auto_update_query:
             '{"query":{"and":[{"and":[{"or":[{"key":"genre","value":"Horror"},{"key":"genre","value":"Fantasy"}]},{"key":"language","value":"eng"},{"key":"classification","value":"mystery"}]},{"not":[{"or":[{"key":"author","op":"contains","value":"bracken"},{"key":"title","value":"wicked appetite"}]}]}]}}',
         },
+        {
+          collections: [],
+          id: 42,
+          name: "Another Auto Updating List",
+          auto_update: true,
+          auto_update_facets: '{"media":"Audio","order":"title"}',
+        },
       ],
     };
 
@@ -350,6 +357,22 @@ describe("custom list editor reducer", () => {
           },
         ],
       });
+    });
+
+    it("updates the search params when there are saved search facets", () => {
+      const state = {
+        ...initialState,
+        id: 42,
+      };
+
+      const nextState = reducer(state, {
+        type: `${ActionCreator.CUSTOM_LISTS}_${ActionCreator.LOAD}`,
+        data: listData,
+      });
+
+      expect(nextState.properties.current.autoUpdate).to.equal(true);
+      expect(nextState.searchParams.current.entryPoint).to.equal("Audio");
+      expect(nextState.searchParams.current.sort).to.equal("title");
     });
 
     context("when auto update is enabled", () => {
@@ -2369,6 +2392,125 @@ describe("custom list editor reducer", () => {
         '{"query":{"key":"title","value":"Little Women"}}'
       );
     });
+
+    it("should include auto update facets if the list is auto updating", () => {
+      const state = {
+        ...initialState,
+        id: 123,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "My New List",
+            autoUpdate: true,
+          },
+        },
+        searchParams: {
+          ...initialState.searchParams,
+          current: {
+            ...initialState.searchParams.current,
+            entryPoint: "Audio",
+            sort: "title",
+            advanced: {
+              ...initialState.searchParams.current.advanced,
+              include: {
+                ...initialState.searchParams.current.advanced.include,
+                query: {
+                  id: "0",
+                  key: "title",
+                  op: "eq",
+                  value: "Little Women",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = getCustomListEditorFormData(state);
+
+      expect(formData.get("auto_update_facets")).to.equal(
+        '{"media":"Audio","order":"title"}'
+      );
+    });
+
+    it('should not include media in auto update facets if entryPoint is "All"', () => {
+      const state = {
+        ...initialState,
+        id: 123,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "My New List",
+            autoUpdate: true,
+          },
+        },
+        searchParams: {
+          ...initialState.searchParams,
+          current: {
+            ...initialState.searchParams.current,
+            entryPoint: "All",
+            sort: "title",
+            advanced: {
+              ...initialState.searchParams.current.advanced,
+              include: {
+                ...initialState.searchParams.current.advanced.include,
+                query: {
+                  id: "0",
+                  key: "title",
+                  op: "eq",
+                  value: "Little Women",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = getCustomListEditorFormData(state);
+
+      expect(formData.get("auto_update_facets")).to.equal('{"order":"title"}');
+    });
+
+    it("should not include order in auto update facets if sort is null", () => {
+      const state = {
+        ...initialState,
+        id: 123,
+        properties: {
+          ...initialState.properties,
+          current: {
+            ...initialState.properties.current,
+            name: "My New List",
+            autoUpdate: true,
+          },
+        },
+        searchParams: {
+          ...initialState.searchParams,
+          current: {
+            ...initialState.searchParams.current,
+            entryPoint: "Book",
+            sort: null,
+            advanced: {
+              ...initialState.searchParams.current.advanced,
+              include: {
+                ...initialState.searchParams.current.advanced.include,
+                query: {
+                  id: "0",
+                  key: "title",
+                  op: "eq",
+                  value: "Little Women",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = getCustomListEditorFormData(state);
+
+      expect(formData.get("auto_update_facets")).to.equal('{"media":"Book"}');
+    });
   });
 
   context("getCustomListEditorSearchUrl", () => {
@@ -2400,11 +2542,11 @@ describe("custom list editor reducer", () => {
       const url = getCustomListEditorSearchUrl(state, library);
 
       expect(url).to.equal(
-        "/lib/search?entrypoint=Book&order=title&q=foo%20bar%20baz"
+        "/lib/search?media=Book&order=title&q=foo%20bar%20baz"
       );
     });
 
-    it('should omit the entrypoint param if it is "All"', () => {
+    it('should omit the media param if entryPoint is "All"', () => {
       const state = {
         ...initialState,
         searchParams: {

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -86,8 +86,7 @@ export const buildSearchFacetString = (
   searchParams: CustomListEditorSearchParams
 ): string => {
   const { entryPoint, sort } = searchParams;
-
-  const facets: any = {};
+  const facets: Record<string, string> = {};
 
   if (entryPoint !== "All") {
     facets.media = entryPoint;


### PR DESCRIPTION
## Description

This sends the media type and sort order parameters when saving auto updating lists. Previously, only the advanced search query was sent.

## Motivation and Context

This allows the CM to exactly reproduce the search that was configured by the user when editing a list in the admin UI. In the UI, the user is able to select a media type (all, book, audio) and a sort order (relevance, title, author), in addition to an advanced search query. These all affect the search results. (Somewhat non-intuitively, setting the sort order to title or author changes the search results, because a relevance cut-off is automatically applied.)

This finishes off https://www.notion.so/lyrasis/Admin-UI-Automatically-add-new-titles-to-list-when-they-match-search-parameters-b86ceeffe55d4628b822e661eb992544. (There is some discussion of this in the comments of that ticket).

## How Has This Been Tested?

- Create or edit a list, with auto update set to true.
- Select values for the Search For and Sort By fields in the Search for Titles section.
- Save the list. The selected values should be retained after save.
- Reload the page in the browser. The selected values should be retained after reload.
- Repeat with various combinations of values of Search For and Sort By.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
