### PR TITLE
Clear role checkboxes after saving a new user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### v0.5.0
+
+#### Updated
+
+- A placeholder and help text are now displayed when the Publication Date field is selected in advanced search.
+
+#### Fixed
+
+- The role checkboxes are now cleared after saving a user.
+
 ### v0.4.2
 
 #### Updated

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -8,7 +8,7 @@ import Admin from "../models/Admin";
 import PathForProvider from "@thepalaceproject/web-opds-client/lib/components/context/PathForContext";
 import ActionCreator from "../actions";
 
-export interface ContextProviderProps extends React.Props<{}> {
+export interface ContextProviderProps extends React.Props<ContextProvider> {
   csrfToken: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
@@ -23,8 +23,7 @@ export interface ContextProviderProps extends React.Props<{}> {
 /** Provides a redux store, configuration options, and a function to create URLs
     as context to admin interface pages. */
 export default class ContextProvider extends React.Component<
-  ContextProviderProps,
-  {}
+  ContextProviderProps
 > {
   store: Store<State>;
   admin: Admin;
@@ -76,7 +75,7 @@ export default class ContextProvider extends React.Component<
     }
   }
 
-  static childContextTypes: React.ValidationMap<{}> = {
+  static childContextTypes: React.ValidationMap<object> = {
     editorStore: PropTypes.object.isRequired,
     csrfToken: PropTypes.string.isRequired,
     showCircEventsDownload: PropTypes.bool.isRequired,

--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -44,8 +44,8 @@ export default class IndividualAdminEditForm extends React.Component<
   private systemRef = React.createRef<EditableInput>();
   private managerAllRef = React.createRef<EditableInput>();
   private librarianAllRef = React.createRef<EditableInput>();
-  private libraryManagerRef = React.createRef<EditableInput>();
-  private librarianRef = React.createRef<EditableInput>();
+  private libraryManagerRefs = {};
+  private librarianRefs = {};
 
   constructor(props) {
     super(props);
@@ -71,9 +71,10 @@ export default class IndividualAdminEditForm extends React.Component<
         this.systemRef,
         this.managerAllRef,
         this.librarianAllRef,
-        this.libraryManagerRef,
-        this.librarianRef,
       ].forEach((ref) => clearForm(ref));
+
+      clearForm(this.librarianRefs);
+      clearForm(this.libraryManagerRefs);
     }
   }
 
@@ -197,7 +198,11 @@ export default class IndividualAdminEditForm extends React.Component<
                       type="checkbox"
                       disabled={this.isDisabled("manager", library.short_name)}
                       name={"manager-" + library.short_name}
-                      ref={this.libraryManagerRef}
+                      ref={(componentInstance) => {
+                        this.libraryManagerRefs[
+                          library.short_name
+                        ] = componentInstance;
+                      }}
                       label=""
                       aria-label={`Administrator of ${library.short_name}`}
                       checked={this.isSelected("manager", library.short_name)}
@@ -215,7 +220,11 @@ export default class IndividualAdminEditForm extends React.Component<
                         library.short_name
                       )}
                       name={"librarian-" + library.short_name}
-                      ref={this.librarianRef}
+                      ref={(componentInstance) => {
+                        this.librarianRefs[
+                          library.short_name
+                        ] = componentInstance;
+                      }}
                       label=""
                       aria-label={`User of ${library.short_name}`}
                       checked={this.isSelected("librarian", library.short_name)}

--- a/tests/jest/components/IndividualAdminEditForm.test.tsx
+++ b/tests/jest/components/IndividualAdminEditForm.test.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import IndividualAdminEditForm from "../../../src/components/IndividualAdminEditForm";
+import renderWithContext from "../testUtils/renderWithContext";
+
+describe("IndividualAdminEditForm", () => {
+  it("clears the role checkboxes after save", async () => {
+    const user = userEvent.setup();
+
+    const contextProviderProps = {
+      csrfToken: "",
+      roles: [
+        {
+          role: "system",
+        },
+      ],
+    };
+
+    const props = {
+      data: {
+        allLibraries: [
+          {
+            name: "Alpha",
+            short_name: "alpha",
+            uuid: "a3247ce9-9639-426b-bb09-82e9cb4cf44b",
+          },
+          {
+            name: "Beta",
+            short_name: "beta",
+            uuid: "da80cd40-7a87-41db-a789-5f1e87732aeb",
+          },
+          {
+            name: "Gamma",
+            short_name: "gamma",
+            uuid: "15f32675-73f5-46f3-91f4-837b933bc7b1",
+          },
+        ],
+      },
+      disabled: false,
+      listDataKey: "",
+      urlBase: "",
+    };
+
+    const { rerender } = renderWithContext(
+      <IndividualAdminEditForm {...props} />,
+      contextProviderProps
+    );
+
+    const systemAdminCheckbox = screen.getByRole("checkbox", {
+      name: /^system admin$/i,
+    });
+
+    const allAdminCheckbox = screen.getByRole("checkbox", {
+      name: /^administrator$/i,
+    });
+
+    const allUserCheckbox = screen.getByRole("checkbox", {
+      name: /^user$/i,
+    });
+
+    const alphaAdminCheckbox = screen.getByRole("checkbox", {
+      name: /administrator of alpha/i,
+    });
+
+    const alphaUserCheckbox = screen.getByRole("checkbox", {
+      name: /user of alpha/i,
+    });
+
+    const betaAdminCheckbox = screen.getByRole("checkbox", {
+      name: /administrator of beta/i,
+    });
+
+    const betaUserCheckbox = screen.getByRole("checkbox", {
+      name: /user of beta/i,
+    });
+
+    const gammaAdminCheckbox = screen.getByRole("checkbox", {
+      name: /administrator of gamma/i,
+    });
+
+    const gammaUserCheckbox = screen.getByRole("checkbox", {
+      name: /user of gamma/i,
+    });
+
+    expect(systemAdminCheckbox).not.toBeChecked();
+
+    await user.click(systemAdminCheckbox);
+
+    expect(systemAdminCheckbox).toBeChecked();
+
+    expect(allAdminCheckbox).toBeChecked();
+    expect(allUserCheckbox).toBeChecked();
+
+    expect(alphaAdminCheckbox).toBeChecked();
+    expect(alphaUserCheckbox).toBeChecked();
+
+    expect(betaAdminCheckbox).toBeChecked();
+    expect(betaUserCheckbox).toBeChecked();
+
+    expect(gammaAdminCheckbox).toBeChecked();
+    expect(gammaUserCheckbox).toBeChecked();
+
+    const nextProps = {
+      ...props,
+      // Existence of the responseBody prop indicates that the form was just saved.
+      responseBody: "some response",
+    };
+
+    rerender(<IndividualAdminEditForm {...nextProps} />);
+
+    expect(systemAdminCheckbox).not.toBeChecked();
+
+    expect(allAdminCheckbox).not.toBeChecked();
+    expect(allUserCheckbox).not.toBeChecked();
+
+    expect(alphaAdminCheckbox).not.toBeChecked();
+    expect(alphaUserCheckbox).not.toBeChecked();
+
+    expect(betaAdminCheckbox).not.toBeChecked();
+    expect(betaUserCheckbox).not.toBeChecked();
+
+    expect(gammaAdminCheckbox).not.toBeChecked();
+    expect(gammaUserCheckbox).not.toBeChecked();
+  });
+});

--- a/tests/jest/testUtils/renderWithContext.tsx
+++ b/tests/jest/testUtils/renderWithContext.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { render, RenderOptions, RenderResult } from "@testing-library/react";
+import ContextProvider, {
+  ContextProviderProps,
+} from "../../../src/components/ContextProvider";
+
+/**
+ * Renders a given React element, wrapped in a ContextProvider. The resulting rerender function is
+ * also wrapped, so that rerenders will have the identical context.
+ *
+ * @param ui                   The element to render
+ * @param contextProviderProps Props to pass to the ContextProvider wrapper
+ * @param renderOptions        Options to pass through to the RTL render function
+ * @returns
+ */
+export default function renderWithContext(
+  ui: React.ReactElement,
+  contextProviderProps: ContextProviderProps,
+  renderOptions?: Omit<RenderOptions, "queries">
+): RenderResult {
+  const renderResult = render(
+    <ContextProvider {...contextProviderProps}>{ui}</ContextProvider>,
+    renderOptions
+  );
+
+  const rerenderWithContext = (ui) => {
+    return renderResult.rerender(
+      <ContextProvider {...contextProviderProps}>{ui}</ContextProvider>
+    );
+  };
+
+  return {
+    ...renderResult,
+    rerender: rerenderWithContext,
+  };
+}


### PR DESCRIPTION
## Description

This fixes a bug where role checkboxes remained checked after saving a new user in the Admins tab. The code stores references to the checkbox components on the form, and clears them after save, but this only worked if there was a single library. If there is more than one library, the code only kept references to the checkboxes for the last library in the list, so only those checkboxes were cleared. The fix stores references to the checkboxes for all libraries, so they can all be cleared.

(The whole notion of storing references to the checkboxes and imperatively calling clear() on them is pretty cringey, but I'm not doing a big refactor now.)

In order to simplify writing a test for the fix, a new test utility function has been added that automatically wraps some JSX in a `ContextProvider` component, so that the component under test can be rendered (and re-rendered) with the appropriate context.

Finally, some typing tweaks were made to the `ContextProvider` component to resolve typing and linter errors.

## Motivation and Context

When creating multiple users, the previously created user's roles were retained for the next user, which made it easy to accidentally assign incorrect roles.

Notion: https://www.notion.so/lyrasis/Admin-Roles-check-boxes-do-not-automatically-reset-after-page-reload-on-CM-4a12a18e7a914eaebfb25756234a3d7a

## How Has This Been Tested?

- On the System Configuration/Admins tab, click the "Create new individual admin" button.
- Enter an email, and select some roles using the checkboxes under "Admin Roles".
- Click the Submit button.
   Expect: All of the role checkboxes are unchecked following the save.
- Repeat for various combinations of roles.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
