### PR TITLE
Settings `menu` items unavailable when none already selected. (PP-1022)

### DIFF
--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -262,14 +262,15 @@ export default class InputList extends React.Component<
       }
     }
     // Items that have already been selected, and should be eliminated from the menu.
-    const listItems = this.state?.listItems
-      ? this.state.listItems
-      : this.props.value || this.props.setting.default || [];
+    const listItems =
+      this.state?.listItems ||
+      this.props.value ||
+      this.props.setting.default ||
+      [];
     // Items that haven't been selected yet.
-    const remainingOptions = listItems
+    return listItems
       ? allOptions.filter((o) => listItems.indexOf(o.props.value) < 0)
       : [];
-    return remainingOptions;
   }
 
   updateNewItem() {

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -23,7 +23,7 @@ export interface InputListProps {
   onEmpty?: string;
   title?: string;
   capitalize?: boolean;
-  onChange?: (value: any) => unknown;
+  onChange?: (value: any) => object;
   readOnly?: boolean;
   disableButton?: boolean;
 }
@@ -268,9 +268,7 @@ export default class InputList extends React.Component<
       this.props.setting.default ||
       [];
     // Items that haven't been selected yet.
-    return listItems
-      ? allOptions.filter((o) => listItems.indexOf(o.props.value) < 0)
-      : [];
+    return allOptions.filter((o) => !listItems.includes(o.props.value));
   }
 
   updateNewItem() {

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -16,20 +16,20 @@ export interface InputListProps {
   labelAndDescription?: (setting: SettingData) => JSX.Element[];
   setting: SettingData | CustomListsSetting;
   disabled: boolean;
-  value: Array<string | {} | JSX.Element>;
+  value: Array<string | object | JSX.Element>;
   altValue?: string;
   additionalData?: any;
   onSubmit?: any;
   onEmpty?: string;
   title?: string;
   capitalize?: boolean;
-  onChange?: (value: any) => {};
+  onChange?: (value: any) => unknown;
   readOnly?: boolean;
   disableButton?: boolean;
 }
 
 export interface InputListState {
-  listItems: Array<string | {}>;
+  listItems: Array<string | object>;
   newItem?: string;
   options?: JSX.Element[];
 }
@@ -225,7 +225,7 @@ export default class InputList extends React.Component<
     }
   }
 
-  renderToolTip(item: {} | string, format: string) {
+  renderToolTip(item: object | string, format: string) {
     const icons = {
       geographic: <LocatorIcon />,
     };
@@ -262,9 +262,9 @@ export default class InputList extends React.Component<
       }
     }
     // Items that have already been selected, and should be eliminated from the menu.
-    const listItems = this.state
+    const listItems = this.state?.listItems
       ? this.state.listItems
-      : this.props.value || this.props.setting.default;
+      : this.props.value || this.props.setting.default || [];
     // Items that haven't been selected yet.
     const remainingOptions = listItems
       ? allOptions.filter((o) => listItems.indexOf(o.props.value) < 0)
@@ -280,7 +280,7 @@ export default class InputList extends React.Component<
     this.setState({ ...this.state, ...{ newItem: (ref as any).getValue() } });
   }
 
-  async removeListItem(listItem: string | {}) {
+  async removeListItem(listItem: string | object) {
     await this.setState({
       listItems: this.state.listItems.filter(
         (stateListItem) => stateListItem !== listItem

--- a/src/components/__tests__/InputList-test.tsx
+++ b/src/components/__tests__/InputList-test.tsx
@@ -374,6 +374,24 @@ describe("InputList", () => {
       );
       expect(wrapper.state()["listItems"].includes("Option 1")).to.be.true;
     });
+    it("doesn't lose options when nothing is selected", () => {
+      const setting = {
+        ...wrapper.prop("setting"),
+        ...{ type: "menu", default: null, format: "narrow" },
+      };
+      wrapper = mount(
+        <InputList
+          createEditableInput={createEditableInput}
+          labelAndDescription={labelAndDescription}
+          value={null}
+          setting={setting}
+          disabled={false}
+        />,
+        { context }
+      );
+      const options = wrapper.find("option");
+      expect(options.length).to.equal(3);
+    });
     it("optionally eliminates already-selected options from the menu", () => {
       let options = wrapper.find("option");
       expect(options.length).to.equal(3);


### PR DESCRIPTION
## Description

- Fixes a check and a default value in the code that filters already-selected options from the list available options for `menu` settings.
- Adds a test that fails without this change, but passes with it.
- Some typing fixes in unrelated parts of the affected file, in order to appease `eslint`.

## Motivation and Context

The bug resulted in no options being available for selection if none were already selected.

[Jira [PP-1022](https://ebce-lyrasis.atlassian.net/browse/PP-1022)]

## How Has This Been Tested?

- Manually tested in a local development environment.
- Added a new confirmation test.
- Tests pass locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- N/A I have updated the documentation accordingly.
- [x] All new and existing tests passed.


[PP-1022]: https://ebce-lyrasis.atlassian.net/browse/PP-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ