### PR TITLE
Fix catalog search error when running dev-server.

### DIFF
--- a/webpack.dev-server.config.js
+++ b/webpack.dev-server.config.js
@@ -99,6 +99,29 @@ module.exports = (env) => {
   };
 
   /**
+   * Rewrites an OpenSearch description response. This changes back-end URLs in the feed to point
+   * to the local server instead. This is a simple find-and-replace.
+   *
+   * @param responseBuffer A buffer containing the response body.
+   * @param req The request.
+   * @returns
+   */
+  const rewriteOpenSearch = (responseBuffer, req) => {
+    const requestHost = req.headers.host;
+
+    if (!requestHost) {
+      return responseBuffer;
+    }
+
+    const osd = responseBuffer.toString("utf8");
+
+    return osd.replace(
+      new RegExp(backendUrl.origin, "g"),
+      `http://${requestHost}`
+    );
+  };
+
+  /**
    * Rewrites an OPDS response. This changes back-end URLs in the feed to point to the local server
    * instead. This is a simple find-and-replace.
    *
@@ -160,6 +183,10 @@ module.exports = (env) => {
 
         if (contentType.startsWith("text/html")) {
           return rewriteHTML(responseBuffer, req);
+        }
+
+        if (contentType.startsWith("application/opensearchdescription+xml")) {
+          return rewriteOpenSearch(responseBuffer, req);
         }
 
         return responseBuffer;

--- a/webpack.dev-server.config.js
+++ b/webpack.dev-server.config.js
@@ -99,8 +99,8 @@ module.exports = (env) => {
   };
 
   /**
-   * Rewrites an OpenSearch description response. This changes back-end URLs in the feed to point
-   * to the local server instead. This is a simple find-and-replace.
+   * Rewrites an OpenSearch description response. This changes back-end URLs in the description to
+   * point to the local server instead. This is a simple find-and-replace.
    *
    * @param responseBuffer A buffer containing the response body.
    * @param req The request.


### PR DESCRIPTION
## Description

During development, a local dev server can be run that proxies requests to a remote back-end, using the command `npm run dev-server -- --env=backend={url}`. The local proxy currently rewrites HTML and OPDS responses, changing URLs that point to the back-end to point to the local proxy, so that all requests from the UI will go through the proxy.

This enables rewriting of OpenSearch description responses as well, so that responses of type `application/opensearchdescription+xml` will have URLs that point to the back end changed to point to the local proxy.

## Motivation and Context

When running the dev server, catalog searches were broken, because they were going to an incorrect URL. Rewriting the  OpenSearch description to point to the correct local URL fixes this.

## How Has This Been Tested?

- Run `npm run dev-server -- --env=backend=https://minotaur.dev.palaceproject.io`
- Go to http://localhost:8080/admin
- Log in using minotaur credentials
- Open the catalog for any library
- Perform a search using the Search box in the upper right
The search should complete without error.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
