### PR TITLE
Clear list entries from state when opening a new list.

### DIFF
--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -1037,4 +1037,36 @@ describe("actions", () => {
       expect(fetchArgs[0][1].body).to.equal(formData);
     });
   });
+
+  describe("openCustomListEditor", () => {
+    it("dispatches CUSTOM_LIST_DETAILS_CLEAR and OPEN_CUSTOM_LIST_EDITOR", async () => {
+      const dispatch = stub();
+
+      const getState = () => ({
+        editor: {
+          customLists: {
+            data: {
+              foo: "bar",
+            },
+          },
+        },
+      });
+
+      await actions.openCustomListEditor("list_id")(dispatch, getState);
+
+      expect(dispatch.callCount).to.equal(2);
+
+      expect(dispatch.args[0][0].type).to.equal(
+        `${ActionCreator.CUSTOM_LIST_DETAILS}_${ActionCreator.CLEAR}`
+      );
+
+      expect(dispatch.args[1][0].type).to.equal(
+        ActionCreator.OPEN_CUSTOM_LIST_EDITOR
+      );
+      expect(dispatch.args[1][0].id).to.equal("list_id");
+      expect(dispatch.args[1][0].data).to.deep.equal(
+        getState().editor.customLists.data
+      );
+    });
+  });
 });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -956,12 +956,15 @@ export default class ActionCreator extends BaseActionCreator {
   }
 
   openCustomListEditor(listId: string) {
-    return (dispatch, getState) =>
-      dispatch({
+    return (dispatch, getState) => {
+      dispatch(this.clear(ActionCreator.CUSTOM_LIST_DETAILS));
+
+      return dispatch({
         type: ActionCreator.OPEN_CUSTOM_LIST_EDITOR,
         id: listId,
         data: getState().editor.customLists.data,
       });
+    };
   }
 
   updateCustomListEditorProperty(name: string, value) {

--- a/src/reducers/__tests__/createFetchEditReducer-test.ts
+++ b/src/reducers/__tests__/createFetchEditReducer-test.ts
@@ -64,6 +64,17 @@ describe("fetch-edit reducer", () => {
     expect(extraActionReducer(undefined, {})).to.deep.equal(initState);
   });
 
+  it("handles clear", () => {
+    const action = { type: "TEST_FETCH_CLEAR" };
+
+    const state = Object.assign({}, initState, {
+      data: testData,
+      isLoaded: true,
+    });
+
+    expect(reducer(state, action)).to.deep.equal(initState);
+  });
+
   it("handles fetch request", () => {
     const action = { type: "TEST_FETCH_REQUEST", url: "test_url" };
 

--- a/src/reducers/createFetchEditReducer.ts
+++ b/src/reducers/createFetchEditReducer.ts
@@ -73,6 +73,9 @@ export default <T>(
           isLoaded: true,
         });
 
+      case `${fetchPrefix}_${ActionCreator.CLEAR}`:
+        return initialState;
+
       default:
         if (extraActions) {
           let manipulateDataFunction;


### PR DESCRIPTION
## Description

The clears the custom list entries from the Redux store when opening a different list or creating a new list.

Specifically, the `openCustomListEditor` action creator now dispatches the `CUSTOM_LIST_DETAILS_CLEAR` action in addition to the `OPEN_CUSTOM_LIST_EDITOR` action, and a handler for `CUSTOM_LIST_DETAILS_CLEAR` has been implemented that restores the initial (empty) state.

## Motivation and Context

When a list is edited, its entries are loaded, and stored in the Redux store. When a different list is opened, or a new list is created, the entries were not being cleared. This didn't cause an evident problem if a different list was opened, because its entries would be loaded immediately, replacing the old entries. But when a new list is created, there are no entries to load, so the continued existence of the entries from the previous list can cause issues.

This manifested as the "Load more" button on the entries list appearing when creating a new list, even though a new list has no entries. The "Load more" button was left over from the previous list being edited.

Notion: https://www.notion.so/lyrasis/Load-More-button-appears-on-list-entries-when-creating-a-new-list-e07458826c3640539ac8dfd0adb959b8

## How Has This Been Tested?

1. Edit a list that has more than 50 entries. The "Load more" button should appear on the entries list.
2. Click the "Create New List" button at the top of the sidebar.
   On the form for the new list, the "Load more" button should not appear on the entries list.
1. Edit some other lists, and verify that the list entries appear correctly, and the the "Load more" button appears when it is supposed to. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
