### PR TITLE
Removes option to request circulation events by location.

### DIFF
--- a/src/components/CirculationEventsDownloadForm.tsx
+++ b/src/components/CirculationEventsDownloadForm.tsx
@@ -4,36 +4,25 @@ import { Button, Form } from "library-simplified-reusable-components";
 import EditableInput from "./EditableInput";
 import * as qs from "qs";
 
-export interface CirculationEventsDownloadFormProps
-  extends React.Props<CirculationEventsDownloadForm> {
+export interface CirculationEventsDownloadFormProps {
   show: boolean;
   hide: () => void;
   library?: string;
 }
 
-export interface CirculationEventsDownloadFormState {
-  showLocationsInput: boolean;
-}
-
 /** Form for downloading CirculationEvents for a particular date. */
 export default class CirculationEventsDownloadForm extends React.Component<
-  CirculationEventsDownloadFormProps,
-  CirculationEventsDownloadFormState
+  CirculationEventsDownloadFormProps
 > {
-  private type = React.createRef<HTMLSelectElement>();
   private dateStart = React.createRef<EditableInput>();
   private dateEnd = React.createRef<EditableInput>();
-  private locations = React.createRef<EditableInput>();
 
   constructor(props) {
     super(props);
-    this.state = { showLocationsInput: false };
-
     this.download = this.download.bind(this);
     this.renderForm = this.renderForm.bind(this);
     this.renderInputs = this.renderInputs.bind(this);
     this.getRefValue = this.getRefValue.bind(this);
-    this.toggleLocationsInput = this.toggleLocationsInput.bind(this);
   }
 
   render(): JSX.Element {
@@ -73,28 +62,10 @@ export default class CirculationEventsDownloadForm extends React.Component<
   }
 
   /**
-   * Toggle the locations text input whenever "locations" is selected in the dropdown.
-   */
-  toggleLocationsInput() {
-    // select elements get the value from the React ref differently.
-    const type = this.type.current && this.type.current.value;
-    let showLocationsInput = false;
-    if (type === "locations") {
-      showLocationsInput = true;
-    }
-    this.setState({ showLocationsInput });
-  }
-
-  /**
    * Render all the inputs for the form. The locations input is conditionally
    * rendered if it is selected in the Event type dropdown.
    */
   renderInputs() {
-    const eventTypes = [
-      { id: "all", label: "All Events" },
-      { id: "locations", label: "Events by Location" },
-    ];
-    // date inputs require YYYY-MM-DD format
     const today = new Date().toISOString().split("T")[0];
 
     return (
@@ -103,39 +74,6 @@ export default class CirculationEventsDownloadForm extends React.Component<
           <legend className="control-label visuallyHidden">
             Configuration
           </legend>
-          <label htmlFor="event-select">
-            Event Type
-            <select
-              className="form-control"
-              id="event-select"
-              ref={this.type}
-              name="type"
-              onChange={this.toggleLocationsInput}
-              onBlur={this.toggleLocationsInput}
-            >
-              {eventTypes.map((event) => (
-                <option
-                  key={`${event.id}-option`}
-                  value={event.id}
-                  aria-selected={false}
-                >
-                  {event.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          {this.state.showLocationsInput && (
-            <EditableInput
-              ref={this.locations}
-              className=""
-              label="Locations"
-              description="Comma-separated list of locations (e.g. ZIP codes or library branch codes) to focus on."
-              name="locations"
-              id="locations"
-              optionalText={false}
-              placeholder="10001,10002,10003"
-            />
-          )}
           <EditableInput
             ref={this.dateStart}
             name="dateStart"
@@ -164,8 +102,7 @@ export default class CirculationEventsDownloadForm extends React.Component<
    */
   getRefValue(ref: React.RefObject<EditableInput>) {
     const current = ref.current || null;
-    const value = (current && current.getValue()) || null;
-    return value;
+    return (current && current.getValue()) || null;
   }
 
   /**
@@ -174,8 +111,7 @@ export default class CirculationEventsDownloadForm extends React.Component<
   download() {
     const date = this.getRefValue(this.dateStart);
     const dateEnd = this.getRefValue(this.dateEnd);
-    const locations = this.getRefValue(this.locations);
-    const paramValues = { date, dateEnd, locations };
+    const paramValues = { date, dateEnd };
     let library = "";
 
     if (this.props.library) {

--- a/src/components/__tests__/CirculationEventsDownloadForm-test.tsx
+++ b/src/components/__tests__/CirculationEventsDownloadForm-test.tsx
@@ -15,41 +15,6 @@ describe("CirculationEventsDownloadForm", () => {
     wrapper = mount(<CirculationEventsDownloadForm show={true} hide={hide} />);
   });
 
-  it("renders a select element", () => {
-    const select = wrapper.find("select");
-    const textInput = wrapper.find("input[name='locations']");
-
-    expect(select.length).to.equal(1);
-    expect(textInput.length).to.equal(0);
-  });
-
-  it("renders a text input when 'locations' is selected", () => {
-    const select = wrapper.find("select");
-    let textInput = wrapper.find("input[name='locations']");
-
-    expect(textInput.length).to.equal(0);
-    select.getDOMNode().value = "locations";
-    select.simulate("change");
-
-    textInput = wrapper.find("input[name='locations']");
-    expect(textInput.length).to.equal(1);
-
-    select.getDOMNode().value = "all";
-    select.simulate("change");
-
-    textInput = wrapper.find("input[name='locations']");
-    expect(textInput.length).to.equal(0);
-
-    // Manually testing the `toggleLocationsInput` function
-    // without simulation the select element.
-    select.getDOMNode().value = "locations";
-    (wrapper.instance() as any).toggleLocationsInput();
-    wrapper.update();
-
-    textInput = wrapper.find("input[name='locations']");
-    expect(textInput.length).to.equal(1);
-  });
-
   it("renders start date and end date inputs", () => {
     const dates = wrapper.find("input[type='date']");
     expect(dates.length).to.equal(2);


### PR DESCRIPTION
## Description

- Removes option to request circulation events by location.
- Also removes the drop-down for choosing between "All Events" or "Events By Location", since "All Events" is the only remaining option. The behavior now is to fetch all events for the provided date range.
- Removes tests specific to the events by location functionality.

## Motivation and Context

The "locations" implementation is specific to one non-Palace library and caused confusion to users. [[Notion](https://www.notion.so/lyrasis/Admin-UI-Remove-Events-by-Location-functionality-when-downloading-CSV-16b1cbbfe39e44e5af191cadcad92379?pvs=4)]

## How Has This Been Tested?

- Manually tested in local development environment.
- Tests pass locally.
- [CI tests for this branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/4522384105/jobs/7964809560) passed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
