### PR TITLE
Remove collection library registrations (PP-241)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -111,10 +111,6 @@ export default class ActionCreator extends BaseActionCreator {
     "REGISTER_LIBRARY_WITH_DISCOVERY_SERVICE";
   static readonly DISCOVERY_SERVICE_LIBRARY_REGISTRATIONS =
     "DISCOVERY_SERVICE_LIBRARY_REGISTRATIONS";
-  static readonly REGISTER_LIBRARY_WITH_COLLECTION =
-    "REGISTER_LIBRARY_WITH_COLLECTION";
-  static readonly COLLECTION_LIBRARY_REGISTRATIONS =
-    "COLLECTION_LIBRARY_REGISTRATIONS";
   static readonly CUSTOM_LISTS = "CUSTOM_LISTS";
   static readonly CUSTOM_LIST_DETAILS = "CUSTOM_LIST_DETAILS";
   static readonly CUSTOM_LIST_DETAILS_MORE = "CUSTOM_LIST_DETAILS_MORE";
@@ -777,23 +773,6 @@ export default class ActionCreator extends BaseActionCreator {
     const url = "/admin/discovery_service_library_registrations";
     return this.fetchJSON<LibraryRegistrationsData>(
       ActionCreator.DISCOVERY_SERVICE_LIBRARY_REGISTRATIONS,
-      url
-    ).bind(this);
-  }
-
-  registerLibraryWithCollection(data: FormData) {
-    const url = "/admin/collection_library_registrations";
-    return this.postForm(
-      ActionCreator.REGISTER_LIBRARY_WITH_COLLECTION,
-      url,
-      data
-    ).bind(this);
-  }
-
-  fetchCollectionLibraryRegistrations() {
-    const url = "/admin/collection_library_registrations";
-    return this.fetchJSON<LibraryRegistrationsData>(
-      ActionCreator.COLLECTION_LIBRARY_REGISTRATIONS,
       url
     ).bind(this);
   }

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -139,31 +139,16 @@ function mapStateToProps(state, ownProps) {
   if (state.editor.libraries && state.editor.libraries.data) {
     data.allLibraries = state.editor.libraries.data.libraries;
   }
-  if (
-    state.editor.collectionLibraryRegistrations &&
-    state.editor.collectionLibraryRegistrations.data
-  ) {
-    data.libraryRegistrations =
-      state.editor.collectionLibraryRegistrations.data.library_registrations;
-  }
   // fetchError = an error involving loading the list of collections; formError = an error upon
-  // submission of the create/edit form (including upon submitting a change to a library's registration).
+  // submission of the create/edit form.
   return {
     data: data,
     responseBody:
       state.editor.collections && state.editor.collections.successMessage,
     fetchError: state.editor.collections.fetchError,
-    formError:
-      state.editor.collections.formError ||
-      (state.editor.collectionLibraryRegistrations &&
-        state.editor.collectionLibraryRegistrations.fetchError) ||
-      (state.editor.registerLibraryWithCollection &&
-        state.editor.registerLibraryWithCollection.fetchError),
+    formError: state.editor.collections.formError,
     isFetching:
       state.editor.collections.isFetching || state.editor.collections.isEditing,
-    isFetchingLibraryRegistrations:
-      state.editor.collectionLibraryRegistrations &&
-      state.editor.collectionLibraryRegistrations.isFetching,
   };
 }
 
@@ -174,10 +159,6 @@ function mapDispatchToProps(dispatch, ownProps) {
     editItem: (data: FormData) => dispatch(actions.editCollection(data)),
     deleteItem: (identifier: string | number) =>
       dispatch(actions.deleteCollection(identifier)),
-    registerLibrary: (data: FormData) =>
-      dispatch(actions.registerLibraryWithCollection(data)),
-    fetchLibraryRegistrations: () =>
-      dispatch(actions.fetchCollectionLibraryRegistrations()),
   };
 }
 

--- a/src/reducers/collectionLibraryRegistrations.ts
+++ b/src/reducers/collectionLibraryRegistrations.ts
@@ -1,7 +1,0 @@
-import { LibraryRegistrationsData } from "../interfaces";
-import ActionCreator from "../actions";
-import createFetchEditReducer from "./createFetchEditReducer";
-
-export default createFetchEditReducer<LibraryRegistrationsData>(
-  ActionCreator.COLLECTION_LIBRARY_REGISTRATIONS
-);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -23,8 +23,6 @@ import catalogServices from "./catalogServices";
 import discoveryServices from "./discoveryServices";
 import registerLibraryWithDiscoveryService from "./registerLibraryWithDiscoveryService";
 import discoveryServiceLibraryRegistrations from "./discoveryServiceLibraryRegistrations";
-import registerLibraryWithCollection from "./registerLibraryWithCollection";
-import collectionLibraryRegistrations from "./collectionLibraryRegistrations";
 import customLists from "./customLists";
 import customListDetails, {
   FetchMoreCustomListDetails,
@@ -100,8 +98,6 @@ export interface State {
   discoveryServiceLibraryRegistrations: FetchEditState<
     LibraryRegistrationsData
   >;
-  registerLibraryWithCollection: RegisterLibraryState;
-  collectionLibraryRegistrations: FetchEditState<LibraryRegistrationsData>;
   customLists: FetchEditState<CustomListsData>;
   customListDetails: FetchMoreCustomListDetails<CollectionData>;
   customListEditor: CustomListEditorState;
@@ -144,8 +140,6 @@ export default combineReducers<State>({
   discoveryServices,
   registerLibraryWithDiscoveryService,
   discoveryServiceLibraryRegistrations,
-  registerLibraryWithCollection,
-  collectionLibraryRegistrations,
   customLists,
   customListDetails,
   customListEditor,

--- a/src/reducers/registerLibraryWithCollection.ts
+++ b/src/reducers/registerLibraryWithCollection.ts
@@ -1,7 +1,0 @@
-import { RequestError } from "@thepalaceproject/web-opds-client/lib/DataFetcher";
-import ActionCreator from "../actions";
-import createRegisterLibraryReducer from "./createRegisterLibraryReducer";
-
-export default createRegisterLibraryReducer(
-  ActionCreator.REGISTER_LIBRARY_WITH_COLLECTION
-);


### PR DESCRIPTION
## Description

Remove the register libraries handlers.

JIRA: [PP-241](https://ebce-lyrasis.atlassian.net/browse/PP-241)

## Motivation and Context

The changes in https://github.com/ThePalaceProject/circulation/pull/1276 removed the `collection_library_registrations` endpoint, so the admin UI is displaying an error when trying to access it. 

## How Has This Been Tested?

Minotaur has the CM changes deployed, so I was testing against: 
https://minotaur.dev.palaceproject.io

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-241]: https://ebce-lyrasis.atlassian.net/browse/PP-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ