### PR TITLE
Update some GitHub action versions. (PP-1285)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js 💻
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Node.js 💻
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         registry-url: https://registry.npmjs.org/

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,18 +17,18 @@ jobs:
 
     steps:
       - name: Checkout repo to sync
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: code
 
       - name: Checkout CI scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'ThePalaceProject/ci-scripts'
           path: ci
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
 

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -16,19 +16,19 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Install Node.js 💻
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
 
       - name: Set up Python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: pull_request
+on: [push]
 
 jobs:
   test:
@@ -7,10 +7,10 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Node.js 💻
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
## Description

- Updates the versions of some GitHub actions in our workflows.
- Also allows the `Test` workflow run on any push, rather than just on PRs.

## Motivation and Context

I was having some trouble with hangs on the `test.yml` workflow and I was also seeing errors like this in the workflow logs:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

[Jira [PP-1285](https://ebce-lyrasis.atlassian.net/browse/PP-1285)]

## How Has This Been Tested?

- Some testing locally with [`act` v0.2.62](https://github.com/nektos/act).
- Some parts need to be verified on GitHub.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[PP-1285]: https://ebce-lyrasis.atlassian.net/browse/PP-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ