### PR TITLE
Prevent duplicate variable declaration error.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,10 @@
     "outDir": "lib",
     "lib": ["es2019", "dom"],
     "rootDir": ".",
+    // Mocha and jest are both used in this project. Certain globals are declared by both,
+    // such as describe, it, and test. Setting skipLibCheck to true prevents typescript from
+    // erroring when it sees duplicate variable declarations with different types.
+    "skipLibCheck": true,
     "types": ["mocha", "node", "jest", "@testing-library/jest-dom"],
     "jsx": "react"
   },


### PR DESCRIPTION
## Description

This fixes a TypeScript compilation error that occurs because we now have both Mocha and Jest in the project. Both projects declare certain global variables with the same names, such as `describe`, `it`, and `test`, but different types. The fix configures TypeScript not to check every type definition file in `node_modules/@types`. Instead, it only checks the types that are imported by our source files. See https://www.typescriptlang.org/tsconfig#skipLibCheck.

## Motivation and Context

Since we added Jest tests, the `npm run build-docs` script produces errors like:

```
node_modules/@types/mocha/index.d.ts:2733:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'test' must be of type 'It', but here has type 'TestFunction'.

2733 declare var test: Mocha.TestFunction;
                 ~~~~

  node_modules/@types/jest/index.d.ts:43:13
    43 declare var test: jest.It;
                   ~~~~
    'test' was also declared here.

```

## How Has This Been Tested?

The `npm run build-docs` should run without error. All other npm scripts should also contuinue to run without error.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
