### PR TITLE
Add help text to publication date search field.

### DIFF
--- a/src/components/AdvancedSearchBuilder.tsx
+++ b/src/components/AdvancedSearchBuilder.tsx
@@ -20,7 +20,12 @@ export interface AdvancedSearchBuilderProps {
 export const fields = [
   { value: "data_source", label: "distributor" },
   { value: "publisher", label: "publisher" },
-  { value: "published", label: "publication date" },
+  {
+    value: "published",
+    label: "publication date",
+    helpText: "Publication dates must be entered in the format YYYY-MM-DD.",
+    placeholder: "YYYY-MM-DD",
+  },
   { value: "genre", label: "genre" },
   { value: "language", label: "language" },
   { value: "classification", label: "subject" },

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -73,6 +73,7 @@ export default function AdvancedSearchFilterInput({
       </div>
       <div className="filter-op-value-inputs">
         <EditableInput
+          aria-label="filter operator"
           elementType="select"
           onBlur={handleOpChange}
           onChange={handleOpChange}
@@ -91,6 +92,7 @@ export default function AdvancedSearchFilterInput({
         </EditableInput>
 
         <EditableInput
+          aria-label="filter value"
           description={selectedField.helpText}
           elementType="input"
           type="text"

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -53,6 +53,8 @@ export default function AdvancedSearchFilterInput({
     addFilter();
   };
 
+  const selectedField = fields.find((field) => field.value === filterKey);
+
   return (
     <form className="advanced-search-filter-input">
       Add filter on:
@@ -89,9 +91,11 @@ export default function AdvancedSearchFilterInput({
         </EditableInput>
 
         <EditableInput
+          description={selectedField.helpText}
           elementType="input"
           type="text"
           optionalText={false}
+          placeholder={selectedField.placeholder}
           ref={valueInput}
           value={filterValue}
           onChange={handleValueChange}

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -113,6 +113,7 @@ export default class EditableInput extends React.Component<
       minLength,
       maxLength,
     } = this.props;
+
     return React.createElement(
       elementType || "input",
       {

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 
+let idCounter = 0;
+
+function generateId(): string {
+  return `editableInput-${idCounter++}`;
+}
+
 export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   elementType?: string;
   label?: string;
@@ -67,7 +73,9 @@ export default class EditableInput extends React.Component<
         ? "(Optional) "
         : "";
     const descriptionText = description ? description : "";
-    const descriptionStr = `${optionalTextStr}${descriptionText}`;
+    const descriptionStr = `${optionalTextStr}${descriptionText}`.trim();
+    const descriptionId = descriptionStr && generateId();
+
     const errorClass =
       clientError ||
       (error && error.status >= 400 && !this.state.value && required)
@@ -87,15 +95,16 @@ export default class EditableInput extends React.Component<
         {(extraContent || !label) && (
           <div className={extraContent ? "with-add-on" : ""}>
             {extraContent}
-            {!label && this.renderElement()}
+            {!label && this.renderElement(descriptionId)}
           </div>
         )}
-        {descriptionStr.trim() && this.renderDescription(descriptionStr)}
+        {descriptionStr &&
+          this.renderDescription(descriptionId, descriptionStr)}
       </div>
     );
   }
 
-  renderElement() {
+  renderElement(descriptionId?: string) {
     const {
       type,
       elementType,
@@ -138,14 +147,16 @@ export default class EditableInput extends React.Component<
         minLength,
         maxLength,
         ["aria-label"]: this.props["aria-label"],
+        ["aria-describedby"]: descriptionId,
       },
       children
     );
   }
 
-  renderDescription(description: string) {
+  renderDescription(id: string, description: string) {
     return (
       <p
+        id={id}
         className="description"
         dangerouslySetInnerHTML={{ __html: description }}
       />

--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 
-let idCounter = 0;
+let descriptonIdCounter = 0;
 
-function generateId(): string {
-  return `editableInput-${idCounter++}`;
+function generateDescriptionId(): string {
+  return `editableInputDescription-${descriptonIdCounter++}`;
 }
 
 export interface EditableInputProps extends React.HTMLProps<EditableInput> {
@@ -74,7 +74,7 @@ export default class EditableInput extends React.Component<
         : "";
     const descriptionText = description ? description : "";
     const descriptionStr = `${optionalTextStr}${descriptionText}`.trim();
-    const descriptionId = descriptionStr && generateId();
+    const descriptionId = descriptionStr && generateDescriptionId();
 
     const errorClass =
       clientError ||
@@ -87,7 +87,7 @@ export default class EditableInput extends React.Component<
           <label className="control-label">
             {type !== "checkbox" && type !== "radio" && label}
             {required && <span className="required-field">Required</span>}
-            {this.renderElement()}
+            {this.renderElement(descriptionId)}
             {type === "checkbox" && label}
             {type === "radio" && <span>{label}</span>}
           </label>

--- a/src/stylesheets/colors.scss
+++ b/src/stylesheets/colors.scss
@@ -8,6 +8,7 @@ $red-error: tint($red, 80%);
 $red-tint: tint($red, 30%);
 $light-gray: #D7D4D0;
 $medium-gray: #DDD;
+$medium-dark-gray: #AAA;
 $dark-gray: #080807;
 $gray-tint: #F5F5F4;
 $gray-border: #CCCCCC;

--- a/src/stylesheets/global.scss
+++ b/src/stylesheets/global.scss
@@ -37,6 +37,12 @@
   padding: 0 6px;
 }
 
+.palace .form-control {
+  &::placeholder {
+    color: $medium-dark-gray;
+  }
+}
+
 .btn:not(.inverted), .btn.btn-default {
   background: $blue-dark;
   color: $white;

--- a/tests/jest/components/AdvancedSearchBuilder.test.tsx
+++ b/tests/jest/components/AdvancedSearchBuilder.test.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AdvancedSearchBuilder from "../../../src/components/AdvancedSearchBuilder";
+
+describe("AdvancedSearchBuilder", () => {
+  it("renders a placeholder and help text when the publication date filter is selected", async () => {
+    const user = userEvent.setup();
+
+    const query = {
+      id: "0",
+      key: "genre",
+      value: "Horror",
+    };
+
+    render(
+      <AdvancedSearchBuilder
+        isOwner={true}
+        name="search"
+        query={query}
+        selectedQueryId="0"
+      />
+    );
+
+    const publicationDateRadio = screen.getByRole("radio", {
+      name: "publication date",
+    });
+
+    await user.click(publicationDateRadio);
+
+    const filterValueField = screen.getByRole("textbox", {
+      name: "filter value",
+    });
+
+    expect(filterValueField).toHaveAttribute("placeholder", "YYYY-MM-DD");
+    expect(filterValueField).toHaveAccessibleDescription(/publication date/i);
+    expect(filterValueField).toHaveAccessibleDescription(/YYYY-MM-DD/i);
+  });
+});

--- a/tests/jest/components/EditableInput.test.tsx
+++ b/tests/jest/components/EditableInput.test.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import EditableInput from "../../../src/components/EditableInput";
+
+describe("EditableInput", () => {
+  it("renders an accessible description if a description prop is supplied and a label prop is supplied", () => {
+    const label = "input1";
+    const description = "this is a field";
+
+    render(
+      <EditableInput
+        label={label}
+        optionalText={false}
+        description={description}
+      />
+    );
+
+    const textbox = screen.getByRole("textbox", { name: label });
+
+    expect(textbox).toHaveAccessibleDescription(description);
+  });
+
+  it("renders an accessible description if a description prop is supplied and a label prop is not supplied", () => {
+    const description = "this is a field";
+
+    render(<EditableInput optionalText={false} description={description} />);
+
+    const textbox = screen.getByRole("textbox");
+
+    expect(textbox).toHaveAccessibleDescription(description);
+  });
+
+  it("renders an accessible description if optionalText is true", () => {
+    render(<EditableInput optionalText={true} />);
+
+    const textbox = screen.getByRole("textbox");
+
+    expect(textbox).toHaveAccessibleDescription(/optional/i);
+  });
+
+  it("associates accessible descriptions with the correct inputs when multiple instances are present", () => {
+    const descriptions = ["desc 1", "desc 2", "desc 3"];
+
+    render(
+      <div>
+        <EditableInput optionalText={false} description={descriptions[0]} />
+        <EditableInput optionalText={false} />
+        <EditableInput optionalText={false} />
+        <EditableInput optionalText={false} description={descriptions[1]} />
+        <EditableInput optionalText={false} description={descriptions[2]} />
+        <EditableInput optionalText={false} />
+      </div>
+    );
+
+    const textboxes = screen.getAllByRole("textbox");
+
+    expect(textboxes[0]).toHaveAccessibleDescription(descriptions[0]);
+    expect(textboxes[1]).toHaveAccessibleDescription("");
+    expect(textboxes[2]).toHaveAccessibleDescription("");
+    expect(textboxes[3]).toHaveAccessibleDescription(descriptions[1]);
+    expect(textboxes[4]).toHaveAccessibleDescription(descriptions[2]);
+    expect(textboxes[5]).toHaveAccessibleDescription("");
+  });
+});


### PR DESCRIPTION
## Description

This adds a placeholder and help text to the advanced search form when the publication date field is selected. More generally, it allows a placeholder and help text to be associated with any advanced search field. It also changes the color of placeholder text to gray (instead of black) throughout the app. Finally, it improves accessibility by assigning aria labels to a couple of fields that did not have labels, and associating descriptions with input fields in an accessible way.

![localhost_8080_admin_web_lists_cerberus-test-1_edit_30 (1)](https://user-images.githubusercontent.com/1395885/213830502-67f04e0d-591f-42d4-815f-5651739d831e.png)

## Motivation and Context

Publication dates must be entered in a specific format for search, but there was no indication of this to users.

Notion: https://www.notion.so/lyrasis/Add-descriptive-text-for-publication-date-format-in-list-search-7f3c6854b9254008a4bef70672ca001a#382051252fc24ec6a7b89cdb3cc28337

## How Has This Been Tested?

- Edit a list
- In the "Search for titles" form, click the publication date field. The "YYYY-MMM-DD" placeholder should appear in the value input field. Below the field, the text "Publication dates must be entered in the format YYYY-MM-DD" should appear.
- Click any other field. The placeholder and help text should disappear.

Unit tests are included.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
