### PR TITLE
Fix error loading lists page when there are no owned lists.

### DIFF
--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -164,7 +164,7 @@ export class CustomLists extends React.Component<
   renderSidebar(): JSX.Element {
     return (
       <CustomListsSidebar
-        lists={this.sortedLists()}
+        lists={this.filteredSortedLists()}
         library={this.props.library}
         identifier={this.props.identifier}
         isLibraryManager={this.context.admin.isLibraryManager(
@@ -265,10 +265,12 @@ export class CustomLists extends React.Component<
     const { editOrCreate, fetchError, lists } = nextProps;
 
     if (!editOrCreate && lists && !fetchError) {
-      if (lists.length === 0) {
+      const filteredSortedLists = this.filteredSortedLists(lists);
+
+      if (filteredSortedLists.length === 0) {
         window.location.href += "/create";
       } else {
-        const firstList = this.sortedLists(lists)[0];
+        const firstList = filteredSortedLists[0];
         window.location.href += "/edit/" + firstList.id;
       }
     }
@@ -313,7 +315,7 @@ export class CustomLists extends React.Component<
     return selectedFilter ? lists.filter(selectedFilter) : lists;
   }
 
-  sortedLists(lists?: CustomListData[]) {
+  filteredSortedLists(lists?: CustomListData[]) {
     lists = lists || this.props.lists || [];
 
     return this.filterLists(lists).sort((a, b) => {

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -305,6 +305,48 @@ describe("CustomLists", () => {
       wrapper.setProps({ lists: listsData });
       expect(window.location.href).to.contain("edit");
       expect(window.location.href).to.contain("1");
+
+      // The create page should open if there are no owned lists.
+
+      const noOwnedListsData = [
+        {
+          id: 1,
+          name: "a list",
+          entry_count: 0,
+          collections: [],
+          is_owner: false,
+          is_shared: true,
+        },
+      ];
+
+      wrapper = mount(
+        <CustomLists
+          csrfToken="token"
+          library="library"
+          lists={undefined}
+          searchResults={searchResults}
+          collections={collections}
+          isFetching={false}
+          isFetchingSearchResults={false}
+          isFetchingMoreSearchResults={false}
+          isFetchingMoreCustomListEntries={false}
+          fetchCustomLists={fetchCustomLists}
+          fetchCustomListDetails={fetchCustomListDetails}
+          saveCustomListEditor={saveCustomListEditor}
+          deleteCustomList={deleteCustomList}
+          openCustomListEditor={openCustomListEditor}
+          loadMoreSearchResults={loadMoreSearchResults}
+          loadMoreEntries={loadMoreEntries}
+          fetchCollections={fetchCollections}
+          fetchLibraries={fetchLibraries}
+          fetchLanes={fetchLanes}
+          fetchLanguages={fetchLanguages}
+          languages={languages}
+        />,
+        { context: { admin: libraryManager } }
+      );
+      wrapper.setProps({ lists: noOwnedListsData });
+      expect(window.location.href).to.contain("create");
     });
 
     it("sorts lists", () => {
@@ -699,7 +741,9 @@ describe("CustomLists", () => {
       );
 
       deleteCustomListFn = (wrapper.instance() as CustomLists).deleteCustomList;
-      listDataSort = (wrapper.instance() as CustomLists).sortedLists(listsData);
+      listDataSort = (wrapper.instance() as CustomLists).filteredSortedLists(
+        listsData
+      );
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Description

This fixes a bug in #42. When a library only has lists that it does not own, there is an error opening the Lists screen, and nothing appears.

Currently, when the Lists screen is opened, the first list in the sidebar is automatically opened for editing (or if there are no lists, the form to create a new list is opened). With #42, the lists in the sidebar are by default filtered to show only owned lists, so it's possible for lists to exist, but for none to appear in the sidebar when the Lists screen is first opened. The code that opens the detail view doesn't expect this.

Now, when there are lists, but none are owned, the form to create a new list is opened.

Also, the function that was named `sortedLists` has been changed to `filteredSortedLists` to make it clear that it both filters and sorts lists.

## Motivation and Context

This should have been included in #42, to make it possible to share lists and work with lists shared by other libraries. Notion: https://www.notion.so/lyrasis/Create-interface-for-list-sharing-between-libraries-on-the-same-Palace-Manager-a63f04a22a8043e19b283f0ac5863841

## How Has This Been Tested?

On a CM that includes #42:
1. In a library, create a list and share it.
1. Change to another library that has no lists of its own.
1. Open the Lists screen.
   The Lists sidebar should appear, with "Owned" selected in the "Show" menu. There should be no lists in the sidebar. On the right, the form to create a new list should appear.
1. In the sidebar, select "Subscribed" in the "Show" menu.
   The shared list should appear.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
