### PR TITLE
Fix breadcrumb issues when opening book details from the list editor.

### DIFF
--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -123,6 +123,7 @@ export default function CustomListEditor({
   }, [listId, isLoaded]);
 
   const readOnly = !isOwner;
+
   const opdsFeedUrl =
     listId && savedName
       ? `${library?.short_name}/lists/${savedName}/crawlable`

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -40,6 +40,7 @@ type CustomListEditorProps = {
   library: LibraryData;
   listId?: string;
   properties?: CustomListEditorProperties;
+  savedName?: string;
   searchParams?: CustomListEditorSearchParams;
   searchResults?: CollectionData;
   startingTitle?: string;
@@ -89,6 +90,7 @@ export default function CustomListEditor({
   library,
   listId,
   properties,
+  savedName,
   searchParams,
   searchResults,
   startingTitle,
@@ -121,6 +123,10 @@ export default function CustomListEditor({
   }, [listId, isLoaded]);
 
   const readOnly = !isOwner;
+  const opdsFeedUrl =
+    listId && savedName
+      ? `${library?.short_name}/lists/${savedName}/crawlable`
+      : undefined;
 
   return (
     <div className="custom-list-editor">
@@ -281,9 +287,7 @@ export default function CustomListEditor({
           isFetchingSearchResults={isFetchingSearchResults}
           isFetchingMoreSearchResults={isFetchingMoreSearchResults}
           isFetchingMoreCustomListEntries={isFetchingMoreCustomListEntries}
-          opdsFeedUrl={`${library?.short_name}/${
-            name ? `lists/${name}/` : ""
-          }crawlable`}
+          opdsFeedUrl={opdsFeedUrl}
           entryCount={entries.currentTotalCount}
           listId={listId}
           addEntry={addEntry}

--- a/src/components/CustomListEntriesEditor.tsx
+++ b/src/components/CustomListEntriesEditor.tsx
@@ -33,7 +33,7 @@ export interface CustomListEntriesEditorProps {
   refreshResults?: () => void;
 }
 
-const renderCatalogLink = (book, opdsFeedUrl) => {
+const renderCatalogLink = (book, opdsFeedUrl?) => {
   const { title, url } = book;
 
   if (!url) {
@@ -217,7 +217,7 @@ const CustomListEntriesEditor = ({
                             {getMediumSVG(getMedium(book))}
 
                             <div className="links">
-                              {renderCatalogLink(book, opdsFeedUrl)}
+                              {renderCatalogLink(book)}
 
                               {!readOnly && (
                                 <Button

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -32,6 +32,7 @@ import CustomListsSidebar from "./CustomListsSidebar";
 
 export interface CustomListsStateProps {
   customListEditorProperties?: CustomListEditorProperties;
+  customListEditorSavedName?: string;
   customListEditorSearchParams?: CustomListEditorSearchParams;
   customListEditorEntries?: CustomListEditorEntriesData;
   customListEditorIsLoaded?: boolean;
@@ -184,6 +185,7 @@ export class CustomLists extends React.Component<
       collections: this.collectionsForLibrary(),
       isAutoUpdateEnabled: this.props.customListEditorIsAutoUpdateEnabled,
       properties: this.props.customListEditorProperties,
+      savedName: this.props.customListEditorSavedName,
       searchParams: this.props.customListEditorSearchParams,
       isLoaded: this.props.customListEditorIsLoaded,
       isValid: this.props.customListEditorIsValid,
@@ -434,6 +436,8 @@ function mapStateToProps(state, ownProps) {
   return {
     customListEditorProperties:
       state.editor.customListEditor.properties.current,
+    customListEditorSavedName:
+      state.editor.customListEditor.properties.baseline.name,
     customListEditorSearchParams:
       state.editor.customListEditor.searchParams.current,
     customListEditorEntries: state.editor.customListEditor.entries,

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -247,6 +247,26 @@ describe("CustomListEditor", () => {
     expect(entriesEditor.props().opdsFeedUrl).to.equal(undefined);
   });
 
+  it("sets the feed url in the entries editor to undefined when the saved list name is falsy", () => {
+    wrapper.setProps({
+      savedName: "",
+    });
+
+    let entriesEditor;
+
+    entriesEditor = wrapper.find(CustomListEntriesEditor);
+
+    expect(entriesEditor.props().opdsFeedUrl).to.equal(undefined);
+
+    wrapper.setProps({
+      savedName: null,
+    });
+
+    entriesEditor = wrapper.find(CustomListEntriesEditor);
+
+    expect(entriesEditor.props().opdsFeedUrl).to.equal(undefined);
+  });
+
   it("shows collections", () => {
     const collectionsPanel = wrapper.find("#add-from-collections-panel");
     const inputs = collectionsPanel.find(EditableInput);

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -224,6 +224,29 @@ describe("CustomListEditor", () => {
     );
   });
 
+  it("sets the feed url in the entries editor to the url for the saved list name", () => {
+    wrapper.setProps({
+      savedName: "Books to Read Today",
+    });
+
+    const entriesEditor = wrapper.find(CustomListEntriesEditor);
+
+    expect(entriesEditor.props().opdsFeedUrl).to.equal(
+      "library/lists/Books to Read Today/crawlable"
+    );
+  });
+
+  it("sets the feed url in the entries editor to undefined when the list is new", () => {
+    wrapper.setProps({
+      listId: null, // new, unsaved lists have null listId
+      savedName: "Books to Read Today",
+    });
+
+    const entriesEditor = wrapper.find(CustomListEntriesEditor);
+
+    expect(entriesEditor.props().opdsFeedUrl).to.equal(undefined);
+  });
+
   it("shows collections", () => {
     const collectionsPanel = wrapper.find("#add-from-collections-panel");
     const inputs = collectionsPanel.find(EditableInput);

--- a/src/components/__tests__/CustomListEntriesEditor-test.tsx
+++ b/src/components/__tests__/CustomListEntriesEditor-test.tsx
@@ -304,6 +304,37 @@ describe("CustomListEntriesEditor", () => {
     );
   });
 
+  it("does not include the opds feed url in links to view search results", () => {
+    const wrapper = mount(
+      <CustomListEntriesEditor
+        entries={entriesData}
+        isOwner={true}
+        opdsFeedUrl="opdsFeedUrl"
+        searchResults={searchResultsData}
+        loadMoreSearchResults={loadMoreSearchResults}
+        loadMoreEntries={loadMoreEntries}
+        isFetchingSearchResults={false}
+        isFetchingMoreSearchResults={false}
+        isFetchingMoreCustomListEntries={false}
+      />,
+      { context: fullContext, childContextTypes }
+    );
+
+    const results = wrapper.find(".custom-list-search-results Draggable");
+
+    expect(results.at(0).find("CatalogLink").prop("collectionUrl")).to.equal(
+      undefined
+    );
+
+    expect(results.at(1).find("CatalogLink").prop("collectionUrl")).to.equal(
+      undefined
+    );
+
+    expect(results.at(2).find("CatalogLink").prop("collectionUrl")).to.equal(
+      undefined
+    );
+  });
+
   it("renders an SVG icon for each search result", () => {
     const wrapper = mount(
       <CustomListEntriesEditor
@@ -452,6 +483,33 @@ describe("CustomListEntriesEditor", () => {
     expect(entries.at(1).find("CatalogLink").text()).to.equal("View details");
     expect(entries.at(1).find("CatalogLink").prop("bookUrl")).to.equal(
       "/some/urlB"
+    );
+  });
+
+  it("includes the opds feed url in links to view entries", () => {
+    const wrapper = mount(
+      <CustomListEntriesEditor
+        entries={entriesData}
+        isOwner={true}
+        loadMoreSearchResults={loadMoreSearchResults}
+        loadMoreEntries={loadMoreEntries}
+        isFetchingSearchResults={false}
+        isFetchingMoreSearchResults={false}
+        isFetchingMoreCustomListEntries={false}
+        opdsFeedUrl="opdsFeedUrl"
+        entryCount={2}
+      />,
+      { context: fullContext, childContextTypes }
+    );
+
+    const entries = wrapper.find(".custom-list-entries Draggable");
+
+    expect(entries.at(0).find("CatalogLink").prop("collectionUrl")).to.equal(
+      "opdsFeedUrl"
+    );
+
+    expect(entries.at(1).find("CatalogLink").prop("collectionUrl")).to.equal(
+      "opdsFeedUrl"
     );
   });
 


### PR DESCRIPTION
## Description

This makes a few changes to the breadcrumb trail that is displayed on the book detail page when it is opened from the list editor:
![cerberus tpp-qa lyrasistechnology org_admin_web_collection_cerberus-test-1%2Flists%2FPalace%20Marketplace%2Fcrawlable_book_cerberus-test-1%2FISBN%2F9788726607031](https://user-images.githubusercontent.com/1395885/192832607-97a038ea-2411-4a2c-83d2-e2042ed9576b.png)

- When the book detail page is opened from the list editor while creating a new list, don't show breadcrumbs. Since the new list hasn’t been saved, there is nowhere for the breadcrumb to go.
- When the book detail page is opened from the list editor while editing an existing list, use the saved list name to build the breadcrumb trail, not the current unsaved name. The current name may have been changed, and therefore would not be known to the CM yet.
- While editing an existing list, when the View Details button is clicked from a search result (as opposed to a list entry), don’t show a breadcrumb trail on the book detail page. Showing the list name in the breadcrumb trail implies that the book is in the list, but search results aren’t necessarily in the list.

## Motivation and Context

This fixes an error opening the book detail page from the list editor while creating a new list, before the list has been saved. I found the other related issues while investigating that error.

Notion: https://www.notion.so/lyrasis/Error-appears-when-viewing-a-title-before-a-list-has-been-saved-2b75711414874784af874a8235f59a0c

## How Has This Been Tested?

1. Create a new list. Before saving it, perform a search, and click the View Details button on one of the results.
   The book detail page should open in a new tab, without an error. There should be no breadcrumb trail on the page.
1. Add one or more entries to the list. Click the View Details button on one of the entries.
   The book detail page should open in a new tab, without an error. There should be no breadcrumb trail on the page.
1. Save the list.
2. Click the View Details button on one of the entries.
   The book detail page should open in a new tab, without an error. The name of the list should appear in the breadcrumb trail.
1. Perform a search, and click the View Details button on one of the results.
   The book detail page should open in a new tab, without an error. There should be no breadcrumb trail on the page.
1. Change the name of the list, but don't save it.
2. Click the View Details button on one of the entries.
   The book detail page should open in a new tab, without an error. The saved name of the list (not the unsaved changed name) should appear in the breadcrumb trail.
1. Save the list.
2. Click the View Details button on one of the entries.
   The book detail page should open in a new tab, without an error. The new name of the list should appear in the breadcrumb trail.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
