### PR TITLE
dev-server handles relative redirects without crashing.

### DIFF
--- a/webpack.dev-server.config.js
+++ b/webpack.dev-server.config.js
@@ -67,7 +67,7 @@ module.exports = (env) => {
       return;
     }
 
-    const locationUrl = new URL(location);
+    const locationUrl = new URL(location, backendUrl);
 
     if (locationUrl.host !== backendUrl.host) {
       return;


### PR DESCRIPTION
## Description

Let's the `dev-server` properly handle redirects to relative URLs.

## Motivation and Context

Previously, redirects to relative URLs cause the `dev-server to crash like this:
```
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:405:5)
    at new URL (node:internal/url:676:13)
    at rewriteLocationHeader (/Users/Shared/src/tpp/circulation-admin/webpack.dev-server.config.js:70:25)
    at /Users/Shared/src/tpp/circulation-admin/webpack.dev-server.config.js:176:9
    at IncomingMessage.<anonymous> (/Users/Shared/src/tpp/circulation-admin/node_modules/http-proxy-middleware/dist/handlers/response-interceptor.js:24:57)
    at IncomingMessage.emit (node:events:529:35)
    at endReadableNT (node:internal/streams/readable:1400:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  input: '/relative/url',
  code: 'ERR_INVALID_URL'
}
```

## How Has This Been Tested?

Manually tested locally, redirecting to both relative and absolute URLs.

## Checklist:

- N/A - I have updated the documentation accordingly.
- N/A - All new and existing tests passed.
