### PR TITLE
Add quicksight dashboard

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -26,7 +26,7 @@ import {
   DiagnosticsData,
   FeatureFlags,
   SitewideAnnouncementsData,
-  StatisticsData,
+  StatisticsData, DashboardURIData,
 } from "./interfaces";
 import { CollectionData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import DataFetcher from "@thepalaceproject/web-opds-client/lib/DataFetcher";
@@ -190,6 +190,8 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly RESET_ADOBE_ID = "RESET_ADOBE_ID";
 
   static readonly DIAGNOSTICS = "DIAGNOSTICS";
+
+  static readonly DASHBOARD_URI : "DASHBOARD_URI"
 
   csrfToken: string;
 
@@ -1066,4 +1068,14 @@ export default class ActionCreator extends BaseActionCreator {
       value,
     };
   }
+
+  fetchDashboardUri(dashboardId: string) {
+    const url = "/admin/quicksight_embed/" + dashboardId;
+    return this.fetchJSON<DashboardURIData>(
+        ActionCreator.DASHBOARD_URI,
+        url
+    ).bind(this);
+  }
+
 }
+

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -26,7 +26,8 @@ import {
   DiagnosticsData,
   FeatureFlags,
   SitewideAnnouncementsData,
-  StatisticsData, DashboardURIData,
+  StatisticsData,
+  DashboardURIData,
 } from "./interfaces";
 import { CollectionData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import DataFetcher from "@thepalaceproject/web-opds-client/lib/DataFetcher";
@@ -190,8 +191,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly RESET_ADOBE_ID = "RESET_ADOBE_ID";
 
   static readonly DIAGNOSTICS = "DIAGNOSTICS";
-
-  static readonly DASHBOARD_URI : "DASHBOARD_URI"
+  static readonly DASHBOARD_URI: "DASHBOARD_URI";
 
   csrfToken: string;
 
@@ -1072,10 +1072,8 @@ export default class ActionCreator extends BaseActionCreator {
   fetchDashboardUri(dashboardId: string) {
     const url = "/admin/quicksight_embed/" + dashboardId;
     return this.fetchJSON<DashboardURIData>(
-        ActionCreator.DASHBOARD_URI,
-        url
+      ActionCreator.DASHBOARD_URI,
+      url
     ).bind(this);
   }
-
 }
-

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -190,7 +190,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly RESET_ADOBE_ID = "RESET_ADOBE_ID";
 
   static readonly DIAGNOSTICS = "DIAGNOSTICS";
-  static readonly QUICKSIGHT_EMBEDDED_URL: "QUICKSIGHT_EMBEDDED_URL";
+  static readonly QUICKSIGHT_EMBEDDED_URL = "QUICKSIGHT_EMBEDDED_URL";
 
   csrfToken: string;
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -26,7 +26,7 @@ import {
   FeatureFlags,
   SitewideAnnouncementsData,
   StatisticsData,
-  DashboardURIData,
+  QuickSightEmbeddedURLData,
 } from "./interfaces";
 import { CollectionData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import DataFetcher from "@thepalaceproject/web-opds-client/lib/DataFetcher";
@@ -190,7 +190,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly RESET_ADOBE_ID = "RESET_ADOBE_ID";
 
   static readonly DIAGNOSTICS = "DIAGNOSTICS";
-  static readonly DASHBOARD_URI: "DASHBOARD_URI";
+  static readonly QUICKSIGHT_EMBEDDED_URL: "QUICKSIGHT_EMBEDDED_URL";
 
   csrfToken: string;
 
@@ -1068,11 +1068,11 @@ export default class ActionCreator extends BaseActionCreator {
     };
   }
 
-  fetchQuicksightEmbedUri(dashboardId: string, ld: LibrariesData) {
+  fetchQuicksightEmbedUrl(dashboardId: string, ld: LibrariesData) {
     const library_uuids: string = ld.libraries.map((l) => l.uuid).join(",");
     const url = `/admin/quicksight_embed/${dashboardId}?libraryUuids=${library_uuids}`;
-    return this.fetchJSON<DashboardURIData>(
-      ActionCreator.DASHBOARD_URI,
+    return this.fetchJSON<QuickSightEmbeddedURLData>(
+      ActionCreator.QUICKSIGHT_EMBEDDED_URL,
       url
     ).bind(this);
   }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -22,7 +22,6 @@ import {
   RightsStatusData,
   CatalogServicesData,
   SelfTestsData,
-  PatronData,
   DiagnosticsData,
   FeatureFlags,
   SitewideAnnouncementsData,
@@ -1069,8 +1068,9 @@ export default class ActionCreator extends BaseActionCreator {
     };
   }
 
-  fetchDashboardUri(dashboardId: string) {
-    const url = "/admin/quicksight_embed/" + dashboardId;
+  fetchQuicksightEmbedUri(dashboardId: string, ld: LibrariesData) {
+    const library_uuids: string = ld.libraries.map((l) => l.uuid).join(",");
+    const url = `/admin/quicksight_embed/${dashboardId}?libraryUuids=${library_uuids}`;
     return this.fetchJSON<DashboardURIData>(
       ActionCreator.DASHBOARD_URI,
       url

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -7,6 +7,7 @@ import Footer from "./Footer";
 import Stats from "./Stats";
 import CirculationEvents from "./CirculationEvents";
 import title from "../utils/title";
+import QuicksightDashboard from "./QuicksightDashboard";
 
 export interface DashboardPageProps extends React.Props<DashboardPageProps> {
   params: {
@@ -48,6 +49,7 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
             store={this.context.editorStore}
             library={library}
           />
+          <QuicksightDashboard/>
         </main>
         <Footer />
       </div>

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -7,7 +7,6 @@ import Footer from "./Footer";
 import Stats from "./Stats";
 import CirculationEvents from "./CirculationEvents";
 import title from "../utils/title";
-import QuicksightDashboard from "./QuicksightDashboard";
 
 export interface DashboardPageProps extends React.Props<DashboardPageProps> {
   params: {
@@ -32,13 +31,11 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
     library: PropTypes.func,
   };
 
-
   getChildContext() {
     return {
       library: () => this.props.params.library,
     };
   }
-
 
   render(): JSX.Element {
     const { library } = this.props.params;
@@ -51,7 +48,6 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
             store={this.context.editorStore}
             library={library}
           />
-
         </main>
         <Footer />
       </div>

--- a/src/components/DashboardPage.tsx
+++ b/src/components/DashboardPage.tsx
@@ -32,11 +32,13 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
     library: PropTypes.func,
   };
 
+
   getChildContext() {
     return {
       library: () => this.props.params.library,
     };
   }
+
 
   render(): JSX.Element {
     const { library } = this.props.params;
@@ -45,11 +47,12 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
         <Header />
         <main className="body">
           <Stats library={library} />
+          <QuicksightDashboard dashboardId="library"/>
           <CirculationEvents
             store={this.context.editorStore}
             library={library}
           />
-          <QuicksightDashboard/>
+
         </main>
         <Footer />
       </div>

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -42,7 +42,7 @@ class QuicksightDashboard extends React.Component<
   }
   componentDidMount() {
     // Every time the component is mounted a fresh embed url must be fetched.
-    //TODO:  For whatever reason, the "this.props.libraries" variable was not being
+    // TODO:  For whatever reason, the "this.props.libraries" variable was not being
     // set when I tried to put this logic in the render method (nor did it work trying to access it in this method).
     // Clearly I am missing something. Also the embed url should be set via the action/reducer pattern,
     // but again I wasn't able to get things working following the pattern in Header.tsx so this is where I landed.

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -42,17 +42,16 @@ export class QuicksightDashboard extends React.Component<
     }
 
     this.props.fetchLibraries().then((libs) => {
-      const library_uuids: string = libs.libraries.map((l) => l.uuid).join(",");
-      let library_uuids_key_pair = "library_uuids=" + library_uuids;
-      // TODO Remove next line once https://github.com/ThePalaceProject/circulation/pull/1548
-      // is merged
-      library_uuids_key_pair = "libraryIds=1";
+      const library_uuids: string = libs.libraries
+        .slice(0, 5)
+        .map((l) => l.uuid)
+        .join(",");
       try {
         fetch(
           "/admin/quicksight_embed/" +
             this.props.dashboardId +
-            "?" +
-            library_uuids_key_pair
+            "?libraryUuids=" +
+            library_uuids
         )
           .then((response) => response.json())
           .then((data) => this.setState({ embedUrl: data["embedUrl"] }))
@@ -67,15 +66,12 @@ export class QuicksightDashboard extends React.Component<
 
   render(): JSX.Element {
     return (
-      <div className="quicksight-dashboard">
-        <h2>Quicksight Dashboard</h2>
-        <iframe
-          title="Quicksight Dashboard"
-          height="900"
-          width="1200"
-          src={this.state.embedUrl}
-        />
-      </div>
+      <iframe
+        title="Quicksight Dashboard"
+        height="1200"
+        width="100%"
+        src={this.state.embedUrl}
+      />
     );
   }
 }

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import ActionCreator from "../actions";
+
+export interface QuicksightDashboardStateProps {
+}
+
+export interface QuicksightDashboardDispatchProps {
+  fetchDashboardUri?: () => Promise<any>;
+}
+
+export interface QuicksightDashboardProps
+    extends QuicksightDashboardStateProps,QuicksightDashboardDispatchProps {}
+
+export interface QuicksightDashboardState {
+   dashboardId: string
+}
+
+
+
+export class QuicksightDashboard extends React.Component <
+    QuicksightDashboardProps,
+    QuicksightDashboardState
+>{
+  context: { dashboardId: boolean}
+
+  constructor(props) {
+    super(props);
+    this.state = {dashboardId: "library"}
+  }
+  render(): JSX.Element {
+    return (
+      <div className="quicksight-dashboard">
+        <h2>Quicksight Dashboard</h2>
+        <iframe src="https://www.amazon.com" height="800" width="1000"/>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    events: state.editor.circulationEvents.data || [],
+    fetchError: state.editor.circulationEvents.fetchError,
+    isLoaded: state.editor.circulationEvents.isLoaded,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  const actions = new ActionCreator();
+  return {
+    fetchDashboardUri: () => dispatch(actions.fetchDashboardUri(dispatch.dashboardId)),
+  };
+}
+
+export default QuicksightDashboard;

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -43,15 +43,11 @@ class QuicksightDashboard extends React.Component<
 
     this.props.fetchLibraries().then((libs) => {
       const library_uuids: string = libs.libraries
-        .slice(0, Math.min(1, 10))// TODO: remove this once  https://github.com/ThePalaceProject/circulation/pull/1577 is merged
         .map((l) => l.uuid)
         .join(",");
       try {
         fetch(
-          "/admin/quicksight_embed/" +
-            this.props.dashboardId +
-            "?libraryUuids=" +
-            library_uuids
+          `/admin/quicksight_embed/${this.props.dashboardId}?libraryUuids=${library_uuids}`
         )
           .then((response) => response.json())
           .then((data) => this.setState({ embedUrl: data["embedUrl"] }))

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -28,7 +28,7 @@ export interface QuicksightDashboardState {
   embedUrl: string;
 }
 
-export class QuicksightDashboard extends React.Component<
+class QuicksightDashboard extends React.Component<
   QuicksightDashboardProps,
   QuicksightDashboardState
 > {
@@ -43,7 +43,7 @@ export class QuicksightDashboard extends React.Component<
 
     this.props.fetchLibraries().then((libs) => {
       const library_uuids: string = libs.libraries
-        .slice(0, 5)
+        .slice(0, Math.min(1, 10))// TODO: remove this once  https://github.com/ThePalaceProject/circulation/pull/1577 is merged
         .map((l) => l.uuid)
         .join(",");
       try {
@@ -67,6 +67,7 @@ export class QuicksightDashboard extends React.Component<
   render(): JSX.Element {
     return (
       <iframe
+          role="iframe"
         title="Quicksight Dashboard"
         height="1200"
         width="100%"

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -72,7 +72,7 @@ class QuicksightDashboard extends React.Component<
   render(): JSX.Element {
     return (
       <iframe
-        title="Quicksight Dashboard"
+        title="Library Dashboard"
         height="1200"
         width="100%"
         src={this.state.embedUrl}

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
-import { DashboardURIData, LibrariesData, LibraryData } from "../interfaces";
+import {
+  QuickSightEmbeddedURLData,
+  LibrariesData,
+  LibraryData,
+} from "../interfaces";
 import { Store } from "redux";
 import { RootState } from "../store";
 import { connect } from "react-redux";
@@ -15,7 +19,7 @@ export interface QuicksightDashboardDispatchProps {
   fetchQuicksightEmbedUrl?: (
     dashboardId: string,
     ld: LibrariesData
-  ) => Promise<DashboardURIData>;
+  ) => Promise<QuickSightEmbeddedURLData>;
 }
 
 export interface QuicksightDashboardOwnProps {
@@ -41,6 +45,9 @@ class QuicksightDashboard extends React.Component<
     this.state = { embedUrl: null };
   }
   componentDidMount() {
+    if (this.state.embedUrl) {
+      return;
+    }
     // Every time the component is mounted a fresh embed url must be fetched.
     // TODO:  For whatever reason, the "this.props.libraries" variable was not being
     // set when I tried to put this logic in the render method (nor did it work trying to access it in this method).
@@ -88,7 +95,7 @@ function mapDispatchToProps(dispatch) {
     fetchQuicksightEmbedUrl: (
       dashboardId: string,
       librariesData: LibrariesData
-    ) => dispatch(actions.fetchQuicksightEmbedUri(dashboardId, librariesData)),
+    ) => dispatch(actions.fetchQuicksightEmbedUrl(dashboardId, librariesData)),
   };
 }
 

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { LibrariesData, LibraryData } from "../interfaces";
+import { DashboardURIData, LibrariesData, LibraryData } from "../interfaces";
 import { Store } from "redux";
 import { RootState } from "../store";
 import { connect } from "react-redux";
@@ -12,6 +12,10 @@ export interface QuicksightDashboardStateProps {
 
 export interface QuicksightDashboardDispatchProps {
   fetchLibraries?: () => Promise<LibrariesData>;
+  fetchQuicksightEmbedUrl?: (
+    dashboardId: string,
+    ld: LibrariesData
+  ) => Promise<DashboardURIData>;
 }
 
 export interface QuicksightDashboardOwnProps {
@@ -41,16 +45,12 @@ class QuicksightDashboard extends React.Component<
       return;
     }
 
+    const dashboardId = this.props.dashboardId;
     this.props.fetchLibraries().then((libs) => {
-      const library_uuids: string = libs.libraries
-        .map((l) => l.uuid)
-        .join(",");
       try {
-        fetch(
-          `/admin/quicksight_embed/${this.props.dashboardId}?libraryUuids=${library_uuids}`
-        )
-          .then((response) => response.json())
-          .then((data) => this.setState({ embedUrl: data["embedUrl"] }))
+        this.props
+          .fetchQuicksightEmbedUrl(dashboardId, libs)
+          .then((data) => this.setState({ embedUrl: data.embedUrl }))
           .catch((error) => {
             console.error(error);
           });
@@ -63,7 +63,6 @@ class QuicksightDashboard extends React.Component<
   render(): JSX.Element {
     return (
       <iframe
-          role="iframe"
         title="Quicksight Dashboard"
         height="1200"
         width="100%"
@@ -84,6 +83,10 @@ function mapDispatchToProps(dispatch) {
   const actions = new ActionCreator();
   return {
     fetchLibraries: () => dispatch(actions.fetchLibraries()),
+    fetchQuicksightEmbedUrl: (
+      dashboardId: string,
+      librariesData: LibrariesData
+    ) => dispatch(actions.fetchQuicksightEmbedUri(dashboardId, librariesData)),
   };
 }
 

--- a/src/components/QuicksightDashboard.tsx
+++ b/src/components/QuicksightDashboard.tsx
@@ -41,15 +41,17 @@ class QuicksightDashboard extends React.Component<
     this.state = { embedUrl: null };
   }
   componentDidMount() {
-    if (this.state.embedUrl) {
-      return;
-    }
-
-    const dashboardId = this.props.dashboardId;
+    // Every time the component is mounted a fresh embed url must be fetched.
+    //TODO:  For whatever reason, the "this.props.libraries" variable was not being
+    // set when I tried to put this logic in the render method (nor did it work trying to access it in this method).
+    // Clearly I am missing something. Also the embed url should be set via the action/reducer pattern,
+    // but again I wasn't able to get things working following the pattern in Header.tsx so this is where I landed.
+    // It's ugly but it works.
+    // Nevertheless it should be brought into alignment before it goes into production.
     this.props.fetchLibraries().then((libs) => {
       try {
         this.props
-          .fetchQuicksightEmbedUrl(dashboardId, libs)
+          .fetchQuicksightEmbedUrl(this.props.dashboardId, libs)
           .then((data) => this.setState({ embedUrl: data.embedUrl }))
           .catch((error) => {
             console.error(error);

--- a/src/components/QuicksightDashboardPage.tsx
+++ b/src/components/QuicksightDashboardPage.tsx
@@ -4,27 +4,24 @@ import { RootState } from "../store";
 import * as PropTypes from "prop-types";
 import Header from "./Header";
 import Footer from "./Footer";
-import Stats from "./Stats";
-import CirculationEvents from "./CirculationEvents";
 import title from "../utils/title";
 import QuicksightDashboard from "./QuicksightDashboard";
 
-export interface DashboardPageProps extends React.Props<DashboardPageProps> {
+export interface QuicksightDashboardPageProps extends React.Props<QuicksightDashboardPageProps> {
   params: {
     library?: string;
   };
 }
 
-export interface DashboardPageContext {
+export interface QuicksightDashboardPageContext {
   editorStore: Store<RootState>;
 }
 
-/** Page that shows high-level statistics about patrons and collections
-    and a list of the most recent circulation events. */
-export default class DashboardPage extends React.Component<DashboardPageProps> {
-  context: DashboardPageContext;
+/** Page holds quicksight dashboards. */
+export default class DashboardPage extends React.Component<QuicksightDashboardPageProps> {
+  context: QuicksightDashboardPageContext;
 
-  static contextTypes: React.ValidationMap<DashboardPageContext> = {
+  static contextTypes: React.ValidationMap<QuicksightDashboardPageContext> = {
     editorStore: PropTypes.object.isRequired as React.Validator<Store>,
   };
 
@@ -43,15 +40,10 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
   render(): JSX.Element {
     const { library } = this.props.params;
     return (
-      <div className="dashboard">
+      <div className="quicksight-dashboard">
         <Header />
         <main className="body">
-          <Stats library={library} />
-          <CirculationEvents
-            store={this.context.editorStore}
-            library={library}
-          />
-
+          <QuicksightDashboard dashboardId="library"/>
         </main>
         <Footer />
       </div>
@@ -59,6 +51,6 @@ export default class DashboardPage extends React.Component<DashboardPageProps> {
   }
 
   UNSAFE_componentWillMount() {
-    document.title = title("Dashboard");
+    document.title = title("Quicksight Dashboard");
   }
 }

--- a/src/components/QuicksightDashboardPage.tsx
+++ b/src/components/QuicksightDashboardPage.tsx
@@ -7,7 +7,8 @@ import Footer from "./Footer";
 import title from "../utils/title";
 import QuicksightDashboard from "./QuicksightDashboard";
 
-export interface QuicksightDashboardPageProps extends React.Props<QuicksightDashboardPageProps> {
+export interface QuicksightDashboardPageProps
+  extends React.Props<QuicksightDashboardPageProps> {
   params: {
     library?: string;
   };
@@ -18,7 +19,9 @@ export interface QuicksightDashboardPageContext {
 }
 
 /** Page holds quicksight dashboards. */
-export default class DashboardPage extends React.Component<QuicksightDashboardPageProps> {
+export default class QuicksightDashboardPage extends React.Component<
+  QuicksightDashboardPageProps
+> {
   context: QuicksightDashboardPageContext;
 
   static contextTypes: React.ValidationMap<QuicksightDashboardPageContext> = {
@@ -29,13 +32,11 @@ export default class DashboardPage extends React.Component<QuicksightDashboardPa
     library: PropTypes.func,
   };
 
-
   getChildContext() {
     return {
       library: () => this.props.params.library,
     };
   }
-
 
   render(): JSX.Element {
     const { library } = this.props.params;
@@ -43,7 +44,7 @@ export default class DashboardPage extends React.Component<QuicksightDashboardPa
       <div className="quicksight-dashboard">
         <Header />
         <main className="body">
-          <QuicksightDashboard dashboardId="library"/>
+          <QuicksightDashboard dashboardId="library" />
         </main>
         <Footer />
       </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -89,8 +89,8 @@ class CirculationAdmin {
                 component={DashboardPage}
               />
               <Route
-                  path="/admin/web/dashboard/quicksight(/:library)"
-                  component={QuicksightDashboardPage}
+                path="/admin/web/quicksight(/:library)"
+                component={QuicksightDashboardPage}
               />
               <Route
                 path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import CatalogPage from "./components/CatalogPage";
 import CustomListPage from "./components/CustomListPage";
 import LanePage from "./components/LanePage";
 import DashboardPage from "./components/DashboardPage";
+import QuicksightDashboardPage from "./components/QuicksightDashboardPage";
 import ConfigPage from "./components/ConfigPage";
 import AccountPage from "./components/AccountPage";
 import SetupPage from "./components/SetupPage";
@@ -86,6 +87,10 @@ class CirculationAdmin {
               <Route
                 path="/admin/web/dashboard(/:library)"
                 component={DashboardPage}
+              />
+              <Route
+                  path="/admin/web/dashboard/quicksight(/:library)"
+                  component={QuicksightDashboardPage}
               />
               <Route
                 path="/admin/web/config(/:tab)(/:editOrCreate)(/:identifier)"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -89,7 +89,7 @@ class CirculationAdmin {
                 component={DashboardPage}
               />
               <Route
-                path="/admin/web/quicksight(/:library)"
+                path="/admin/web/quicksight"
                 component={QuicksightDashboardPage}
               />
               <Route

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -470,3 +470,8 @@ export interface AdvancedSearchQuery {
 export interface AdvancedSearchData {
   query: AdvancedSearchQuery;
 }
+
+export interface DashboardURIData {
+  uri: string;
+}
+

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -472,6 +472,6 @@ export interface AdvancedSearchData {
 }
 
 export interface DashboardURIData {
-  uri: string;
+  embedUrl: string;
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -471,7 +471,6 @@ export interface AdvancedSearchData {
   query: AdvancedSearchQuery;
 }
 
-export interface DashboardURIData {
+export interface QuickSightEmbeddedURLData {
   embedUrl: string;
 }
-

--- a/src/stylesheets/quicksight-dashboard.scss
+++ b/src/stylesheets/quicksight-dashboard.scss
@@ -1,0 +1,7 @@
+.quicksight-dashboard {
+  .body {
+    height: 100%;
+    margin: 10px;
+    margin-top: 60px;
+  }
+}

--- a/tests/jest/components/QuicksightDashboard.test.tsx
+++ b/tests/jest/components/QuicksightDashboard.test.tsx
@@ -1,23 +1,29 @@
 import * as React from "react";
-import {screen, waitFor} from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import QuicksightDashboard from "../../../src/components/QuicksightDashboard";
-import {LibrariesData, LibraryData} from "../../../src/interfaces";
-import buildStore, {RootState} from "../../../src/store"
-import {setupServer} from "msw/node";
-import {rest} from "msw";
+import { LibrariesData, LibraryData } from "../../../src/interfaces";
+import buildStore, { RootState } from "../../../src/store";
+import { setupServer } from "msw/node";
+import { rest } from "msw";
 import renderWithContext from "../testUtils/renderWithContext";
 
-const libraries: LibrariesData = {libraries: [{uuid: "my-uuid"}]};
+const libraries: LibrariesData = { libraries: [{ uuid: "my-uuid" }] };
 const dashboardId = "test";
-const embedUrl = "http://embedUrl"
-const dashboardUrlData = {embedUrl: embedUrl}
+const embedUrl = "http://embedUrl";
+const dashboardUrlData = { embedUrl: embedUrl };
 
 describe("QuicksightDashboard", () => {
   const server = setupServer(
-      rest.get("*/admin/libraries", (req, res, ctx) => res(ctx.json(libraries))),
+    rest.get("*/admin/libraries", (req, res, ctx) => res(ctx.json(libraries))),
 
-      rest.get("*/admin/quicksight_embed/" + dashboardId + "?libraryUuids=" + libraries["libraries"][0]["uuid"], (req, res, ctx) => res(ctx.json(dashboardUrlData)))
+    rest.get(
+      "*/admin/quicksight_embed/" +
+        dashboardId +
+        "?libraryUuids=" +
+        libraries["libraries"][0]["uuid"],
+      (req, res, ctx) => res(ctx.json(dashboardUrlData))
+    )
   );
 
   beforeAll(() => {
@@ -29,23 +35,18 @@ describe("QuicksightDashboard", () => {
   });
 
   it("embed url is retrieved and set in iframe", async () => {
-
     const contextProviderProps = {
       csrfToken: "",
-      roles: [{role: "system"}],
-
+      roles: [{ role: "system" }],
     };
 
     renderWithContext(
-        <QuicksightDashboard
-            dashboardId={dashboardId}
-            store={buildStore()}
-        />,
-        contextProviderProps
+      <QuicksightDashboard dashboardId={dashboardId} store={buildStore()} />,
+      contextProviderProps
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('iframe')).toHaveAttribute("src", embedUrl)
+      expect(screen.getByRole("iframe")).toHaveAttribute("src", embedUrl);
     });
   });
 });

--- a/tests/jest/components/QuicksightDashboard.test.tsx
+++ b/tests/jest/components/QuicksightDashboard.test.tsx
@@ -46,7 +46,10 @@ describe("QuicksightDashboard", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("iframe")).toHaveAttribute("src", embedUrl);
+      expect(screen.getAllByTitle("Library Dashboard")[0]).toHaveAttribute(
+        "src",
+        embedUrl
+      );
     });
   });
 });

--- a/tests/jest/components/QuicksightDashboard.test.tsx
+++ b/tests/jest/components/QuicksightDashboard.test.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import {screen, waitFor} from "@testing-library/react";
+
+import QuicksightDashboard from "../../../src/components/QuicksightDashboard";
+import {LibrariesData, LibraryData} from "../../../src/interfaces";
+import buildStore, {RootState} from "../../../src/store"
+import {setupServer} from "msw/node";
+import {rest} from "msw";
+import renderWithContext from "../testUtils/renderWithContext";
+
+const libraries: LibrariesData = {libraries: [{uuid: "my-uuid"}]};
+const dashboardId = "test";
+const embedUrl = "http://embedUrl"
+const dashboardUrlData = {embedUrl: embedUrl}
+
+describe("QuicksightDashboard", () => {
+  const server = setupServer(
+      rest.get("*/admin/libraries", (req, res, ctx) => res(ctx.json(libraries))),
+
+      rest.get("*/admin/quicksight_embed/" + dashboardId + "?libraryUuids=" + libraries["libraries"][0]["uuid"], (req, res, ctx) => res(ctx.json(dashboardUrlData)))
+  );
+
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("embed url is retrieved and set in iframe", async () => {
+
+    const contextProviderProps = {
+      csrfToken: "",
+      roles: [{role: "system"}],
+
+    };
+
+    renderWithContext(
+        <QuicksightDashboard
+            dashboardId={dashboardId}
+            store={buildStore()}
+        />,
+        contextProviderProps
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('iframe')).toHaveAttribute("src", embedUrl)
+    });
+  });
+});


### PR DESCRIPTION
## Description

```
nvm install 18
nvm use 18
npm run dev-server -- --env=backend=https://minotaur.dev.palaceproject.io
```
Once you've logged in, to see the dashboard you need to go to:

http://localhost:8080/admin/web/quicksight

The URL is not exposed in the App (since I don't think it is quite ready for prime time).

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-517

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test.
Tested it manually.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
