### PR TITLE
Feature/toggle clear redux approach

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -49,6 +49,7 @@ import {
 export default class ActionCreator extends BaseActionCreator {
   static readonly SET_FEATURE_FLAGS = "SET_FEATURE_FLAGS";
   static readonly UPDATE_FEATURE_FLAG = "UPDATE_FEATURE_FLAG";
+  static readonly UPDATE_CLEAR_FILTERS_FLAG = "UPDATE_CLEAR_FILTERS_FLAG";
   static readonly EDIT_BOOK = "EDIT_BOOK";
   static readonly BOOK_ADMIN = "BOOK_ADMIN";
   static readonly ROLES = "ROLES";
@@ -1191,6 +1192,13 @@ export default class ActionCreator extends BaseActionCreator {
     return {
       type: ActionCreator.UPDATE_FEATURE_FLAG,
       name,
+      value,
+    };
+  }
+
+  updateClearFiltersFlag(value: boolean) {
+    return {
+      type: ActionCreator.UPDATE_CLEAR_FILTERS_FLAG,
       value,
     };
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -938,6 +938,14 @@ export default class ActionCreator extends BaseActionCreator {
     };
   }
 
+  updateClearFiltersFlag(builderName: string, value: boolean) {
+    return {
+      type: ActionCreator.UPDATE_CLEAR_FILTERS_FLAG,
+      builderName,
+      value,
+    };
+  }
+
   addCustomListEditorAdvSearchQuery(
     builderName: string,
     query: AdvancedSearchQuery
@@ -1192,13 +1200,6 @@ export default class ActionCreator extends BaseActionCreator {
     return {
       type: ActionCreator.UPDATE_FEATURE_FLAG,
       name,
-      value,
-    };
-  }
-
-  updateClearFiltersFlag(value: boolean) {
-    return {
-      type: ActionCreator.UPDATE_CLEAR_FILTERS_FLAG,
       value,
     };
   }

--- a/src/components/AdvancedSearchBuilder.tsx
+++ b/src/components/AdvancedSearchBuilder.tsx
@@ -11,6 +11,7 @@ export interface AdvancedSearchBuilderProps {
   query: AdvancedSearchQuery;
   selectedQueryId: string;
   addQuery?: (builderName: string, query: AdvancedSearchQuery) => void;
+  updateClearFiltersFlag?: (builderName: string, value: boolean) => void;
   updateQueryBoolean?: (builderName: string, id: string, bool: string) => void;
   moveQuery?: (builderName: string, id: string, targetId: string) => void;
   removeQuery?: (builderName: string, id: string) => void;
@@ -51,6 +52,7 @@ export default function AdvancedSearchBuilder({
   query,
   selectedQueryId,
   addQuery,
+  updateClearFiltersFlag,
   updateQueryBoolean,
   moveQuery,
   removeQuery,
@@ -65,6 +67,9 @@ export default function AdvancedSearchBuilder({
           <AdvancedSearchFilterInput
             name={name}
             onAdd={(query) => addQuery?.(name, query)}
+            onClearFiltersFlagChange={(value) =>
+              updateClearFiltersFlag?.(name, value)
+            }
           />
         )}
 

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -110,6 +110,8 @@ export default function AdvancedSearchFilterInput({
           disabled={!(filterKey && filterOp && filterValue.trim())}
           type="submit"
         />
+
+        <input type="checkbox" />
       </div>
     </form>
   );

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -7,11 +7,13 @@ import EditableInput from "./EditableInput";
 export interface AdvancedSearchFilterInputProps {
   name: string;
   onAdd: (query: AdvancedSearchQuery) => void;
+  onClearFiltersFlagChange: (value: boolean) => void;
 }
 
 export default function AdvancedSearchFilterInput({
   name: builderName,
   onAdd,
+  onClearFiltersFlagChange,
 }: AdvancedSearchFilterInputProps) {
   const opSelect = React.useRef(null);
   const valueInput = React.useRef(null);
@@ -19,7 +21,6 @@ export default function AdvancedSearchFilterInput({
   const [filterKey, setFilterKey] = React.useState("genre");
   const [filterOp, setFilterOp] = React.useState("eq");
   const [filterValue, setFilterValue] = React.useState("");
-  const [clearFilters, setClearFilters] = React.useState(false);
 
   const handleKeyChange = (value) => {
     setFilterKey(value);
@@ -42,7 +43,6 @@ export default function AdvancedSearchFilterInput({
         op: filterOp,
         value: filterValueTrimmed,
       });
-
       setFilterValue("");
     }
   };
@@ -52,6 +52,17 @@ export default function AdvancedSearchFilterInput({
     event.preventDefault();
 
     addFilter();
+  };
+
+  const updateClearFiltersFlag = (checked: boolean) => {
+    onClearFiltersFlagChange(checked);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    updateClearFiltersFlag(event.target.checked);
   };
 
   const selectedField = fields.find((field) => field.value === filterKey);
@@ -115,9 +126,7 @@ export default function AdvancedSearchFilterInput({
         <input
           id="clear-filters-on-search"
           type="checkbox"
-          onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
-            setClearFilters(e.target.checked);
-          }}
+          onInput={handleInputChange}
         />
         <label htmlFor="clear-filters-on-search">Clear filters on search</label>
       </div>

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -43,6 +43,7 @@ export default function AdvancedSearchFilterInput({
         key: filterKey,
         op: filterOp,
         value: filterValueTrimmed,
+        clearFilters: clearFilters,
       });
 
       setFilterValue("");

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -19,6 +19,7 @@ export default function AdvancedSearchFilterInput({
   const [filterKey, setFilterKey] = React.useState("genre");
   const [filterOp, setFilterOp] = React.useState("eq");
   const [filterValue, setFilterValue] = React.useState("");
+  const [clearFilters, setClearFilters] = React.useState(false);
 
   const handleKeyChange = (value) => {
     setFilterKey(value);
@@ -34,6 +35,8 @@ export default function AdvancedSearchFilterInput({
 
   const addFilter = () => {
     const filterValueTrimmed = filterValue.trim();
+
+    console.log("Should clear filters?", clearFilters);
 
     if (filterKey && filterOp && filterValueTrimmed) {
       onAdd?.({
@@ -111,7 +114,14 @@ export default function AdvancedSearchFilterInput({
           type="submit"
         />
 
-        <input type="checkbox" />
+        <input
+          id="clear-filters-on-search"
+          type="checkbox"
+          onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setClearFilters(e.target.checked);
+          }}
+        />
+        <label htmlFor="clear-filters-on-search">Clear filters on search</label>
       </div>
     </form>
   );

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -36,8 +36,6 @@ export default function AdvancedSearchFilterInput({
   const addFilter = () => {
     const filterValueTrimmed = filterValue.trim();
 
-    console.log("Should clear filters?", clearFilters);
-
     if (filterKey && filterOp && filterValueTrimmed) {
       onAdd?.({
         key: filterKey,

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -41,7 +41,6 @@ export default function AdvancedSearchFilterInput({
         key: filterKey,
         op: filterOp,
         value: filterValueTrimmed,
-        clearFilters: clearFilters,
       });
 
       setFilterValue("");

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -60,6 +60,7 @@ export type CustomListEditorProps = {
   updateProperty?: (name: string, value) => void;
   updateSearchParam?: (name: string, value) => void;
   addAdvSearchQuery?: (builderName: string, query: AdvancedSearchQuery) => void;
+  updateClearFiltersFlag?: (builderName: string, value: boolean) => void;
   updateAdvSearchQueryBoolean?: (
     builderName: string,
     id: string,
@@ -112,6 +113,7 @@ export default function CustomListEditor({
   updateProperty,
   updateSearchParam,
   addAdvSearchQuery,
+  updateClearFiltersFlag,
   updateAdvSearchQueryBoolean,
   moveAdvSearchQuery,
   removeAdvSearchQuery,
@@ -276,6 +278,7 @@ export default function CustomListEditor({
             languages={languages}
             showAutoUpdate={isAutoUpdateEnabled}
             addAdvSearchQuery={addAdvSearchQuery}
+            updateClearFiltersFlag={updateClearFiltersFlag}
             updateAdvSearchQueryBoolean={updateAdvSearchQueryBoolean}
             moveAdvSearchQuery={moveAdvSearchQuery}
             removeAdvSearchQuery={removeAdvSearchQuery}

--- a/src/components/CustomListSearch.tsx
+++ b/src/components/CustomListSearch.tsx
@@ -20,6 +20,7 @@ export interface CustomListSearchProps {
   updateSearchParam?: (name: string, value) => void;
   search: () => void;
   addAdvSearchQuery?: (builderName: string, query: AdvancedSearchQuery) => void;
+  updateClearFiltersFlag?: (builderName: string, value: boolean) => void;
   updateAdvSearchQueryBoolean?: (
     builderName: string,
     id: string,
@@ -53,6 +54,7 @@ const CustomListSearch = ({
   updateSearchParam,
   search,
   addAdvSearchQuery,
+  updateClearFiltersFlag,
   updateAdvSearchQueryBoolean,
   moveAdvSearchQuery,
   removeAdvSearchQuery,
@@ -88,6 +90,7 @@ const CustomListSearch = ({
         query={builder.query}
         selectedQueryId={builder.selectedQueryId}
         addQuery={addAdvSearchQuery}
+        updateClearFiltersFlag={updateClearFiltersFlag}
         updateQueryBoolean={updateAdvSearchQueryBoolean}
         moveQuery={moveAdvSearchQuery}
         removeQuery={removeAdvSearchQuery}

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -77,6 +77,7 @@ export interface CustomListsDispatchProps {
     builderName: string,
     query: AdvancedSearchQuery
   ) => void;
+  updateClearFiltersFlag?: (builderName: string, value: boolean) => void;
   updateCustomListEditorAdvSearchQueryBoolean?: (
     builderName: string,
     id: string,
@@ -225,6 +226,7 @@ export class CustomLists extends React.Component<
       toggleCollection: this.props.toggleCustomListEditorCollection,
       updateSearchParam: this.props.updateCustomListEditorSearchParam,
       addAdvSearchQuery: this.props.addCustomListEditorAdvSearchQuery,
+      updateClearFiltersFlag: this.props.updateClearFiltersFlag,
       updateAdvSearchQueryBoolean: this.props
         .updateCustomListEditorAdvSearchQueryBoolean,
       moveAdvSearchQuery: this.props.moveCustomListEditorAdvSearchQuery,
@@ -536,6 +538,9 @@ function mapDispatchToProps(dispatch, ownProps) {
     updateCustomListEditorSearchParam: (name: string, value) => {
       dispatch(actions.updateCustomListEditorSearchParam(name, value));
       dispatch(actions.executeCustomListEditorSearch(ownProps.library));
+    },
+    updateClearFiltersFlag: (builderName: string, value: boolean) => {
+      dispatch(actions.updateClearFiltersFlag(builderName, value));
     },
     addCustomListEditorAdvSearchQuery: (
       builderName: string,

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -47,6 +47,7 @@ export interface CustomListsStateProps {
   customListEditorIsModified?: boolean;
   customListEditorIsSearchModified?: boolean;
   customListEditorIsAutoUpdateEnabled?: boolean;
+  customListEditorIsClearFiltersEnabled?: boolean;
   lists: CustomListData[];
   listDetails?: CollectionData;
   collections: AdminCollectionData[];
@@ -190,6 +191,7 @@ export class CustomLists extends React.Component<
       collections: this.collectionsForLibrary(),
       autoUpdateStatus: this.props.customListEditorAutoUpdateStatus,
       isAutoUpdateEnabled: this.props.customListEditorIsAutoUpdateEnabled,
+      isClearFiltersEnabled: this.props.customListEditorIsClearFiltersEnabled,
       properties: this.props.customListEditorProperties,
       savedName: this.props.customListEditorSavedName,
       searchParams: this.props.customListEditorSearchParams,
@@ -463,6 +465,8 @@ function mapStateToProps(state, ownProps) {
       state.editor.customListEditor.isSearchModified,
     customListEditorIsAutoUpdateEnabled:
       state.editor.customListEditor.isAutoUpdateEnabled,
+    customListEditorIsClearFiltersEnabled:
+      state.editor.customListEditor.isClearFiltersEnabled,
     lists:
       state.editor.customLists &&
       state.editor.customLists.data &&

--- a/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
+++ b/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
@@ -8,11 +8,19 @@ import AdvancedSearchFilterInput from "../AdvancedSearchFilterInput";
 describe("AdvancedSearchFilterInput", () => {
   let wrapper;
   let onAdd;
+  let onClearFiltersFlagChange;
 
   beforeEach(() => {
     onAdd = stub();
+    onClearFiltersFlagChange = stub();
 
-    wrapper = mount(<AdvancedSearchFilterInput name="include" onAdd={onAdd} />);
+    wrapper = mount(
+      <AdvancedSearchFilterInput
+        name="include"
+        onAdd={onAdd}
+        onClearFiltersFlagChange={onClearFiltersFlagChange}
+      />
+    );
   });
 
   it("should render radio buttons for field selection", () => {

--- a/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
+++ b/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
@@ -78,7 +78,6 @@ describe("AdvancedSearchFilterInput", () => {
 
     expect(onAdd.args[0]).to.deep.equal([
       {
-        clearFilters: false,
         key: "genre",
         op: "eq",
         value: "hello",
@@ -99,7 +98,6 @@ describe("AdvancedSearchFilterInput", () => {
 
     expect(onAdd.args[0]).to.deep.equal([
       {
-        clearFilters: false,
         key: "genre",
         op: "eq",
         value: "hello",

--- a/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
+++ b/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
@@ -78,6 +78,7 @@ describe("AdvancedSearchFilterInput", () => {
 
     expect(onAdd.args[0]).to.deep.equal([
       {
+        clearFilters: false,
         key: "genre",
         op: "eq",
         value: "hello",
@@ -98,6 +99,7 @@ describe("AdvancedSearchFilterInput", () => {
 
     expect(onAdd.args[0]).to.deep.equal([
       {
+        clearFilters: false,
         key: "genre",
         op: "eq",
         value: "hello",

--- a/src/components/__tests__/CustomListEditor-test.tsx
+++ b/src/components/__tests__/CustomListEditor-test.tsx
@@ -97,10 +97,12 @@ describe("CustomListEditor", () => {
       include: {
         query: null,
         selectedQueryId: null,
+        clearFilters: null,
       },
       exclude: {
         query: null,
         selectedQueryId: null,
+        clearFilters: null,
       },
     },
   };

--- a/src/components/__tests__/CustomListSearch-test.tsx
+++ b/src/components/__tests__/CustomListSearch-test.tsx
@@ -31,10 +31,12 @@ describe("CustomListSearch", () => {
       include: {
         query: null,
         selectedQueryId: null,
+        clearFilters: null,
       },
       exclude: {
         query: null,
         selectedQueryId: null,
+        clearFilters: null,
       },
     },
   };

--- a/src/components/__tests__/CustomLists-test.tsx
+++ b/src/components/__tests__/CustomLists-test.tsx
@@ -51,10 +51,12 @@ describe("CustomLists", () => {
       include: {
         query: null,
         selectedQueryId: null,
+        clearFilters: null,
       },
       exclude: {
         query: null,
         selectedQueryId: null,
+        clearFilters: null,
       },
     },
   };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -459,7 +459,6 @@ export interface AdvancedSearchQuery {
   and?: AdvancedSearchQuery[];
   or?: AdvancedSearchQuery[];
   not?: AdvancedSearchQuery[];
-  clearFilters?: boolean;
 }
 
 export interface AdvancedSearchData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -459,6 +459,7 @@ export interface AdvancedSearchQuery {
   and?: AdvancedSearchQuery[];
   or?: AdvancedSearchQuery[];
   not?: AdvancedSearchQuery[];
+  clearFilters?: boolean;
 }
 
 export interface AdvancedSearchData {

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -534,7 +534,7 @@ describe("custom list editor reducer", () => {
               book91: { id: "book91", title: "Huckleberry Finn" },
             },
             removed: {
-              book1: true as true,
+              book1: true as const,
             },
           },
         };
@@ -606,8 +606,8 @@ describe("custom list editor reducer", () => {
               book98: { id: "book98", title: "The Bell Jar" },
             },
             removed: {
-              book1: true as true,
-              book90: true as true,
+              book1: true as const,
+              book90: true as const,
             },
           },
         };
@@ -1781,7 +1781,7 @@ describe("custom list editor reducer", () => {
         entries: {
           ...initialState.entries,
           removed: {
-            book2: true as true,
+            book2: true as const,
           },
         },
       };
@@ -1930,7 +1930,7 @@ describe("custom list editor reducer", () => {
         entries: {
           ...initialState.entries,
           removed: {
-            book2: true as true,
+            book2: true as const,
           },
         },
       };
@@ -2260,7 +2260,7 @@ describe("custom list editor reducer", () => {
             book91: { id: "book91", title: "Huckleberry Finn" },
           },
           removed: {
-            book1: true as true,
+            book1: true as const,
           },
         },
       };
@@ -2294,8 +2294,8 @@ describe("custom list editor reducer", () => {
             },
           },
           removed: {
-            book1: true as true,
-            book3: true as true,
+            book1: true as const,
+            book3: true as const,
           },
           current: [
             { id: "book2", title: "Little Women" },
@@ -2508,7 +2508,7 @@ describe("custom list editor reducer", () => {
             { id: "book91", title: "Huckleberry Finn" },
           ],
           removed: {
-            book90: true as true,
+            book90: true as const,
           },
         },
       };
@@ -2568,7 +2568,7 @@ describe("custom list editor reducer", () => {
             { id: "book91", title: "Huckleberry Finn" },
           ],
           removed: {
-            book90: true as true,
+            book90: true as const,
           },
         },
       };
@@ -2719,10 +2719,12 @@ describe("custom list editor reducer", () => {
               include: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
               exclude: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
             },
           },
@@ -2751,10 +2753,12 @@ describe("custom list editor reducer", () => {
               include: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
               exclude: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
             },
           },
@@ -2781,10 +2785,12 @@ describe("custom list editor reducer", () => {
               include: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
               exclude: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
             },
           },
@@ -2811,10 +2817,12 @@ describe("custom list editor reducer", () => {
               include: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
               exclude: {
                 query: null,
                 selectedQueryId: null,
+                clearFilters: null,
               },
             },
           },

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -470,11 +470,6 @@ export interface CustomListEditorAdvancedSearchBuilderData {
    * The root advanced search query.
    */
   query: AdvancedSearchQuery;
-
-  /**
-   * Whether to clear all filters on search or not.
-   */
-  clearFilters: boolean;
 }
 
 /**
@@ -560,9 +555,9 @@ export interface CustomListEditorState {
   isAutoUpdateEnabled: boolean;
 
   /**
-   * Flag indicating ifclearing filters on search is enabled.
+   * Object keyed by builderName containing boolean values of whether clearFilters is enabled for a given builder or not.
    */
-  isClearFiltersEnabled: boolean;
+  builderClearFiltersFlags: object;
 
   /**
    * The loading state of the list; true if the list data has been loaded (not including the list
@@ -663,7 +658,7 @@ export const initialState: CustomListEditorState = {
   isOwner: true,
   isShared: false,
   isSharePending: false,
-  isClearFiltersEnabled: false,
+  builderClearFiltersFlags: {},
   properties: {
     baseline: initialProperties,
     current: initialProperties,
@@ -1341,7 +1336,7 @@ const handleAddCustomListEditorAdvSearchQuery = validatedHandler(
           id: newQueryId(),
         };
 
-        if (!currentQuery || draftState.isClearFiltersEnabled) {
+        if (!currentQuery || draftState.builderClearFiltersFlags[builderName]) {
           builder.query = newQuery;
           builder.selectedQueryId = newQuery.id;
         } else {
@@ -1794,10 +1789,10 @@ const handleUpdateClearFiltersFlag = (
   state: CustomListEditorState,
   action
 ): CustomListEditorState => {
-  const { value } = action;
+  const { builderName, value } = action;
 
   return produce(state, (draftState) => {
-    draftState.isClearFiltersEnabled = !!value;
+    draftState.builderClearFiltersFlags[builderName] = !!value;
   });
 };
 

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -1335,7 +1335,8 @@ const handleAddCustomListEditorAdvSearchQuery = validatedHandler(
           id: newQueryId(),
         };
 
-        if (!currentQuery || query.clearFilters) {
+        // if (!currentQuery || query.clearFilters) {
+        if (!currentQuery) {
           builder.query = newQuery;
           builder.selectedQueryId = newQuery.id;
         } else {

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -560,6 +560,11 @@ export interface CustomListEditorState {
   isAutoUpdateEnabled: boolean;
 
   /**
+   * Flag indicating ifclearing filters on search is enabled.
+   */
+  isClearFiltersEnabled: boolean;
+
+  /**
    * The loading state of the list; true if the list data has been loaded (not including the list
    * entries), false otherwise.
    */
@@ -1335,8 +1340,7 @@ const handleAddCustomListEditorAdvSearchQuery = validatedHandler(
           id: newQueryId(),
         };
 
-        // if (!currentQuery || query.clearFilters) {
-        if (!currentQuery) {
+        if (!currentQuery || draftState.isClearFiltersEnabled) {
           builder.query = newQuery;
           builder.selectedQueryId = newQuery.id;
         } else {
@@ -1785,6 +1789,17 @@ const handleUpdateFeatureFlag = (
   return state;
 };
 
+const handleUpdateClearFiltersFlag = (
+  state: CustomListEditorState,
+  action
+): CustomListEditorState => {
+  const { value } = action;
+
+  return produce(state, (draftState) => {
+    draftState.isClearFiltersEnabled = !!value;
+  });
+};
+
 export default (
   state: CustomListEditorState = initialState,
   action
@@ -1834,6 +1849,8 @@ export default (
       return handleSetFeatureFlags(state, action);
     case ActionCreator.UPDATE_FEATURE_FLAG:
       return handleUpdateFeatureFlag(state, action);
+    case ActionCreator.UPDATE_CLEAR_FILTERS_FLAG:
+      return handleUpdateClearFiltersFlag(state, action);
     default:
       return state;
   }

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -1328,6 +1328,13 @@ const handleAddCustomListEditorAdvSearchQuery = validatedHandler(
           id: newQueryId(),
         };
 
+        if (query.clearFilters) {
+          console.log(
+            "handleAddCustomListEditorAdvSearchQuery",
+            "TODO: Clear filters here."
+          );
+        }
+
         if (!currentQuery) {
           builder.query = newQuery;
           builder.selectedQueryId = newQuery.id;

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -470,6 +470,11 @@ export interface CustomListEditorAdvancedSearchBuilderData {
    * The root advanced search query.
    */
   query: AdvancedSearchQuery;
+
+  /**
+   * Whether to clear all filters on search or not.
+   */
+  clearFilters: boolean;
 }
 
 /**
@@ -632,10 +637,12 @@ const initialSearchParams = {
     include: {
       query: null,
       selectedQueryId: null,
+      clearFilters: null,
     },
     exclude: {
       query: null,
       selectedQueryId: null,
+      clearFilters: null,
     },
   },
 };

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -663,6 +663,7 @@ export const initialState: CustomListEditorState = {
   isOwner: true,
   isShared: false,
   isSharePending: false,
+  isClearFiltersEnabled: false,
   properties: {
     baseline: initialProperties,
     current: initialProperties,

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -1328,14 +1328,7 @@ const handleAddCustomListEditorAdvSearchQuery = validatedHandler(
           id: newQueryId(),
         };
 
-        if (query.clearFilters) {
-          console.log(
-            "handleAddCustomListEditorAdvSearchQuery",
-            "TODO: Clear filters here."
-          );
-        }
-
-        if (!currentQuery) {
+        if (!currentQuery || query.clearFilters) {
           builder.query = newQuery;
           builder.selectedQueryId = newQuery.id;
         } else {


### PR DESCRIPTION
## Description

Added checkbox to toggle clear on search for Lists.

## Motivation and Context

It is currently laborious to quickly search for different titles and authors, requiring an extra click to remove the old filter ("search term") each time. This gives the option to remove filters every time a new filter is added, when the checkbox is checked.

Reference: https://www.notion.so/lyrasis/Add-a-toggle-feature-to-clear-search-terms-after-search-results-are-returned-when-creating-or-editin-344246ea07a3458a823c897d2a2c3a69

## How Has This Been Tested?

I have confirmed that all functionality works. Please advise if there is a best practice around adding a unit test for this. I would imagine integration testing to be more useful, which could be achieved via software like Selenium or through a third-party service.  I would be happy to add integration or unit testing as appropraite, with the advice from a code reviewer.

## Checklist:

- [x] I have updated the documentation accordingly. NOTE: There have been no changes to the documentation.
- [x] All new and existing tests passed.
