### PR TITLE
Mark password field as required

### DIFF
--- a/src/components/IndividualAdminEditForm.tsx
+++ b/src/components/IndividualAdminEditForm.tsx
@@ -134,7 +134,7 @@ export default class IndividualAdminEditForm extends React.Component<
             name="password"
             label="Password"
             ref={this.passwordRef}
-            required={this.context.settingUp}
+            required={true}
             error={this.props.error}
           />
         )}

--- a/src/components/__tests__/IndividualAdminEditForm-test.tsx
+++ b/src/components/__tests__/IndividualAdminEditForm-test.tsx
@@ -396,14 +396,8 @@ describe("IndividualAdminEditForm", () => {
     });
 
     it("requires the correct fields", () => {
-      // Usually, only the email field is required.
-      let required = wrapper.find(".required-field");
-      expect(required.length).to.equal(1);
-      expect(wrapper.html()).to.contain("(Optional)");
-
-      // On setup, the password is required too.
-      wrapper.setContext({ settingUp: true });
-      required = wrapper.find(".required-field");
+      // Both the email and password fields are required.
+      const required = wrapper.find(".required-field");
       expect(required.length).to.equal(2);
       expect(wrapper.html()).not.to.contain("(Optional)");
     });


### PR DESCRIPTION
## Description

The CM now considers passwords to be required and not optional. This updates the UI so that the password field shows the "Required" text.

## Motivation and Context

See: https://github.com/ThePalaceProject/circulation/pull/801

## How Has This Been Tested?

I just checked the form in the web interface. All of the real changes happened in the CM.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
