### PR TITLE
Add language=all param to custom list searches.

### DIFF
--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -2714,7 +2714,7 @@ describe("custom list editor reducer", () => {
             entryPoint: "Book",
             terms: "foo bar baz",
             sort: "title",
-            language: "eng",
+            language: "all",
             advanced: {
               include: {
                 query: null,
@@ -2748,7 +2748,7 @@ describe("custom list editor reducer", () => {
             entryPoint: "All",
             terms: "foo bar baz",
             sort: "title",
-            language: "eng",
+            language: "all",
             advanced: {
               include: {
                 query: null,
@@ -2782,7 +2782,7 @@ describe("custom list editor reducer", () => {
             entryPoint: "All",
             terms: "foo bar baz",
             sort: null,
-            language: "eng",
+            language: "all",
             advanced: {
               include: {
                 query: null,
@@ -2834,7 +2834,7 @@ describe("custom list editor reducer", () => {
       const library = "lib";
       const url = getCustomListEditorSearchUrl(state, library);
 
-      expect(url).to.equal("/lib/search?language=all&q=foo%20bar%20baz");
+      expect(url).to.equal("/lib/search?q=foo%20bar%20baz");
     });
   });
 });

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -2735,7 +2735,7 @@ describe("custom list editor reducer", () => {
       const url = getCustomListEditorSearchUrl(state, library);
 
       expect(url).to.equal(
-        "/lib/search?media=Book&order=title&q=foo%20bar%20baz"
+        "/lib/search?language=all&media=Book&order=title&q=foo%20bar%20baz"
       );
     });
 
@@ -2768,7 +2768,9 @@ describe("custom list editor reducer", () => {
       const library = "lib";
       const url = getCustomListEditorSearchUrl(state, library);
 
-      expect(url).to.equal("/lib/search?order=title&q=foo%20bar%20baz");
+      expect(url).to.equal(
+        "/lib/search?language=all&order=title&q=foo%20bar%20baz"
+      );
     });
 
     it("should omit the order param if sort is null", () => {
@@ -2800,7 +2802,7 @@ describe("custom list editor reducer", () => {
       const library = "lib";
       const url = getCustomListEditorSearchUrl(state, library);
 
-      expect(url).to.equal("/lib/search?q=foo%20bar%20baz");
+      expect(url).to.equal("/lib/search?language=all&q=foo%20bar%20baz");
     });
 
     it("should omit the language param if language is null", () => {
@@ -2832,7 +2834,7 @@ describe("custom list editor reducer", () => {
       const library = "lib";
       const url = getCustomListEditorSearchUrl(state, library);
 
-      expect(url).to.equal("/lib/search?q=foo%20bar%20baz");
+      expect(url).to.equal("/lib/search?language=all&q=foo%20bar%20baz");
     });
   });
 });

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -210,9 +210,13 @@ export const buildSearchUrl = (
   searchParams: CustomListEditorSearchParams,
   library: string
 ): string => {
-  const { entryPoint, terms, sort } = searchParams;
+  const { entryPoint, language, terms, sort } = searchParams;
 
-  const queryParams = ["language=all"];
+  const queryParams = [];
+
+  if (language) {
+    queryParams.push(`language=${encodeURIComponent(language)}`);
+  }
 
   if (entryPoint !== "All") {
     queryParams.push(`media=${encodeURIComponent(entryPoint)}`);

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -212,7 +212,7 @@ export const buildSearchUrl = (
 ): string => {
   const { entryPoint, terms, sort } = searchParams;
 
-  const queryParams = [];
+  const queryParams = ["language=all"];
 
   if (entryPoint !== "All") {
     queryParams.push(`media=${encodeURIComponent(entryPoint)}`);


### PR DESCRIPTION
## Description

This adds the `language=all` query parameter to all custom list searches.

## Motivation and Context

Only English titles were being returned in custom list search results.

JIRA: https://ebce-lyrasis.atlassian.net/browse/PP-80

## How Has This Been Tested?

- Run `npm run dev-server -- --env=backend=https://minotaur.dev.palaceproject.io`
- Go to http://localhost:8080/admin
- Log in using minotaur credentials
- Open the Lists screen for Minotaur Test Library
- Create a new list
- In Works to Include, search for _title contains jane eyre_
A French title ("Jane Eyre ou Les Mémoires d'une institutrice") and a German title ("Jane Eyre, die Waise von Lowood") should be included in the results.
- Add _language equals french_ to the search filters
The results should now contain only the French title.
- Delete the _language equals french_ filter
The English and German titles should reappear in the results.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
