### PR TITLE
Add fiction list filter (PP-1110)

### DIFF
--- a/src/components/AdvancedSearchBuilder.tsx
+++ b/src/components/AdvancedSearchBuilder.tsx
@@ -33,6 +33,12 @@ export const fields = [
   { value: "audience", label: "audience" },
   { value: "author", label: "author" },
   { value: "title", label: "title" },
+  {
+    value: "fiction",
+    label: "fiction",
+    options: ["fiction", "nonfiction"],
+    operators: ["eq"],
+  },
 ];
 
 export const operators = [

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -27,11 +27,20 @@ export default function AdvancedSearchFilterInput({
     setFilterKey(value);
     const selected = fields.find((field) => field.value === value);
 
-    // Set the value to either the default option, or blank when changing the filter type
+    // Set the value to either the first option, or blank.
     if (selected.options && selected.options.length) {
       setFilterValue(selected.options[0]);
     } else {
       setFilterValue("");
+    }
+
+    // Update operator if the filter doesn't support it.
+    if (
+      selected.operators &&
+      selected.operators.length &&
+      !selected.operators.find((op) => op === filterOp)
+    ) {
+      setFilterOp(selected.operators[0]);
     }
   };
 

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -25,6 +25,7 @@ export default function AdvancedSearchFilterInput({
 
   const handleKeyChange = (value) => {
     setFilterKey(value);
+    setFilterValue("");
   };
 
   const handleOpChange = () => {
@@ -64,6 +65,26 @@ export default function AdvancedSearchFilterInput({
   };
 
   const selectedField = fields.find((field) => field.value === filterKey);
+  const selectedFieldOperators =
+    selectedField.operators !== undefined
+      ? operators.filter((element) => {
+          return selectedField.operators.includes(element.value);
+        })
+      : operators;
+
+  const selectedFieldOptions = selectedField.options ?? [];
+  const selectedFieldElementType = selectedFieldOptions.length
+    ? "input"
+    : "select";
+  if (selectedFieldOptions.length !== 0) {
+    if (
+      !selectedFieldOptions.find((element) => {
+        return element === filterValue;
+      })
+    ) {
+      setFilterValue(selectedFieldOptions[0]);
+    }
+  }
 
   return (
     <form className="advanced-search-filter-input">
@@ -89,8 +110,9 @@ export default function AdvancedSearchFilterInput({
           onChange={handleOpChange}
           ref={opSelect}
           value={filterOp}
+          className="filter-operator"
         >
-          {operators.map(({ value, label }) => (
+          {selectedFieldOperators.map(({ value, label }) => (
             <option
               aria-selected={value === filterOp}
               key={value}
@@ -104,14 +126,23 @@ export default function AdvancedSearchFilterInput({
         <EditableInput
           aria-label="filter value"
           description={selectedField.helpText}
-          elementType="input"
+          elementType={selectedFieldElementType}
           type="text"
           optionalText={false}
           placeholder={selectedField.placeholder}
           ref={valueInput}
           value={filterValue}
           onChange={handleValueChange}
-        />
+          className="filter-value"
+        >
+          {selectedFieldOptions.length === 0
+            ? null
+            : selectedFieldOptions.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+        </EditableInput>
 
         <Button
           className="inverted inline"

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -25,7 +25,14 @@ export default function AdvancedSearchFilterInput({
 
   const handleKeyChange = (value) => {
     setFilterKey(value);
-    setFilterValue("");
+    const selected = fields.find((field) => field.value === value);
+
+    // Set the value to either the default option, or blank when changing the filter type
+    if (selected.options && selected.options.length) {
+      setFilterValue(selected.options[0]);
+    } else {
+      setFilterValue("");
+    }
   };
 
   const handleOpChange = () => {
@@ -74,17 +81,8 @@ export default function AdvancedSearchFilterInput({
 
   const selectedFieldOptions = selectedField.options ?? [];
   const selectedFieldElementType = selectedFieldOptions.length
-    ? "input"
-    : "select";
-  if (selectedFieldOptions.length !== 0) {
-    if (
-      !selectedFieldOptions.find((element) => {
-        return element === filterValue;
-      })
-    ) {
-      setFilterValue(selectedFieldOptions[0]);
-    }
-  }
+    ? "select"
+    : "input";
 
   return (
     <form className="advanced-search-filter-input">

--- a/src/components/AdvancedSearchFilterInput.tsx
+++ b/src/components/AdvancedSearchFilterInput.tsx
@@ -72,12 +72,9 @@ export default function AdvancedSearchFilterInput({
   };
 
   const selectedField = fields.find((field) => field.value === filterKey);
-  const selectedFieldOperators =
-    selectedField.operators !== undefined
-      ? operators.filter((element) => {
-          return selectedField.operators.includes(element.value);
-        })
-      : operators;
+  const selectedFieldOperators = selectedField.operators
+    ? operators.filter((op) => selectedField.operators.includes(op.value))
+    : operators;
 
   const selectedFieldOptions = selectedField.options ?? [];
   const selectedFieldElementType = selectedFieldOptions.length

--- a/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
+++ b/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
@@ -58,6 +58,43 @@ describe("AdvancedSearchFilterInput", () => {
     expect(options).to.have.length(fictionField.operators.length);
   });
 
+  it("should use the currently selected operator when changing filters", () => {
+    const sourceFilterButton = wrapper.find(
+      'input[type="radio"][value="data_source"]'
+    );
+    const fictionFilterButton = wrapper.find(
+      'input[type="radio"][value="fiction"]'
+    );
+    const fictionField = fields.find((element) => {
+      return element.value === "fiction";
+    });
+
+    const operatorOptions = wrapper.find(".filter-operator select");
+    operatorOptions.getDOMNode().value = "regex";
+    operatorOptions.simulate("change");
+
+    sourceFilterButton.getDOMNode().checked = true;
+    sourceFilterButton.simulate("change");
+
+    expect(operatorOptions.getDOMNode().value).to.equal("regex");
+
+    // unless the operator is not supported by the filter.
+    fictionFilterButton.getDOMNode().checked = true;
+    fictionFilterButton.simulate("change");
+
+    expect(operatorOptions.getDOMNode().value).to.equal(
+      fictionField.operators[0]
+    );
+
+    // the new operator will be persisted when changing back to source filter
+    sourceFilterButton.getDOMNode().checked = true;
+    sourceFilterButton.simulate("change");
+
+    expect(operatorOptions.getDOMNode().value).to.equal(
+      fictionField.operators[0]
+    );
+  });
+
   it("should render a text input for value entry", () => {
     const valueSelect = wrapper.find(".filter-value select");
     const valueInput = wrapper.find('.filter-value input[type="text"]');

--- a/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
+++ b/src/components/__tests__/AdvancedSearchFilterInput-test.tsx
@@ -43,10 +43,57 @@ describe("AdvancedSearchFilterInput", () => {
     });
   });
 
-  it("should render a text input for value entry", () => {
-    const valueInput = wrapper.find('input[type="text"]');
+  it("should restrict the operator selection, if the filter requests it", () => {
+    const fictionRadioButton = wrapper.find(
+      'input[type="radio"][value="fiction"]'
+    );
+    fictionRadioButton.getDOMNode().checked = true;
+    fictionRadioButton.simulate("change");
 
+    const options = wrapper.find(".filter-operator select > option");
+    const fictionField = fields.find((element) => {
+      return element.value === "fiction";
+    });
+
+    expect(options).to.have.length(fictionField.operators.length);
+  });
+
+  it("should render a text input for value entry", () => {
+    const valueSelect = wrapper.find(".filter-value select");
+    const valueInput = wrapper.find('.filter-value input[type="text"]');
+
+    expect(valueSelect).to.have.length(0);
     expect(valueInput).to.have.length(1);
+  });
+
+  it("should render a select for value selection, if the filter requests it", () => {
+    const fictionRadioButton = wrapper.find(
+      'input[type="radio"][value="fiction"]'
+    );
+    fictionRadioButton.getDOMNode().checked = true;
+    fictionRadioButton.simulate("change");
+
+    const valueSelect = wrapper.find(".filter-value select");
+    const valueInput = wrapper.find('.filter-value input[type="text"]');
+
+    expect(valueSelect).to.have.length(1);
+    expect(valueInput).to.have.length(0);
+  });
+
+  it("should clear the current value when changing the filter", () => {
+    const valueInput = wrapper.find(".filter-value input");
+
+    valueInput.getDOMNode().value = "ABC";
+    valueInput.simulate("change");
+
+    const filterRadioButton = wrapper.find(
+      'input[type="radio"][value="data_source"]'
+    );
+
+    filterRadioButton.getDOMNode().checked = true;
+    filterRadioButton.simulate("change");
+
+    expect(valueInput.getDOMNode().value).to.equal("");
   });
 
   it("should render an Add Filter button", () => {

--- a/src/stylesheets/advanced_search.scss
+++ b/src/stylesheets/advanced_search.scss
@@ -19,6 +19,12 @@
       width: 40em;
     }
 
+    .filter-operator {
+      select {
+        width: 15em;
+      }
+    }
+
     .filter-key-options {
       .form-group {
         margin: 5px 20px 0 2px;;

--- a/src/stylesheets/advanced_search.scss
+++ b/src/stylesheets/advanced_search.scss
@@ -15,8 +15,10 @@
       }
     }
 
-    input[type="text"] {
-      width: 40em;
+    .filter-value {
+      input[type="text"],select {
+        width: 40em;
+      }
     }
 
     .filter-operator {


### PR DESCRIPTION
## Description

Add a new filter to the list search that allows filtering on `fiction` and `nonfiction`. If the new filter is selected, the input is replaced with a select list, so that the values you can enter are restricted to `fiction` and `nonfiction` since these are the only two valid values for the field. 

Any feedback on this one would be great. It does accomplish what is asked in the ticket, and I think it works from the user perspective, in my testing at least. I only know enough to be dangerous about react though, so there may be better ways to accomplish what I'm doing here.

## Motivation and Context

Would like to be able to filter custom lists by `fiction` status. See PP-1110.

## How Has This Been Tested?

Tested against gorgon running the admin interface locally with the blackstone collection.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
