### PR TITLE
Adds a RootState interface to reflect complete Redux store state.

### DIFF
--- a/src/components/AccountPage.tsx
+++ b/src/components/AccountPage.tsx
@@ -2,18 +2,18 @@ import * as React from "react";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
 import ChangePasswordForm from "./ChangePasswordForm";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import Header from "./Header";
 import Footer from "./Footer";
 import title from "../utils/title";
 
 export interface AccountPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 
 /** Page for configuring account settings. */
-export default class AccountPage extends React.Component<{}, {}> {
+export default class AccountPage extends React.Component<object, object> {
   context: AccountPageContext;
 
   static contextTypes: React.ValidationMap<AccountPageContext> = {

--- a/src/components/BookCoverEditor.tsx
+++ b/src/components/BookCoverEditor.tsx
@@ -8,7 +8,7 @@ import ErrorMessage from "./ErrorMessage";
 import EditableInput from "./EditableInput";
 import { BookData, RightsStatusData } from "../interfaces";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { Panel, Button, Form } from "library-simplified-reusable-components";
 import UpdatingLoader from "./UpdatingLoader";
 
@@ -31,7 +31,7 @@ export interface BookCoverEditorDispatchProps {
 }
 
 export interface BookCoverEditorOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken: string;
   bookUrl: string;
   book: BookData;
@@ -44,7 +44,7 @@ export interface BookCoverEditorProps
     BookCoverEditorOwnProps {}
 
 /** Tab on the book details page for uploading a new book cover. */
-export class BookCoverEditor extends React.Component<BookCoverEditorProps, {}> {
+export class BookCoverEditor extends React.Component<BookCoverEditorProps> {
   private formContainerRef = React.createRef<HTMLDivElement>();
   private imageFormRef = React.createRef<Form>();
   private coverUrlRef = React.createRef<EditableInput>();

--- a/src/components/BookDetailsContainer.tsx
+++ b/src/components/BookDetailsContainer.tsx
@@ -5,12 +5,12 @@ import * as PropTypes from "prop-types";
 import BookDetailsTabContainer from "./BookDetailsTabContainer";
 import BookDetails from "./BookDetails";
 import { BookDetailsContainerProps } from "@thepalaceproject/web-opds-client/lib/components/Root";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 
 export interface BookDetailsContainerContext {
   csrfToken: string;
   tab: string;
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   library: (collectionUrl: string, bookUrl: string) => string;
 }
 
@@ -18,8 +18,7 @@ export interface BookDetailsContainerContext {
     and converts them into props. This component is passed into the OPDSCatalog from
     web-opds-client to replace the body of the book details page. */
 export default class BookDetailsContainer extends React.Component<
-  BookDetailsContainerProps,
-  {}
+  BookDetailsContainerProps
 > {
   context: BookDetailsContainerContext;
 

--- a/src/components/BookDetailsEditor.tsx
+++ b/src/components/BookDetailsEditor.tsx
@@ -8,7 +8,7 @@ import BookEditForm from "./BookEditForm";
 import ErrorMessage from "./ErrorMessage";
 import { BookData, RolesData, MediaData, LanguagesData } from "../interfaces";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { Button } from "library-simplified-reusable-components";
 import UpdatingLoader from "./UpdatingLoader";
 
@@ -34,7 +34,7 @@ export interface BookDetailsEditorDispatchProps {
 export interface BookDetailsEditorOwnProps {
   bookUrl?: string;
   csrfToken: string;
-  store?: Store<State>;
+  store?: Store<RootState>;
   refreshCatalog?: () => Promise<any>;
 }
 
@@ -45,10 +45,7 @@ export interface BookDetailsEditorProps
     BookDetailsEditorOwnProps {}
 
 /** Tab for editing a book's metadata on the book details page. */
-export class BookDetailsEditor extends React.Component<
-  BookDetailsEditorProps,
-  {}
-> {
+export class BookDetailsEditor extends React.Component<BookDetailsEditorProps> {
   constructor(props) {
     super(props);
     this.editBook = this.editBook.bind(this);

--- a/src/components/ChangePasswordForm.tsx
+++ b/src/components/ChangePasswordForm.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Store } from "redux";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import LoadingIndicator from "@thepalaceproject/web-opds-client/lib/components/LoadingIndicator";
@@ -19,7 +19,7 @@ export interface ChangePasswordFormDispatchProps {
 }
 
 export interface ChangePasswordFormOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken: string;
 }
 

--- a/src/components/CirculationEvents.tsx
+++ b/src/components/CirculationEvents.tsx
@@ -9,7 +9,7 @@ import * as PropTypes from "prop-types";
 import CirculationEventsDownloadForm from "./CirculationEventsDownloadForm";
 import { CirculationEventData } from "../interfaces";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { Button } from "library-simplified-reusable-components";
 
 export interface CirculationEventsStateProps {
@@ -23,7 +23,7 @@ export interface CirculationEventsDispatchProps {
 }
 
 export interface CirculationEventsOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   wait?: number;
   library?: string;
 }

--- a/src/components/Classifications.tsx
+++ b/src/components/Classifications.tsx
@@ -9,7 +9,7 @@ import ClassificationsForm from "./ClassificationsForm";
 import ClassificationsTable from "./ClassificationsTable";
 import { BookData, GenreTree, ClassificationData } from "../interfaces";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import UpdatingLoader from "./UpdatingLoader";
 
 export interface ClassificationsStateProps {
@@ -31,7 +31,7 @@ export interface ClassificationsDispatchProps {
 
 export interface ClassificationsOwnProps {
   // from parent
-  store: Store<State>;
+  store: Store<RootState>;
   csrfToken: string;
   bookUrl: string;
   book: BookData;
@@ -45,7 +45,7 @@ export interface ClassificationsProps
 
 /** Tab on the book details page with a table of a book's current classifications and
     a form for editing them. */
-export class Classifications extends React.Component<ClassificationsProps, {}> {
+export class Classifications extends React.Component<ClassificationsProps> {
   constructor(props) {
     super(props);
     this.refresh = this.refresh.bind(this);

--- a/src/components/Complaints.tsx
+++ b/src/components/Complaints.tsx
@@ -8,7 +8,7 @@ import ComplaintForm from "./ComplaintForm";
 import { Button } from "library-simplified-reusable-components";
 import { BookData, PostComplaint } from "../interfaces";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { formatString } from "../utils/sharedFunctions";
 import UpdatingLoader from "./UpdatingLoader";
 
@@ -27,7 +27,7 @@ export interface ComplaintsDispatchProps {
 export interface ComplaintsOwnProps {
   bookUrl: string;
   book: BookData;
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken: string;
   refreshCatalog: () => Promise<any>;
 }
@@ -39,7 +39,7 @@ export interface ComplaintsProps
 
 /** Tab on the book details page that shows existing complaints and lets an admin resolve
     complaints or add new complaints. */
-export class Complaints extends React.Component<ComplaintsProps, {}> {
+export class Complaints extends React.Component<ComplaintsProps> {
   constructor(props) {
     super(props);
     this.resolve = this.resolve.bind(this);

--- a/src/components/ConfigPage.tsx
+++ b/src/components/ConfigPage.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from "prop-types";
 import Header from "./Header";
 import Footer from "./Footer";
 import ConfigTabContainer from "./ConfigTabContainer";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import title from "../utils/title";
 
 export interface ConfigPageProps extends React.Props<ConfigPageProps> {
@@ -16,13 +16,13 @@ export interface ConfigPageProps extends React.Props<ConfigPageProps> {
 }
 
 export interface ConfigPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 
 /** System configuration page. Extracts parameters from its context
     and passes them to `ConfigTabContainer` as props. */
-export default class ConfigPage extends React.Component<ConfigPageProps, {}> {
+export default class ConfigPage extends React.Component<ConfigPageProps> {
   context: ConfigPageContext;
 
   static contextTypes: React.ValidationMap<ConfigPageContext> = {

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
-import buildStore from "../store";
+import buildStore, { RootState } from "../store";
 import { FeatureFlags, PathFor } from "../interfaces";
-import { State } from "../reducers/index";
 import Admin from "../models/Admin";
 import PathForProvider from "@thepalaceproject/web-opds-client/lib/components/context/PathForContext";
 import ActionCreator from "../actions";
@@ -25,7 +24,7 @@ export interface ContextProviderProps extends React.Props<ContextProvider> {
 export default class ContextProvider extends React.Component<
   ContextProviderProps
 > {
-  store: Store<State>;
+  store: Store<RootState>;
   admin: Admin;
   pathFor: PathFor;
 

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -8,6 +8,7 @@ import PathForProvider from "@thepalaceproject/web-opds-client/lib/components/co
 import ActionCreator from "../actions";
 
 export interface ContextProviderProps extends React.Props<ContextProvider> {
+  store?: Store<RootState>;
   csrfToken: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;
@@ -30,7 +31,7 @@ export default class ContextProvider extends React.Component<
 
   constructor(props) {
     super(props);
-    this.store = buildStore();
+    this.store = props.store ?? buildStore();
     this.admin = new Admin(props.roles || [], props.email || null);
     this.pathFor = (collectionUrl: string, bookUrl: string, tab?: string) => {
       let path = "/admin/web";

--- a/src/components/CustomListPage.tsx
+++ b/src/components/CustomListPage.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from "prop-types";
 import Header from "./Header";
 import Footer from "./Footer";
 import CustomLists from "./CustomLists";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 
 export interface CustomListPageProps extends React.Props<CustomListPageProps> {
   params: {
@@ -16,7 +16,7 @@ export interface CustomListPageProps extends React.Props<CustomListPageProps> {
 }
 
 export interface CustomListPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 

--- a/src/components/CustomLists.tsx
+++ b/src/components/CustomLists.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import DataFetcher from "@thepalaceproject/web-opds-client/lib/DataFetcher";
 import { adapter } from "@thepalaceproject/web-opds-client/lib/OPDSDataAdapter";
@@ -108,7 +108,7 @@ export interface CustomListsDispatchProps {
 }
 
 export interface CustomListsOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   library: string;
   editOrCreate?: string;
   identifier?: string;

--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -7,7 +7,7 @@ import ErrorMessage from "./ErrorMessage";
 import ProtocolFormField from "./ProtocolFormField";
 import { BookData, CustomListData, CustomListsData } from "../interfaces";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { Link } from "react-router";
 
 export interface CustomListsForBookStateProps {
@@ -27,7 +27,7 @@ export interface CustomListsForBookOwnProps {
   bookUrl: string;
   book: BookData;
   library: string;
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken: string;
   refreshCatalog: () => Promise<any>;
 }

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -5,7 +5,7 @@ import Header from "./Header";
 import Footer from "./Footer";
 import Stats from "./Stats";
 import CirculationEvents from "./CirculationEvents";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import title from "../utils/title";
 
 export interface DashboardPageProps extends React.Props<DashboardPageProps> {
@@ -15,22 +15,19 @@ export interface DashboardPageProps extends React.Props<DashboardPageProps> {
 }
 
 export interface DashboardPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
 }
 
 /** Page that shows high-level statistics about patrons and collections
     and a list of the most recent circulation events. */
-export default class DashboardPage extends React.Component<
-  DashboardPageProps,
-  {}
-> {
+export default class DashboardPage extends React.Component<DashboardPageProps> {
   context: DashboardPageContext;
 
   static contextTypes: React.ValidationMap<DashboardPageContext> = {
     editorStore: PropTypes.object.isRequired as React.Validator<Store>,
   };
 
-  static childContextTypes: React.ValidationMap<{}> = {
+  static childContextTypes: React.ValidationMap<any> = {
     library: PropTypes.func,
   };
 

--- a/src/components/DiagnosticsTabContainer.tsx
+++ b/src/components/DiagnosticsTabContainer.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/camelcase */
 import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { DiagnosticsData } from "../interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import DiagnosticsServiceType from "./DiagnosticsServiceType";
 import LoadingIndicator from "@thepalaceproject/web-opds-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
@@ -16,7 +15,7 @@ export interface DiagnosticsTabContainerDispatchProps {
 }
 
 export interface DiagnosticsTabContainerOwnProps extends TabContainerProps {
-  store: Store<State>;
+  store: Store<RootState>;
   goToTab: (tabName: string) => void;
 }
 
@@ -95,7 +94,7 @@ function mapStateToProps(state, ownProps: DiagnosticsTabContainerOwnProps) {
   };
 }
 
-function mapDispatchToProps(dispatch: Function) {
+function mapDispatchToProps(dispatch) {
   const actions = new ActionCreator();
   return {
     fetchDiagnostics: () => dispatch(actions.fetchDiagnostics()),

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -3,7 +3,7 @@ import { Store } from "redux";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import { SettingData } from "../interfaces";
 import { Alert } from "react-bootstrap";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import { Button } from "library-simplified-reusable-components";
 import LoadingIndicator from "@thepalaceproject/web-opds-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
@@ -29,7 +29,7 @@ export interface EditableConfigListDispatchProps<T> {
 }
 
 export interface EditableConfigListOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken: string;
   editOrCreate?: string;
   identifier?: string;
@@ -57,7 +57,7 @@ export interface EditFormProps<T, U> {
 }
 
 export interface AdditionalContentProps<T, U> {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken?: string;
   item?: U;
   type?: string;
@@ -80,7 +80,7 @@ export abstract class GenericEditableConfigList<
   T,
   U,
   V extends EditableConfigListProps<T>
-> extends React.Component<V, {}> {
+> extends React.Component<V> {
   context: { admin: Admin };
   static contextTypes = {
     admin: PropTypes.object.isRequired,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import { LibraryData, LibrariesData } from "../interfaces";
 import Admin from "../models/Admin";
@@ -28,7 +28,7 @@ export interface HeaderDispatchProps {
 }
 
 export interface HeaderOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
 }
 
 export interface HeaderProps
@@ -332,7 +332,7 @@ const ConnectedHeader = connect<
 /** HeaderWithStore is a wrapper component to pass the store as a prop to the
     ConnectedHeader, since it's not in the regular place in the context. */
 export default class HeaderWithStore extends React.Component<{}, {}> {
-  context: { editorStore: Store<State> };
+  context: { editorStore: Store<RootState> };
 
   static contextTypes = {
     editorStore: PropTypes.object.isRequired,

--- a/src/components/LanePage.tsx
+++ b/src/components/LanePage.tsx
@@ -4,7 +4,7 @@ import * as PropTypes from "prop-types";
 import Header from "./Header";
 import Footer from "./Footer";
 import Lanes from "./Lanes";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 
 export interface LanePageProps extends React.Props<LanePageProps> {
   params: {
@@ -15,7 +15,7 @@ export interface LanePageProps extends React.Props<LanePageProps> {
 }
 
 export interface LanePageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 

--- a/src/components/Lanes.tsx
+++ b/src/components/Lanes.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Link } from "react-router";
 import { Store } from "redux";
 import { connect } from "react-redux";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import DataFetcher from "@thepalaceproject/web-opds-client/lib/DataFetcher";
 import {
@@ -42,7 +42,7 @@ export interface LanesDispatchProps {
 }
 
 export interface LanesOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   library: string;
   editOrCreate?: string;
   identifier?: string;

--- a/src/components/ManagePatrons.tsx
+++ b/src/components/ManagePatrons.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ManagePatronsForm from "./ManagePatronsForm";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -16,11 +16,11 @@ export interface ManagePatronsProps extends React.Props<ManagePatronsProps> {
 }
 
 export interface ManagePatronsContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 
-export class ManagePatrons extends React.Component<ManagePatronsProps, {}> {
+export class ManagePatrons extends React.Component<ManagePatronsProps> {
   context: ManagePatronsContext;
 
   static contextTypes: React.ValidationMap<ManagePatronsContext> = {

--- a/src/components/ManagePatronsForm.tsx
+++ b/src/components/ManagePatronsForm.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import { PatronData } from "../interfaces";
@@ -21,7 +21,7 @@ export interface ManagePatronsFormDispatchProps {
 }
 
 export interface ManagePatronsFormOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken?: string;
   library: string;
 }
@@ -31,10 +31,7 @@ export interface ManagePatronsFormProps
     ManagePatronsFormDispatchProps,
     ManagePatronsFormOwnProps {}
 
-export class ManagePatronsForm extends React.Component<
-  ManagePatronsFormProps,
-  {}
-> {
+export class ManagePatronsForm extends React.Component<ManagePatronsFormProps> {
   private identifierRef = React.createRef<EditableInput>();
   constructor(props) {
     super(props);

--- a/src/components/ManagePatronsTabContainer.tsx
+++ b/src/components/ManagePatronsTabContainer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import {
   TabContainer,
@@ -13,7 +13,7 @@ import Admin from "../models/Admin";
 import ResetAdobeId from "./ResetAdobeId";
 
 export interface ManagePatronsTabContainerProps extends TabContainerProps {
-  store: Store<State>;
+  store: Store<RootState>;
   csrfToken: string;
   library: string;
   tab: string;

--- a/src/components/ResetAdobeId.tsx
+++ b/src/components/ResetAdobeId.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import { PatronData } from "../interfaces";
@@ -21,7 +21,7 @@ export interface ResetAdobeIdDispatchProps {
 }
 
 export interface ResetAdobeIdOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken?: string;
   library: string;
 }

--- a/src/components/SelfTests.tsx
+++ b/src/components/SelfTests.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { Store } from "redux";
 import { connect } from "react-redux";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import ActionCreator from "../actions";
 import { ServiceData, SelfTestsData, SelfTestsResult } from "../interfaces";
 import ErrorMessage from "./ErrorMessage";
@@ -24,7 +24,7 @@ export interface SelfTestsDispatchProps {
 
 export interface SelfTestsOwnProps {
   item?: ServiceData;
-  store?: Store<State>;
+  store?: Store<RootState>;
   type: string;
   sortByCollection: boolean;
   csrfToken?: string;

--- a/src/components/SelfTestsCategory.tsx
+++ b/src/components/SelfTestsCategory.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Store } from "redux";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import SelfTests from "./SelfTests";
 import {
   CollectionData,
@@ -15,12 +15,11 @@ export interface SelfTestsCategoryProps {
   linkName: string;
   csrfToken: string;
   items: CollectionData[] | PatronAuthServiceData[] | SearchServiceData[];
-  store: Store<State>;
+  store: Store<RootState>;
 }
 
 export default class SelfTestsCategory extends React.Component<
-  SelfTestsCategoryProps,
-  {}
+  SelfTestsCategoryProps
 > {
   handleUnnamed():
     | CollectionData[]

--- a/src/components/SelfTestsTabContainer.tsx
+++ b/src/components/SelfTestsTabContainer.tsx
@@ -9,7 +9,7 @@ import {
   PatronAuthServicesData,
   SearchServicesData,
 } from "../interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import LoadingIndicator from "@thepalaceproject/web-opds-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
@@ -26,7 +26,7 @@ export interface SelfTestsTabContainerDispatchProps {
 }
 
 export interface SelfTestsTabContainerOwnProps extends TabContainerProps {
-  store: Store<State>;
+  store: Store<RootState>;
   goToTab: (tabName: string) => void;
 }
 
@@ -132,10 +132,7 @@ function mapStateToProps(state, ownProps: SelfTestsTabContainerOwnProps) {
   };
 }
 
-function mapDispatchToProps(
-  dispatch: Function,
-  ownProps: SelfTestsTabContainerOwnProps
-) {
+function mapDispatchToProps(dispatch, ownProps: SelfTestsTabContainerOwnProps) {
   const actions = new ActionCreator();
   const itemTypes = [
     "Collections",

--- a/src/components/SetupPage.tsx
+++ b/src/components/SetupPage.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
 import IndividualAdmins from "./IndividualAdmins";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 
 export interface SetupPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 
@@ -15,7 +15,7 @@ export interface SetupPageContext {
     The page only allows setting up admin authentication. Once that's done, the
     page will automatically refresh so the admin can log in, and after that the
     full interface will show. */
-export default class SetupPage extends React.Component<{}, {}> {
+export default class SetupPage extends React.Component<object> {
   context: SetupPageContext;
 
   static contextTypes: React.ValidationMap<SetupPageContext> = {

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import { StatsData, LibrariesData, LibraryData } from "../interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import LoadingIndicator from "@thepalaceproject/web-opds-client/lib/components/LoadingIndicator";
 import ErrorMessage from "./ErrorMessage";
 import LibraryStats from "./LibraryStats";
@@ -22,7 +22,7 @@ export interface StatsDispatchProps {
 }
 
 export interface StatsOwnProps {
-  store?: Store<State>;
+  store?: Store<RootState>;
   library?: string;
 }
 
@@ -32,7 +32,7 @@ export interface StatsProps
     StatsOwnProps {}
 
 /** Displays statistics about patrons, licenses, and vendors from the server. */
-export class Stats extends React.Component<StatsProps, {}> {
+export class Stats extends React.Component<StatsProps> {
   render(): JSX.Element {
     let libraryData: LibraryData | null = null;
     for (const library of this.props.libraries || []) {

--- a/src/components/TabContainer.tsx
+++ b/src/components/TabContainer.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
 import { Navigate, PathFor } from "../interfaces";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 
 export interface TabContainerProps extends React.Props<TabContainerProps> {
-  store?: Store<State>;
+  store?: Store<RootState>;
   csrfToken?: string;
   tab: string;
   class?: string;

--- a/src/components/TroubleshootingCategoryPage.tsx
+++ b/src/components/TroubleshootingCategoryPage.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { Store } from "redux";
 import * as PropTypes from "prop-types";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import DiagnosticsTabContainer from "./DiagnosticsTabContainer";
 import SelfTestsTabContainer from "./SelfTestsTabContainer";
 
 export interface TroubleshootingCategoryPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 

--- a/src/components/TroubleshootingPage.tsx
+++ b/src/components/TroubleshootingPage.tsx
@@ -3,12 +3,12 @@ import { Store } from "redux";
 import * as PropTypes from "prop-types";
 import Header from "./Header";
 import Footer from "./Footer";
-import { State } from "../reducers/index";
+import { RootState } from "../store";
 import TroubleshootingTabContainer from "./TroubleshootingTabContainer";
 import title from "../utils/title";
 
 export interface TroubleshootingPageContext {
-  editorStore: Store<State>;
+  editorStore: Store<RootState>;
   csrfToken: string;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import buildStore from "./store";
+import { Provider } from "react-redux";
 import { Router, Route, browserHistory } from "react-router";
 import ContextProvider from "./components/ContextProvider";
 import { TOSContextProvider } from "./components/TOSContext";
@@ -63,40 +65,45 @@ class CirculationAdmin {
     const lanePagePath =
       "/admin/web/lanes(/:library)(/:editOrCreate)(/:identifier)";
 
+    const store = buildStore();
     const appElement = "opds-catalog";
     const app = config.settingUp ? (
-      <ContextProvider {...config}>
-        <SetupPage />
-      </ContextProvider>
+      <Provider store={store}>
+        <ContextProvider {...config} store={store}>
+          <SetupPage />
+        </ContextProvider>
+      </Provider>
     ) : (
-      <ContextProvider {...config}>
-        <TOSContextProvider
-          value={...[config.tos_link_text, config.tos_link_href]}
-        >
-          <Router history={browserHistory}>
-            <Route path={catalogEditorPath} component={CatalogPage} />
-            <Route path={customListPagePath} component={CustomListPage} />
-            <Route path={lanePagePath} component={LanePage} />
-            <Route
-              path="/admin/web/dashboard(/:library)"
-              component={DashboardPage}
-            />
-            <Route
-              path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)"
-              component={ConfigPage}
-            />
-            <Route path="/admin/web/account" component={AccountPage} />
-            <Route
-              path="/admin/web/patrons/:library(/:tab)"
-              component={ManagePatrons}
-            />
-            <Route
-              path="/admin/web/troubleshooting(/:tab)(/:subtab)"
-              component={TroubleshootingPage}
-            />
-          </Router>
-        </TOSContextProvider>
-      </ContextProvider>
+      <Provider store={store}>
+        <ContextProvider {...config} store={store}>
+          <TOSContextProvider
+            value={...[config.tos_link_text, config.tos_link_href]}
+          >
+            <Router history={browserHistory}>
+              <Route path={catalogEditorPath} component={CatalogPage} />
+              <Route path={customListPagePath} component={CustomListPage} />
+              <Route path={lanePagePath} component={LanePage} />
+              <Route
+                path="/admin/web/dashboard(/:library)"
+                component={DashboardPage}
+              />
+              <Route
+                path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)"
+                component={ConfigPage}
+              />
+              <Route path="/admin/web/account" component={AccountPage} />
+              <Route
+                path="/admin/web/patrons/:library(/:tab)"
+                component={ManagePatrons}
+              />
+              <Route
+                path="/admin/web/troubleshooting(/:tab)(/:subtab)"
+                component={TroubleshootingPage}
+              />
+            </Router>
+          </TOSContextProvider>
+        </ContextProvider>
+      </Provider>
     );
 
     // `react-axe` should only run in development and testing mode.

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,12 +6,18 @@ import {
   Store,
   Reducer,
 } from "redux";
-import catalogReducers from "@thepalaceproject/web-opds-client/lib/reducers/index";
-import editorReducers, { State } from "./reducers/index";
+import catalogReducers from "@thepalaceproject/web-opds-client/lib/reducers";
+import { State as CatalogState } from "@thepalaceproject/web-opds-client/lib/state";
+import editorReducers, { State as EditorState } from "./reducers/index";
 
-const thunk = require("redux-thunk").default;
+import thunk from "redux-thunk";
 
-const reducers: Reducer = combineReducers({
+export interface RootState {
+  editor: EditorState;
+  catalog: CatalogState;
+}
+
+export const reducers: Reducer = combineReducers({
   editor: editorReducers,
   catalog: catalogReducers,
 });
@@ -21,7 +27,7 @@ const composeEnhancers =
 
 /** Build a redux store with reducers specific to the admin interface
     as well as reducers from web-opds-client. */
-export default function buildStore(initialState?: State): Store<State> {
+export default function buildStore(initialState?: RootState): Store<RootState> {
   return createStore(
     reducers,
     initialState,


### PR DESCRIPTION
## Description

- Adds a RootState interface to reflect actual Redux store state.
- Introduces a Redux `Provider` container and ensures that both it and the existing `ContextProvider` container, which it now wraps, provide the same store.

## Motivation and Context

The `State` interface that was previously propagated reflected only the app-specific (so-called "editor") state, but did not include the state pulled in from the [web-opds-client](https://github.com/ThePalaceProject/web-opds-client) package (the "catalog" state). So that interface could not fully type the contents of the store. This mismatch also led to developer confusion.

The Redux `Provider` container has been added to enable us to start using the `useDispatch` and `useSelector` Redux hooks and custom hooks based on them. This will allow us to incrementally away from using the existing `ContextProvider` container to propagate the Redux store, which is an unconventional pattern in its own right.

## How Has This Been Tested?

- Spot checked functionality in local development environment.
- Tests pass locally.
[CI tests for this branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/4522522907/jobs/7965053335) passed.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
