### PR TITLE
Remove borrow button from catalog list view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.4.2
+
+#### Updated
+
+- The circulation buttons (e.g. Borrow, Read) have been removed from the catalog list view.
+
 ### v0.4.1
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@nypl/dgx-svg-icons": "0.3.4",
-        "@thepalaceproject/web-opds-client": "0.6.4",
+        "@thepalaceproject/web-opds-client": "^1.0.0",
         "bootstrap": "^3.3.6",
         "classnames": "^2.3.1",
         "draft-convert": "^2.1.5",
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@thepalaceproject/web-opds-client": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-0.6.4.tgz",
-      "integrity": "sha512-/emijV+zPqJKJ2gDlkTuGmVcIMMlDk1fGZrFNIK56EfNSOzcrOMYhr/D1VWp3Uect9zT3DMurtHp5SKBb7REcA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-1.0.0.tgz",
+      "integrity": "sha512-TwDo5emrMTWAZ+gk/sEU8bp8p7KPUbsT2eb7O5B+2d+dfiZ+zHu9COME9/Ddqt3Hmc09AQ61VFFNhT+zgqR7jw==",
       "dependencies": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "2.2.8",
@@ -16460,9 +16460,9 @@
       }
     },
     "@thepalaceproject/web-opds-client": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-0.6.4.tgz",
-      "integrity": "sha512-/emijV+zPqJKJ2gDlkTuGmVcIMMlDk1fGZrFNIK56EfNSOzcrOMYhr/D1VWp3Uect9zT3DMurtHp5SKBb7REcA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-1.0.0.tgz",
+      "integrity": "sha512-TwDo5emrMTWAZ+gk/sEU8bp8p7KPUbsT2eb7O5B+2d+dfiZ+zHu9COME9/Ddqt3Hmc09AQ61VFFNhT+zgqR7jw==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "dompurify": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@nypl/dgx-svg-icons": "0.3.4",
-    "@thepalaceproject/web-opds-client": "0.6.4",
+    "@thepalaceproject/web-opds-client": "^1.0.0",
     "bootstrap": "^3.3.6",
     "classnames": "^2.3.1",
     "draft-convert": "^2.1.5",

--- a/src/components/EntryPointsContainer.tsx
+++ b/src/components/EntryPointsContainer.tsx
@@ -39,6 +39,7 @@ export default class EntryPointsContainer extends React.Component<
 
     collectionCopy.facetGroups = facetGroups;
     newProps.collection = collectionCopy;
+    newProps.showCirculationLinks = false;
     const collection = React.createElement(Collection, newProps);
 
     return (


### PR DESCRIPTION
## Description

This removes the Borrow button from the catalog list view. It upgrades opds-web-catalog to 1.0.0, which allows us to show or hide the circulation links by setting a prop.

Before:
<img width="1567" alt="Screen Shot 2022-11-18 at 10 45 58 AM" src="https://user-images.githubusercontent.com/1395885/202746412-d8ec59c4-04d8-411c-b02e-f07fb7ac70cd.png">

After:
<img width="1567" alt="Screen Shot 2022-11-18 at 10 46 28 AM" src="https://user-images.githubusercontent.com/1395885/202746435-c55d6c5d-3ab5-473e-8bdf-9baa18a50a59.png">

## Motivation and Context

The circulation functions are complicated to support in the admin UI, and there is no built-in reader, so we are removing them.

Notion: https://www.notion.so/lyrasis/Hide-Borrow-button-when-viewing-titles-in-list-view-after-opening-a-lane-in-the-Collection-Manager-b00a7e7bac244b57a6abf2a737f42510

## How Has This Been Tested?

In the catalog, click on a lane, and click the list view button at the top. No Borrow buttons should appear in the list, as in the above screenshot. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
