### PR TITLE
Implement global announcements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Changelog
 
-### v0.2.1
+### v0.3.0
 
 #### Fixed
 
 - The selected media type and sort order are now correctly saved with auto updating lists.
+
+#### Updated
+
+- Added Sitewide Announcements configuration tab.
 
 ### v0.2.0
 

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -982,4 +982,59 @@ describe("actions", () => {
       expect(data).to.eql(customListDetailsData);
     });
   });
+
+  describe("fetchSitewideAnnouncements", () => {
+    it("dispatches request, load, and success", async () => {
+      const dispatch = stub();
+      const sitewideAnnouncementsData = "sitewide announcements";
+      fetcher.testData = {
+        ok: true,
+        status: 200,
+        json: () =>
+          new Promise<any>((resolve) => {
+            resolve(sitewideAnnouncementsData);
+          }),
+      };
+      fetcher.resolve = true;
+
+      const data = await actions.fetchSitewideAnnouncements()(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(
+        `${ActionCreator.SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.REQUEST}`
+      );
+      expect(dispatch.args[0][0].url).to.equal("/admin/announcements");
+      expect(dispatch.args[1][0].type).to.equal(
+        `${ActionCreator.SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.SUCCESS}`
+      );
+      expect(dispatch.args[2][0].type).to.equal(
+        `${ActionCreator.SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.LOAD}`
+      );
+      expect(data).to.deep.equal(sitewideAnnouncementsData);
+    });
+  });
+
+  describe("editSitewideAnnouncements", () => {
+    it("dispatches request and success", async () => {
+      const editSitewideAnnouncementsUrl = "/admin/announcements";
+      const dispatch = stub();
+      const formData = new (window as any).FormData();
+      formData.append("announcements", "[]");
+
+      fetchMock.mock(editSitewideAnnouncementsUrl, "server response");
+      const fetchArgs = fetchMock.calls();
+
+      await actions.editSitewideAnnouncements(formData)(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(
+        `${ActionCreator.EDIT_SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.REQUEST}`
+      );
+      expect(dispatch.args[1][0].type).to.equal(
+        `${ActionCreator.EDIT_SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.SUCCESS}`
+      );
+      expect(fetchMock.called()).to.equal(true);
+      expect(fetchArgs[0][0]).to.equal(editSitewideAnnouncementsUrl);
+      expect(fetchArgs[0][1].method).to.equal("POST");
+      expect(fetchArgs[0][1].body).to.equal(formData);
+    });
+  });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -32,6 +32,7 @@ import {
   PatronData,
   DiagnosticsData,
   FeatureFlags,
+  SitewideAnnouncementsData,
 } from "./interfaces";
 import { CollectionData } from "opds-web-client/lib/interfaces";
 import DataFetcher from "opds-web-client/lib/DataFetcher";
@@ -81,6 +82,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly PATRON_AUTH_SERVICES = "PATRON_AUTH_SERVICES";
   static readonly EDIT_PATRON_AUTH_SERVICE = "EDIT_PATRON_AUTH_SERVICE";
   static readonly DELETE_PATRON_AUTH_SERVICE = "DELETE_PATRON_AUTH_SERVICE";
+  static readonly SITEWIDE_ANNOUNCEMENTS = "SITEWIDE_ANNOUNCEMENTS";
   static readonly SITEWIDE_SETTINGS = "SITEWIDE_SETTINGS";
   static readonly EDIT_SITEWIDE_SETTING = "EDIT_SITEWIDE_SETTING";
   static readonly DELETE_SITEWIDE_SETTING = "DELETE_SITEWIDE_SETTING";
@@ -1150,6 +1152,21 @@ export default class ActionCreator extends BaseActionCreator {
   fetchDiagnostics() {
     const url = "/admin/diagnostics";
     return this.fetchJSON<DiagnosticsData>(ActionCreator.DIAGNOSTICS, url).bind(
+      this
+    );
+  }
+
+  fetchSitewideAnnouncements() {
+    const url = "/admin/announcements";
+    return this.fetchJSON<SitewideAnnouncementsData>(
+      ActionCreator.SITEWIDE_ANNOUNCEMENTS,
+      url
+    ).bind(this);
+  }
+
+  editSitewideAnnouncements(data: FormData) {
+    const url = "/admin/announcements";
+    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data).bind(
       this
     );
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -83,6 +83,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_PATRON_AUTH_SERVICE = "EDIT_PATRON_AUTH_SERVICE";
   static readonly DELETE_PATRON_AUTH_SERVICE = "DELETE_PATRON_AUTH_SERVICE";
   static readonly SITEWIDE_ANNOUNCEMENTS = "SITEWIDE_ANNOUNCEMENTS";
+  static readonly EDIT_SITEWIDE_ANNOUNCEMENTS = "EDIT_SITEWIDE_ANNOUNCEMENTS";
   static readonly SITEWIDE_SETTINGS = "SITEWIDE_SETTINGS";
   static readonly EDIT_SITEWIDE_SETTING = "EDIT_SITEWIDE_SETTING";
   static readonly DELETE_SITEWIDE_SETTING = "DELETE_SITEWIDE_SETTING";
@@ -1166,9 +1167,11 @@ export default class ActionCreator extends BaseActionCreator {
 
   editSitewideAnnouncements(data: FormData) {
     const url = "/admin/announcements";
-    return this.postForm(ActionCreator.EDIT_SEARCH_SERVICE, url, data).bind(
-      this
-    );
+    return this.postForm(
+      ActionCreator.EDIT_SITEWIDE_ANNOUNCEMENTS,
+      url,
+      data
+    ).bind(this);
   }
 
   setFeatureFlags(featureFlags: FeatureFlags) {

--- a/src/components/AnnouncementForm.tsx
+++ b/src/components/AnnouncementForm.tsx
@@ -153,6 +153,7 @@ export default class AnnouncementForm extends React.Component<
         />
         <Button
           callback={(e: Event) => this.add(e)}
+          content="Add"
           className="inline left-align"
           disabled={shouldDisable()}
         />

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -5,6 +5,7 @@ import Collections from "./Collections";
 import AdminAuthServices from "./AdminAuthServices";
 import IndividualAdmins from "./IndividualAdmins";
 import PatronAuthServices from "./PatronAuthServices";
+import SitewideAnnouncements from './SitewideAnnouncements';
 import SitewideSettings from "./SitewideSettings";
 import MetadataServices from "./MetadataServices";
 import AnalyticsServices from "./AnalyticsServices";
@@ -58,6 +59,7 @@ export default class ConfigTabContainer extends TabContainer<
     storage: StorageServices,
     catalogServices: CatalogServices,
     discovery: DiscoveryServices,
+    sitewideAnnouncements: SitewideAnnouncements,
   };
 
   LIBRARIAN_TABS = ["libraries"];
@@ -68,6 +70,7 @@ export default class ConfigTabContainer extends TabContainer<
     adminAuth: "Admin Authentication",
     individualAdmins: "Admins",
     patronAuth: "Patron Authentication",
+    sitewideAnnouncements: "Sitewide Announcements",
     sitewideSettings: "Sitewide Settings",
     cdn: "CDN",
     catalogServices: "External Catalogs",

--- a/src/components/ConfigTabContainer.tsx
+++ b/src/components/ConfigTabContainer.tsx
@@ -5,7 +5,7 @@ import Collections from "./Collections";
 import AdminAuthServices from "./AdminAuthServices";
 import IndividualAdmins from "./IndividualAdmins";
 import PatronAuthServices from "./PatronAuthServices";
-import SitewideAnnouncements from './SitewideAnnouncements';
+import SitewideAnnouncements from "./SitewideAnnouncements";
 import SitewideSettings from "./SitewideSettings";
 import MetadataServices from "./MetadataServices";
 import AnalyticsServices from "./AnalyticsServices";

--- a/src/components/SitewideAnnouncements.tsx
+++ b/src/components/SitewideAnnouncements.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+import { connect } from "react-redux";
+import { Alert } from "react-bootstrap";
+import { Panel, Button, Form } from "library-simplified-reusable-components";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import EditableConfigList, {
+  EditableConfigListStateProps,
+  EditableConfigListDispatchProps,
+  EditableConfigListOwnProps,
+  EditableConfigListProps,
+} from "./EditableConfigList";
+import ActionCreator from "../actions";
+import { SitewideAnnouncementsData, AnnouncementData } from "../interfaces";
+import ErrorMessage from "./ErrorMessage";
+import AnnouncementsSection from "./AnnouncementsSection";
+
+/** Right panel for sitewide announcements on the system configuration page. */
+export class SitewideAnnouncements extends EditableConfigList<
+  SitewideAnnouncementsData,
+  AnnouncementData
+> {
+  EditForm = null;
+  listDataKey = "announcements";
+  itemTypeName = "sitewide announcement";
+  urlBase = "/admin/web/config/sitewideAnnouncements/";
+  identifierKey = "id";
+  labelKey = "content";
+
+  private announcementsRef = React.createRef<AnnouncementsSection>();
+
+  constructor(props: EditableConfigListProps<SitewideAnnouncementsData>) {
+    super(props);
+
+    this.submit = this.submit.bind(this);
+  }
+
+  render() {
+    const headers = this.getHeaders();
+
+    const canListAllData =
+      !this.props.isFetching &&
+      !this.props.editOrCreate &&
+      this.props.data?.[this.listDataKey];
+
+    const canEdit = this.canEdit(this.props.data?.settings || {});
+
+    return (
+      <div className={this.getClassName()}>
+        <h2>{headers["h2"]}</h2>
+        {canListAllData && this.links?.["info"] && (
+          <Alert bsStyle="info">{this.links["info"]}</Alert>
+        )}
+        {this.props.responseBody && (
+          <Alert bsStyle="success">{this.successMessage()}</Alert>
+        )}
+        {this.props.fetchError && (
+          <ErrorMessage error={this.props.fetchError} />
+        )}
+        {this.props.formError && (
+          <ErrorMessage error={this.props.formError} />
+        )}
+        {this.props.isFetching && <LoadingIndicator />}
+
+        {canListAllData && (
+          <Form
+            onSubmit={this.submit}
+            className="no-border edit-form"
+            disableButton={!canEdit || this.props.isFetching}
+            content={[
+              <AnnouncementsSection
+                key="announcements-section"
+                setting={this.props.data.settings}
+                value={this.props.data[this.listDataKey]}
+                ref={this.announcementsRef}
+              />
+            ]}
+          />
+        )}
+      </div>
+    );
+  }
+
+  async submit(data: FormData) {
+    const announcements = this.announcementsRef.current.getValue();
+
+    data?.set("announcements", JSON.stringify(announcements));
+
+    await this.editItem(data);
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  const data = {
+    ...(state.editor.sitewideAnnouncements?.data || {})
+  };
+
+  return {
+    data,
+    responseBody: state.editor.sitewideAnnouncements?.successMessage,
+    fetchError: state.editor.sitewideAnnouncements.fetchError,
+    formError: state.editor.sitewideAnnouncements.formError,
+    isFetching:
+      state.editor.sitewideAnnouncements.isFetching ||
+      state.editor.sitewideAnnouncements.isEditing,
+  };
+}
+
+function mapDispatchToProps(dispatch, ownProps) {
+  const actions = new ActionCreator(null, ownProps.csrfToken);
+  return {
+    fetchData: () => dispatch(actions.fetchSitewideAnnouncements()),
+    editItem: (data: FormData) => dispatch(actions.editSitewideAnnouncements(data)),
+  };
+}
+
+const ConnectedSitewideAnnouncements = connect<
+  EditableConfigListStateProps<SitewideAnnouncementsData>,
+  EditableConfigListDispatchProps<SitewideAnnouncementsData>,
+  EditableConfigListOwnProps
+>(
+  mapStateToProps,
+  mapDispatchToProps
+)(SitewideAnnouncements);
+
+export default ConnectedSitewideAnnouncements;

--- a/src/components/__tests__/AnnouncementForm-test.tsx
+++ b/src/components/__tests__/AnnouncementForm-test.tsx
@@ -48,7 +48,7 @@ describe("AnnouncementForm", () => {
   it("renders the buttons", () => {
     let buttons = wrapper.find("button");
     expect(buttons.length).to.equal(2);
-    expect(buttons.at(0).text()).to.equal("Submit");
+    expect(buttons.at(0).text()).to.equal("Add");
     expect(buttons.at(1).text()).to.equal("Cancel");
   });
   it("keeps track of whether the content is too short or too long", () => {

--- a/src/components/__tests__/ConfigTabContainer-test.tsx
+++ b/src/components/__tests__/ConfigTabContainer-test.tsx
@@ -19,6 +19,7 @@ import SearchServices from "../SearchServices";
 import StorageServices from "../StorageServices";
 import CatalogServices from "../CatalogServices";
 import DiscoveryServices from "../DiscoveryServices";
+import SitewideAnnouncements from "../SitewideAnnouncements";
 import { mockRouterContext } from "./routing";
 import Admin from "../../models/Admin";
 
@@ -62,6 +63,7 @@ describe("ConfigTabContainer", () => {
       expect(linkTexts).to.contain("Metadata");
       expect(linkTexts).to.contain("CDN");
       expect(linkTexts).to.contain("External Catalogs");
+      expect(linkTexts).to.contain("Sitewide Announcements");
     });
 
     it("shows components", () => {
@@ -79,6 +81,7 @@ describe("ConfigTabContainer", () => {
         StorageServices,
         CatalogServices,
         DiscoveryServices,
+        SitewideAnnouncements,
       ];
       for (const componentClass of componentClasses) {
         const component = wrapper.find(componentClass);
@@ -152,6 +155,7 @@ describe("ConfigTabContainer", () => {
         CatalogServices,
         DiscoveryServices,
         AnalyticsServices,
+        SitewideAnnouncements,
       ];
       for (const componentClass of hiddenComponentClasses) {
         const component = wrapper.find(componentClass);
@@ -206,6 +210,7 @@ describe("ConfigTabContainer", () => {
         CatalogServices,
         DiscoveryServices,
         AnalyticsServices,
+        SitewideAnnouncements,
       ];
       for (const componentClass of hiddenComponentClasses) {
         const component = wrapper.find(componentClass);

--- a/src/components/__tests__/SitewideAnnouncements-test.tsx
+++ b/src/components/__tests__/SitewideAnnouncements-test.tsx
@@ -1,0 +1,156 @@
+import * as React from "react";
+import { expect } from "chai";
+import { stub } from "sinon";
+import { mount } from "enzyme";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
+import AnnouncementsSection from "../AnnouncementsSection";
+import { SitewideAnnouncements } from "../SitewideAnnouncements";
+
+describe("SitewideAnnouncements", () => {
+  const fetchData = stub();
+
+  const data = {
+    announcements: [
+      {
+        id: "dcf036d9-106b-426c-838f-ce7c57d53801",
+        content: "There is nothing to see here.",
+        start: "2022-08-31",
+        finish: "2022-10-31",
+      },
+    ],
+    settings: [
+      {
+        category: "Announcements",
+        description:
+          "Announcements will be displayed to authenticated patrons.",
+        key: "global_announcements",
+        label: "Scheduled announcements",
+        level: 3,
+        type: "announcements",
+      },
+    ],
+  };
+
+  it("renders a Form containing an AnnouncementsSection", () => {
+    const wrapper = mount(
+      <SitewideAnnouncements
+        data={data}
+        csrfToken="token"
+        fetchData={fetchData}
+        isFetching={false}
+      />,
+      {
+        context: {
+          admin: {
+            isSystemAdmin: () => true,
+            isLibraryManagerOfSomeLibrary: () => true,
+          },
+        },
+      }
+    );
+
+    const form = wrapper.find("form");
+
+    expect(form.length).to.equal(1);
+
+    const announcementsSection = form.find(AnnouncementsSection);
+
+    expect(announcementsSection.length).to.equal(1);
+    expect(announcementsSection.prop("value")).to.deep.equal(
+      data.announcements
+    );
+    expect(announcementsSection.prop("setting")).to.deep.equal(
+      data.settings[0]
+    );
+  });
+
+  it("renders a loading indicator instead of a form when the data is loading", () => {
+    const wrapper = mount(
+      <SitewideAnnouncements
+        data={data}
+        csrfToken="token"
+        fetchData={fetchData}
+        isFetching={true}
+      />,
+      {
+        context: {
+          admin: {
+            isSystemAdmin: () => true,
+            isLibraryManagerOfSomeLibrary: () => true,
+          },
+        },
+      }
+    );
+
+    const form = wrapper.find("form");
+
+    expect(form.length).to.equal(0);
+
+    const loadingIndicator = wrapper.find(LoadingIndicator);
+
+    expect(loadingIndicator.length).to.equal(1);
+  });
+
+  it("calls editItem when the form is submitted", () => {
+    const editItem = stub().returns(
+      new Promise<void>((resolve) => resolve())
+    );
+
+    const wrapper = mount(
+      <SitewideAnnouncements
+        data={data}
+        csrfToken="token"
+        editItem={editItem}
+        fetchData={fetchData}
+        isFetching={false}
+      />,
+      {
+        context: {
+          admin: {
+            isSystemAdmin: () => true,
+            isLibraryManagerOfSomeLibrary: () => true,
+          },
+        },
+      }
+    );
+
+    const form = wrapper.find("form");
+    const submitButton = form.find('button[type="submit"]');
+
+    submitButton.last().simulate("click");
+
+    expect(editItem.callCount).to.equal(1);
+    expect(editItem.args[0]).to.have.length(1);
+
+    const formData = editItem.args[0][0];
+
+    expect(formData).to.be.an.instanceof(window.FormData);
+    expect(formData.get("announcements")).to.equal(
+      '[{"id":"dcf036d9-106b-426c-838f-ce7c57d53801","content":"There is nothing to see here.","start":"2022-08-31","finish":"2022-10-31"}]'
+    );
+  });
+
+  it("disables the submit button when the user does not have the permission level specified in the settings", () => {
+    const wrapper = mount(
+      <SitewideAnnouncements
+        data={data}
+        csrfToken="token"
+        fetchData={fetchData}
+        isFetching={false}
+      />,
+      {
+        context: {
+          admin: {
+            isSystemAdmin: () => false,
+            isLibraryManagerOfSomeLibrary: () => false,
+          },
+        },
+      }
+    );
+
+    const form = wrapper.find("form");
+    const submitButton = form.find('button[type="submit"]');
+
+    expect(submitButton.last().prop("disabled")).to.equal(true);
+  });
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -456,6 +456,11 @@ export interface AnnouncementData {
   finish: string;
 }
 
+export interface SitewideAnnouncementsData {
+  announcements: AnnouncementData[];
+  settings: SettingData;
+}
+
 export interface AdvancedSearchQuery {
   id?: string;
   key?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -458,7 +458,7 @@ export interface AnnouncementData {
 
 export interface SitewideAnnouncementsData {
   announcements: AnnouncementData[];
-  settings: SettingData;
+  settings: SettingData[];
 }
 
 export interface AdvancedSearchQuery {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -13,6 +13,7 @@ import collections from "./collections";
 import adminAuthServices from "./adminAuthServices";
 import individualAdmins from "./individualAdmins";
 import patronAuthServices from "./patronAuthServices";
+import sitewideAnnouncements from "./sitewideAnnouncements";
 import sitewideSettings from "./sitewideSettings";
 import loggingServices from "./loggingServices";
 import metadataServices from "./metadataServices";
@@ -54,6 +55,7 @@ import {
   AdminAuthServicesData,
   IndividualAdminsData,
   PatronAuthServicesData,
+  SitewideAnnouncementsData,
   SitewideSettingsData,
   LoggingServicesData,
   MetadataServicesData,
@@ -90,6 +92,7 @@ export interface State {
   adminAuthServices: FetchEditState<AdminAuthServicesData>;
   individualAdmins: FetchEditState<IndividualAdminsData>;
   patronAuthServices: FetchEditState<PatronAuthServicesData>;
+  sitewideAnnouncements: FetchEditState<SitewideAnnouncementsData>;
   sitewideSettings: FetchEditState<SitewideSettingsData>;
   loggingServices: FetchEditState<LoggingServicesData>;
   metadataServices: FetchEditState<MetadataServicesData>;
@@ -137,6 +140,7 @@ export default combineReducers<State>({
   adminAuthServices,
   individualAdmins,
   patronAuthServices,
+  sitewideAnnouncements,
   sitewideSettings,
   loggingServices,
   metadataServices,

--- a/src/reducers/sitewideAnnouncements.ts
+++ b/src/reducers/sitewideAnnouncements.ts
@@ -1,0 +1,7 @@
+import { SitewideAnnouncementsData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+
+export default createFetchEditReducer<SitewideAnnouncementsData>(
+  ActionCreator.SITEWIDE_ANNOUNCEMENTS,
+);

--- a/src/stylesheets/announcements.scss
+++ b/src/stylesheets/announcements.scss
@@ -54,6 +54,12 @@
       }
     }
   }
+
+  .announcement-form {
+    border: 1px solid $blue;
+    padding: 16px 16px 6px 16px;
+  }
+
   .form-group.wrong-length p.description {
     color: $red;
   }


### PR DESCRIPTION
## Description

This adds a Sitewide Announcements configuration tab, where system administrators can configure announcements for all libraries on a CM.

For consistency, this uses the same UI components as the Announcements section in the library configuration screen, and it works identically. I'm not a fan of the UX of those components, but I'm not rewriting them in this PR; that can be a future task. I also noticed some weird but non-blocker bugs in those components, but those can also be addressed in future work.

## Motivation and Context

This allows administrators to send announcements to all users on a CM when needed, for example to announce outages.

Notion: https://www.notion.so/lyrasis/Add-to-front-end-Add-ability-for-super-admins-to-send-mass-announcements-to-all-libraries-configure-36d71b64670f42bc9a8a96d7cca2f025

## How Has This Been Tested?

- Log in as a system administrator.
- On the configuration screen, there should be a Sitewide Announcements tab at the bottom of the list.
- Open the tab.
- Add announcements and save using the Submit button at the bottom. Reload the page in the browser. The saved announcements should be retrieved.
- Edit an announcement (the UX is weird for this, it moves the announcement to the editing area at the bottom). Save and reload, and verify that the edited announcement is retrieved.
- Delete an announcement. Save and reload, and verify that the deleted announcement remains gone.
- Log in as a library administrator.
- The Sitewide Announcements tab should not appear on the configuration screen.
- Log in as a library user.
- The Sitewide Announcements tab should not appear on the configuration screen. 

Unit tests are included.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
