### PR TITLE
Allow automatically generated lanes to be renamed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - A placeholder and help text are now displayed when the Publication Date field is selected in advanced search.
 - Remove CDN configuration screens.
+- Automatically generated lanes can now be renamed.
 
 #### Fixed
 

--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -47,8 +47,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
   render(): JSX.Element {
     const { lane, active, snapshot, provided, renderLanes } = this.props;
     const hasSublanes = lane.sublanes && !!lane.sublanes.length;
-    const hasCustomLists =
-      lane.custom_list_ids && !!lane.custom_list_ids.length;
+
     return (
       <li key={lane.id}>
         <div
@@ -79,7 +78,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
           </div>
           {this.state.expanded && (
             <div className="lane-buttons">
-              {hasCustomLists && this.renderButton("edit")}
+              {this.renderButton("edit")}
               {this.renderButton("create")}
             </div>
           )}

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -170,6 +170,7 @@ export class Lanes extends React.Component<LanesProps, LanesState> {
       library: this.props.library,
       customLists: this.props.customLists,
       editLane: this.editLane,
+      editOrCreate,
     };
     const extraProps = {
       create: {

--- a/src/components/__tests__/Lane-test.tsx
+++ b/src/components/__tests__/Lane-test.tsx
@@ -91,14 +91,6 @@ describe("Lane", () => {
     );
     expect(editSublane.hasClass("disabled")).to.be.false;
 
-    // A lane that wasn't created from custom lists should not be editable.
-    const notFromCustomLists = { ...laneData, ...{ custom_list_ids: [] } };
-    wrapper.setProps({ lane: notFromCustomLists });
-    editSublane = wrapper
-      .find(Link)
-      .filterWhere((el) => el.find("a").hasClass("edit-lane"));
-    expect(editSublane.length).to.equal(0);
-
     // The link is disabled if there are lane order changes.
     wrapper.setProps({ lane: laneData, orderChanged: true });
     editSublane = wrapper

--- a/tests/jest/components/Lane.test.tsx
+++ b/tests/jest/components/Lane.test.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { stub } from "sinon";
+import { LaneData } from "../../../src/interfaces";
+import Lane from "../../../src/components/Lane";
+
+// Mock the Link component from React Router, so we can verify that it gets rendered with the
+// expected props. This serves as an example of how to do something analogous to Enzyme's shallow
+// rendering, when we don't want/need to render the whole component tree down to HTML elements to
+// test something. This technique is useful for testing components in isolation (unit testing),
+// instead of the integration testing that RTL focuses on.
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  Link: (props) => (
+    <div data-testid="Link" data-to={props.to}>
+      {props.children}
+    </div>
+  ),
+}));
+
+const renderLanes = stub();
+const toggleLaneVisibility = stub();
+
+function createLaneData(displayName: string, isAutomated: boolean): LaneData {
+  return {
+    id: 1,
+    display_name: displayName,
+    visible: true,
+    count: 5,
+    sublanes: [],
+    // The absence/presence of custom list ids determines if a lane is automated or custom.
+    custom_list_ids: isAutomated ? [] : [1],
+    inherit_parent_restrictions: true,
+  };
+}
+
+describe("Lane", () => {
+  it("renders an edit link on a custom lane", () => {
+    const laneData = createLaneData("Custom Lane", false);
+
+    render(
+      <Lane
+        lane={laneData}
+        active={false}
+        library="test_library"
+        orderChanged={false}
+        renderLanes={renderLanes}
+        toggleLaneVisibility={toggleLaneVisibility}
+      />
+    );
+
+    const editLink = screen.getAllByTestId("Link")[0];
+
+    expect(editLink).toHaveAttribute("data-to", expect.stringMatching(/edit/i));
+    expect(editLink).toHaveTextContent(/edit/i);
+  });
+
+  it("renders an edit link on an automated lane", async () => {
+    const laneData = createLaneData("Automated Lane", true);
+
+    render(
+      <Lane
+        lane={laneData}
+        active={false}
+        library="test_library"
+        orderChanged={false}
+        renderLanes={renderLanes}
+        toggleLaneVisibility={toggleLaneVisibility}
+      />
+    );
+
+    const editLink = screen.getAllByTestId("Link")[0];
+
+    expect(editLink).toHaveAttribute("data-to", expect.stringMatching(/edit/i));
+    expect(editLink).toHaveTextContent(/edit/i);
+  });
+});

--- a/tests/jest/components/LaneEditor.test.tsx
+++ b/tests/jest/components/LaneEditor.test.tsx
@@ -62,6 +62,7 @@ describe("LaneEditor", () => {
           library="library"
           lane={laneData}
           customLists={customListsData}
+          editOrCreate="edit"
           editLane={editLane}
           deleteLane={deleteLane}
           findParentOfLane={stub().returns(laneData)}
@@ -91,15 +92,18 @@ describe("LaneEditor", () => {
     const laneData = createLaneData("Automated Lane", true);
 
     beforeEach(() => {
-      <LaneEditor
-        library="library"
-        lane={laneData}
-        customLists={customListsData}
-        editLane={editLane}
-        deleteLane={deleteLane}
-        findParentOfLane={stub().returns(laneData)}
-        toggleLaneVisibility={toggleLaneVisibility}
-      />;
+      render(
+        <LaneEditor
+          library="library"
+          lane={laneData}
+          customLists={customListsData}
+          editOrCreate="edit"
+          editLane={editLane}
+          deleteLane={deleteLane}
+          findParentOfLane={stub().returns(laneData)}
+          toggleLaneVisibility={toggleLaneVisibility}
+        />
+      );
     });
 
     it("does not render a delete button", () => {
@@ -117,5 +121,28 @@ describe("LaneEditor", () => {
     it("does not render a custom lists editor", () => {
       expect(screen.queryByTestId("LaneCustomListsEditor")).toBeNull();
     });
+
+    it("renders an explanation that the lane contents can't be edited", () => {
+      expect(screen.getByText(/contents cannot be edited/i)).not.toBeNull();
+    });
+  });
+
+  it("doesn't render a custom lists editor while a lane is being loaded for editing", () => {
+    const laneData = null;
+
+    render(
+      <LaneEditor
+        library="library"
+        lane={laneData}
+        customLists={customListsData}
+        editOrCreate="edit"
+        editLane={editLane}
+        deleteLane={deleteLane}
+        findParentOfLane={stub().returns(laneData)}
+        toggleLaneVisibility={toggleLaneVisibility}
+      />
+    );
+
+    expect(screen.queryByTestId("LaneCustomListsEditor")).toBeNull();
   });
 });

--- a/tests/jest/components/LaneEditor.test.tsx
+++ b/tests/jest/components/LaneEditor.test.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { stub } from "sinon";
+import { LaneData } from "../../../src/interfaces";
+import LaneEditor from "../../../src/components/LaneEditor";
+
+// Mock the LaneCustomListsEditor so we can verify that it is or isn't rendered. This serves as an
+// example of how to do something analogous to Enzyme's shallow rendering, when we don't want/need
+// to render the whole component tree down to HTML elements to test something. This technique is
+// useful for testing components in isolation (unit testing), instead of the integration testing
+// that RTL focuses on.
+
+jest.mock("../../../src/components/LaneCustomListsEditor", () => ({
+  __esModule: true,
+  default: (props) => <div data-testid="LaneCustomListsEditor" />,
+}));
+
+const customListsData = [
+  { id: 1, name: "list 1", entries: [], is_owner: true, is_shared: false },
+];
+
+const editLane = stub().returns(
+  new Promise<void>((resolve) => resolve())
+);
+
+const deleteLane = stub().returns(
+  new Promise<void>((resolve) => resolve())
+);
+
+const toggleLaneVisibility = stub();
+
+function createLaneData(displayName: string, isAutomated: boolean): LaneData {
+  return {
+    id: 1,
+    display_name: displayName,
+    visible: true,
+    count: 5,
+    sublanes: [
+      {
+        id: 2,
+        display_name: `Sublane of ${displayName}`,
+        visible: true,
+        count: 3,
+        sublanes: [],
+        custom_list_ids: [1],
+        inherit_parent_restrictions: false,
+      },
+    ],
+    // The absence/presence of custom list ids determines if a lane is automated or custom.
+    custom_list_ids: isAutomated ? [] : [1],
+    inherit_parent_restrictions: true,
+  };
+}
+
+describe("LaneEditor", () => {
+  describe("for a custom lane", () => {
+    const laneData = createLaneData("Custom Lane", false);
+
+    beforeEach(() => {
+      render(
+        <LaneEditor
+          library="library"
+          lane={laneData}
+          customLists={customListsData}
+          editLane={editLane}
+          deleteLane={deleteLane}
+          findParentOfLane={stub().returns(laneData)}
+          toggleLaneVisibility={toggleLaneVisibility}
+        />
+      );
+    });
+
+    it("renders a delete button", () => {
+      expect(screen.getByRole("button", { name: /delete/i })).not.toBeNull();
+    });
+
+    it("renders an inherit parent restrictions checkbox", () => {
+      expect(
+        screen.getByRole("checkbox", {
+          name: /inherit restrictions from parent/i,
+        })
+      ).not.toBeNull();
+    });
+
+    it("renders a custom lists editor", () => {
+      expect(screen.getByTestId("LaneCustomListsEditor")).not.toBeNull();
+    });
+  });
+
+  describe("for an automated lane", () => {
+    const laneData = createLaneData("Automated Lane", true);
+
+    beforeEach(() => {
+      <LaneEditor
+        library="library"
+        lane={laneData}
+        customLists={customListsData}
+        editLane={editLane}
+        deleteLane={deleteLane}
+        findParentOfLane={stub().returns(laneData)}
+        toggleLaneVisibility={toggleLaneVisibility}
+      />;
+    });
+
+    it("does not render a delete button", () => {
+      expect(screen.queryByRole("button", { name: /delete/i })).toBeNull();
+    });
+
+    it("does not render an inherit parent restrictions checkbox", () => {
+      expect(
+        screen.queryByRole("checkbox", {
+          name: /inherit restrictions from parent/i,
+        })
+      ).toBeNull();
+    });
+
+    it("does not render a custom lists editor", () => {
+      expect(screen.queryByTestId("LaneCustomListsEditor")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This allows automatically generated lanes to be renamed.

- In the Lanes sidebar, every lane now has an edit button, whether it's custom or automatically generated.
- In the lane editor, automatically generated lanes can only be renamed and made visible/invisible. Other functions are not available: deleting, adding/removing lists, and inheriting restrictons from the parent.

The included tests contain examples of using Jest mocks with React Testing Library to achieve something similar to Enzyme's shallow rendering, which allows isolating tests to a single component.

## Motivation and Context

Libraries have requested the ability to rename the automatically generated lanes. Notion: https://www.notion.so/lyrasis/Admin-UI-Add-ability-to-rename-a-default-lane-name-in-the-CM-4b42fd3a308947a7907442d176447de2

## How Has This Been Tested?

- Run using cerberus as a back end: `npm run dev-server -- --env=backend=https://cerberus.staging.palaceproject.io`
- Select Cerberus Test Library 1, and click Lanes
- In the sidebar, click the Edit button on an automatically generated lane (e.g. Fiction, Nonfiction, Young Adult Fiction, etc.)
The lane editor should open. There should be an Edit Name button, a Hide/Show lane button, and a Save button. There should not be a Delete button. There should not be an Available Lists list, nor a Lists in This Lane list. If this is a sublane, there should not be an "Inherit restrictions from parent lane" checkbox.
- Change the name of the list and save.
The new list name should appear in the sidebar, and in the lane editor.
- Navigate to the catalog, and browse to the lane. It should appear with the new name. (It sometimes takes a while for the change to appear on the catalog, which I assume is some kind of caching in the CM).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
