### PR TITLE
Fix incorrect modified state in custom list editor following save.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.1
+
+#### Fixed
+
+- After an auto updating list is saved, the list status is now correctly updated, and the Save button is now correctly disabled.
+
 ### v0.4.0
 
 #### Updated

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -393,6 +393,23 @@ describe("custom list editor reducer", () => {
       expect(nextState).to.equal(state);
     });
 
+    it("sets isSearchModified and isModified to false", () => {
+      const state = {
+        ...initialState,
+        id: 42,
+        isSearchModified: true,
+        isModified: true,
+      };
+
+      const nextState = reducer(state, {
+        type: `${ActionCreator.CUSTOM_LISTS}_${ActionCreator.LOAD}`,
+        data: listData,
+      });
+
+      expect(nextState.isSearchModified).to.equal(false);
+      expect(nextState.isModified).to.equal(false);
+    });
+
     context("when auto update is enabled", () => {
       it("defaults the autoUpdate property to true for a new list", () => {
         const state = {

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -875,6 +875,8 @@ const initialStateForList = (
         draftState.searchParams.baseline.sort = order;
         draftState.searchParams.current.sort = order;
       }
+
+      draftState.isSearchModified = false;
     }
 
     draftState.error = error;
@@ -955,23 +957,22 @@ const handleCustomListEditorOpen = (
  *                       to the id of a list that is present in the data.
  * @returns      The next state
  */
-const handleCustomListsLoad = (
-  state: CustomListEditorState,
-  action
-): CustomListEditorState => {
-  if (action.isAfterShare) {
-    // If this is a reload of custom list data following a share operation, we can ignore the
-    // action. The sharing state will be updated by the handler for the CUSTOM_LIST_SHARE_SUCCESS
-    // action.
+const handleCustomListsLoad = validatedHandler(
+  (state: CustomListEditorState, action): CustomListEditorState => {
+    if (action.isAfterShare) {
+      // If this is a reload of custom list data following a share operation, we can ignore the
+      // action. The sharing state will be updated by the handler for the CUSTOM_LIST_SHARE_SUCCESS
+      // action.
 
-    return state;
+      return state;
+    }
+
+    const { id } = state;
+    const { data } = action;
+
+    return initialStateForList(id, data, state);
   }
-
-  const { id } = state;
-  const { data } = action;
-
-  return initialStateForList(id, data, state);
-};
+);
 
 /**
  * Handle the CUSTOM_LIST_DETAILS_LOAD action. This action is fired when a call to the


### PR DESCRIPTION
## Description

This sets the `isModified` and `isSearchModified` properties in the custom list editor state correctly when the `CUSTOM_LISTS_LOAD` action is fired, following the reload of a custom list after it has been saved. Since the list has just been saved, `isModified` and `isSearchModified` should become false, but these properties were not being updated.

## Motivation and Context

Because of this, the list status was not changing after save, and the Save button was remaining enabled. Notion: https://www.notion.so/lyrasis/Auto-updating-list-status-is-not-updated-after-save-d5ea52ff27ff463085642df0ce5d6263

## How Has This Been Tested?

1. Create a new list.
2. Add a search filter.
    In the List Entries box, the Status should be “New”.
3. Save the list.
    In the List Entries box, the Status should be “Initializing”.
    The Save button at the top of the page should be disabled.
4. Add another search filter.
    In the List Entries box, the Status should be “Search criteria modified”.
5. Save the list.

In the List Entries box, the Status should be “Repopulating”.
The Save button at the top of the page should be disabled.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
