### PR TITLE
Adds per library book un/suppression. (PP-985)

### DIFF
--- a/src/components/BookDetailsEditorSuppression.tsx
+++ b/src/components/BookDetailsEditorSuppression.tsx
@@ -1,0 +1,130 @@
+import * as React from "react";
+import { Button } from "library-simplified-reusable-components";
+import { LinkData } from "../interfaces";
+import ConfirmationModalWithOutcome, {
+  SHOW_CONFIRMATION,
+  SHOW_OUTCOME,
+  ModalState,
+} from "./ConfirmationModalWithOutcome";
+import ErrorMessage, { pdString } from "./ErrorMessage";
+import { SuppressionMutationMethodType } from "../features/book/bookEditorSlice";
+
+type BookDetailsEditorPerLibraryVisibilityProps = {
+  link: LinkData;
+  onConfirm: () => SuppressionMutationMethodType;
+  onComplete: () => void;
+  buttonContent: string;
+  buttonTitle: string;
+  className?: string;
+  buttonDisabled: boolean;
+  confirmationTitle?: string;
+  confirmationBody?: React.ReactElement;
+  confirmationButtonContent?: string;
+  confirmationButtonTitle?: string;
+  dismissOutcomeButtonContent?: string;
+  dismissOutcomeButtonTitle?: string;
+  defaultSuccessMessage?: React.ReactElement;
+  defaultFailureMessage?: React.ReactElement;
+};
+
+const BookDetailsEditorSuppression = ({
+  link,
+  onConfirm,
+  onComplete = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+  buttonContent,
+  buttonTitle = buttonContent,
+  className = "",
+  buttonDisabled,
+  confirmationTitle = "Confirm",
+  confirmationBody = <p>Are you sure?</p>,
+  confirmationButtonContent = "Confirm",
+  confirmationButtonTitle = "Confirm action.",
+  defaultSuccessMessage = <p>Success!</p>,
+  defaultFailureMessage = <p>Something went wrong.</p>,
+}: BookDetailsEditorPerLibraryVisibilityProps) => {
+  const [modalState, setModalState] = React.useState<ModalState>(undefined);
+  const [outcomeMessage, setOutcomeMessage] = React.useState<
+    React.ReactElement
+  >(null);
+  const [confirmed, setConfirmed] = React.useState(false);
+
+  const reset = () => {
+    confirmed && onComplete();
+    setConfirmed(false);
+    setModalState(undefined);
+    setOutcomeMessage(null);
+  };
+  const modalIsVisible = () => {
+    return !!modalState;
+  };
+  const showModal = () => {
+    setModalState(SHOW_CONFIRMATION);
+  };
+  const localOnConfirm = async () => {
+    onConfirm()
+      .unwrap()
+      .then((resolved) => {
+        setOutcomeMessage(
+          <span>
+            ✅{" "}
+            {
+              (resolved?.message
+                ? resolved.message
+                : defaultSuccessMessage) as React.ReactElement
+            }
+          </span>
+        );
+      })
+      .catch((error) => {
+        let errorMessage: React.ReactElement;
+        if (!error) {
+          errorMessage = defaultFailureMessage;
+        } else {
+          let response: string;
+          if (error.data?.detail && error.data?.title && error.data?.status) {
+            response = `${pdString}: ${JSON.stringify(error.data)}`;
+          } else {
+            response = `<pre>${JSON.stringify(error, undefined, 2)}</pre>`;
+          }
+          errorMessage = (
+            <ErrorMessage
+              error={{ url: link.href, status: error?.status, response }}
+            />
+          );
+        }
+        setOutcomeMessage(<span>❌ {errorMessage}</span>);
+      });
+    setModalState(SHOW_OUTCOME);
+    setConfirmed(true);
+  };
+
+  return (
+    <>
+      {!!link && (
+        <Button
+          className={className}
+          disabled={buttonDisabled || modalIsVisible()}
+          content={buttonContent}
+          title={buttonTitle}
+          callback={showModal}
+        />
+      )}
+      {modalIsVisible() && (
+        <ConfirmationModalWithOutcome
+          modalState={modalState}
+          onClose={reset}
+          onConfirm={localOnConfirm}
+          onDismissOutcome={reset}
+          confirmationTitle={confirmationTitle}
+          confirmationBody={confirmationBody}
+          confirmationButtonContent={confirmationButtonContent}
+          confirmationButtonTitle={confirmationButtonTitle}
+          outcomeTitle="Result"
+          outcomeBody={outcomeMessage}
+        />
+      )}
+    </>
+  );
+};
+
+export default BookDetailsEditorSuppression;

--- a/src/components/ConfirmationModalWithOutcome.tsx
+++ b/src/components/ConfirmationModalWithOutcome.tsx
@@ -1,0 +1,118 @@
+import * as React from "react";
+import { Modal } from "react-bootstrap";
+import { Button } from "library-simplified-reusable-components";
+
+export const SHOW_CONFIRMATION = "requestConfirmation";
+export const SHOW_OUTCOME = "displayOutcome";
+export type ModalState =
+  | typeof SHOW_CONFIRMATION
+  | typeof SHOW_OUTCOME
+  | undefined;
+
+export type ConfirmationModalWithOutcomeProps = {
+  modalState: ModalState;
+  onClose: () => void;
+  onConfirm: () => void;
+  onDismissOutcome?: () => void;
+  confirmationTitle?: string;
+  confirmationBody?: React.ReactElement;
+  confirmationButtonContent?: string;
+  confirmationButtonTitle?: string;
+  confirmationButtonDisabled?: boolean;
+  cancelButtonContent?: string;
+  cancelButtonTitle?: string;
+  outcomeTitle?: string;
+  outcomeBody?: React.ReactElement;
+  dismissOutcomeButtonContent?: string;
+  dismissOutcomeButtonTitle?: string;
+};
+
+export const ConfirmationModalWithOutcome = ({
+  modalState,
+  onClose,
+  onConfirm,
+  onDismissOutcome = onClose,
+  confirmationTitle = "Confirm",
+  confirmationBody = <p>Are you sure?</p>,
+  confirmationButtonContent = "Confirm",
+  confirmationButtonTitle = "Confirm action.",
+  confirmationButtonDisabled = false,
+  cancelButtonContent = "Cancel",
+  cancelButtonTitle = "Cancel action.",
+  outcomeTitle = "Result",
+  outcomeBody = <p>Action performed.</p>,
+  dismissOutcomeButtonContent = "Dismiss",
+  dismissOutcomeButtonTitle = "Dismiss outcome.",
+}: ConfirmationModalWithOutcomeProps) => {
+  switch (modalState) {
+    case SHOW_CONFIRMATION:
+      return renderModal({
+        show: true,
+        onHide: onClose,
+        title: confirmationTitle,
+        content: (
+          <>
+            <div>{confirmationBody}</div>
+            <Button
+              className="left-align small inline"
+              onClick={onConfirm}
+              title={confirmationButtonTitle}
+              content={confirmationButtonContent}
+              disabled={confirmationButtonDisabled}
+            />
+            <Button
+              className="inverted left-align small inline"
+              callback={onClose}
+              title={cancelButtonTitle}
+              content={cancelButtonContent}
+            />
+          </>
+        ),
+      });
+    case SHOW_OUTCOME:
+      return renderModal({
+        show: true,
+        onHide: onDismissOutcome,
+        title: outcomeTitle,
+        className: "confirmation-modal",
+        content: (
+          <>
+            <div>{outcomeBody}</div>
+            <Button
+              className="inverted left-align small inline"
+              callback={onDismissOutcome}
+              title={dismissOutcomeButtonTitle}
+              content={dismissOutcomeButtonContent}
+            />
+          </>
+        ),
+      });
+    default:
+      return null;
+  }
+};
+
+const renderModal = ({
+  show = true,
+  onHide,
+  title = undefined,
+  content = undefined,
+  footer = undefined,
+  className = "",
+}) => {
+  return (
+    <Modal className={className} show={show} onHide={onHide}>
+      {!!title && (
+        <Modal.Header>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+      )}
+      {!!content && (
+        <Modal.Body style={{ overflow: "wrap" }}>{content}</Modal.Body>
+      )}
+      {!!footer && <Modal.Footer>{footer}</Modal.Footer>}
+    </Modal>
+  );
+};
+
+export default ConfirmationModalWithOutcome;

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -41,7 +41,6 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps> {
       let response;
       try {
         response = JSON.parse(this.props.error.response).detail;
-        console.log("error response from parse", response);
       } catch (e) {
         response = this.props.error.response;
         // The response might be a problem detail document encoded as a string rather than as JSON;
@@ -51,20 +50,10 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps> {
           response = this.parseProblemDetail(response, pdString);
           errorMessageHeader = response.title ? response.title : "Error";
           errorMessageText = `${response.description}${response.status}: ${response.detail}`;
-          console.log("this is a problem detail", {
-            response,
-            errorMessageHeader,
-            errorMessageText,
-          });
         }
       }
       if (!errorMessageText) {
         errorMessageText = `Error: ${response}`;
-        console.log("this is not a problem detail", {
-          response,
-          errorMessageHeader,
-          errorMessageText,
-        });
       }
       alertElement = (
         <Alert bsStyle="danger">

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -9,6 +9,8 @@ export interface ErrorMessageProps {
   tryAgain?: () => any;
 }
 
+export const pdString = "Remote service returned a problem detail document";
+
 /** Shows a bootstrap error message at the top of the page when there's a bad
     response from the server. */
 export default class ErrorMessage extends React.Component<ErrorMessageProps> {
@@ -39,20 +41,30 @@ export default class ErrorMessage extends React.Component<ErrorMessageProps> {
       let response;
       try {
         response = JSON.parse(this.props.error.response).detail;
+        console.log("error response from parse", response);
       } catch (e) {
         response = this.props.error.response;
         // The response might be a problem detail document encoded as a string rather than as JSON;
         // if so, we need to parse it and display the relevant information from it
         // (rather than just displaying the entire string, which is hard to read)
-        const pdString = "Remote service returned a problem detail document";
         if (this.isProblemDetail(response, pdString)) {
           response = this.parseProblemDetail(response, pdString);
           errorMessageHeader = response.title ? response.title : "Error";
           errorMessageText = `${response.description}${response.status}: ${response.detail}`;
+          console.log("this is a problem detail", {
+            response,
+            errorMessageHeader,
+            errorMessageText,
+          });
         }
       }
       if (!errorMessageText) {
         errorMessageText = `Error: ${response}`;
+        console.log("this is not a problem detail", {
+          response,
+          errorMessageHeader,
+          errorMessageText,
+        });
       }
       alertElement = (
         <Alert bsStyle="danger">

--- a/src/components/__tests__/BookDetailsEditor-test.tsx
+++ b/src/components/__tests__/BookDetailsEditor-test.tsx
@@ -8,6 +8,10 @@ import { BookDetailsEditor } from "../BookDetailsEditor";
 import { Button } from "library-simplified-reusable-components";
 import BookEditForm from "../BookEditForm";
 import ErrorMessage from "../ErrorMessage";
+import {
+  PER_LIBRARY_SUPPRESS_REL,
+  PER_LIBRARY_UNSUPPRESS_REL,
+} from "../../features/book/bookEditorSlice";
 
 describe("BookDetailsEditor", () => {
   let fetchBookData;
@@ -16,6 +20,8 @@ describe("BookDetailsEditor", () => {
   let fetchLanguages;
   let postBookData;
   let dispatchProps;
+  let suppressBook;
+  let unsuppressBook;
 
   beforeEach(() => {
     fetchBookData = stub();
@@ -23,12 +29,16 @@ describe("BookDetailsEditor", () => {
     fetchMedia = stub();
     fetchLanguages = stub();
     postBookData = stub();
+    suppressBook = stub();
+    unsuppressBook = stub();
     dispatchProps = {
       fetchBookData,
       fetchRoles,
       fetchMedia,
       fetchLanguages,
       postBookData,
+      suppressBook,
+      unsuppressBook,
     };
   });
 
@@ -81,34 +91,31 @@ describe("BookDetailsEditor", () => {
     expect(header.text()).to.contain("title");
   });
 
-  it("shows button form for hide link", () => {
-    const hideLink = {
+  it("shows button form for per-library hide link", () => {
+    const suppressPerLibraryLink = {
       href: "href",
-      rel: "http://librarysimplified.org/terms/rel/hide",
+      rel: PER_LIBRARY_SUPPRESS_REL,
     };
-    const wrapper = shallow(
+    const wrapper = mount(
       <BookDetailsEditor
-        bookData={{ id: "id", title: "title", hideLink: hideLink }}
+        bookData={{ id: "id", title: "title", suppressPerLibraryLink }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}
       />
     );
-    const hide = (wrapper.instance() as any).hide;
-
     const hideButton = wrapper.find(Button);
     expect(hideButton.prop("content")).to.equal("Hide");
-    expect(hideButton.prop("callback")).to.equal(hide);
   });
 
   it("shows button form for restore link", () => {
-    const restoreLink = {
+    const unsuppressPerLibraryLink = {
       href: "href",
-      rel: "http://librarysimplified.org/terms/rel/restore",
+      rel: PER_LIBRARY_UNSUPPRESS_REL,
     };
-    const wrapper = shallow(
+    const wrapper = mount(
       <BookDetailsEditor
-        bookData={{ id: "id", title: "title", restoreLink: restoreLink }}
+        bookData={{ id: "id", title: "title", unsuppressPerLibraryLink }}
         bookUrl="url"
         csrfToken="token"
         {...dispatchProps}
@@ -118,7 +125,6 @@ describe("BookDetailsEditor", () => {
 
     const restoreButton = wrapper.find(Button);
     expect(restoreButton.prop("content")).to.equal("Restore");
-    expect(restoreButton.prop("callback")).to.equal(restore);
   });
 
   it("shows button form for refresh link", () => {

--- a/src/editorAdapter.ts
+++ b/src/editorAdapter.ts
@@ -1,5 +1,24 @@
-import { BookData } from "./interfaces";
-import { OPDSEntry } from "opds-feed-parser";
+import { BookData, LinkData } from "./interfaces";
+import { OPDSEntry, OPDSLink } from "opds-feed-parser";
+import {
+  PER_LIBRARY_SUPPRESS_REL,
+  PER_LIBRARY_UNSUPPRESS_REL,
+} from "./features/book/bookEditorSlice";
+
+/** Convert an OPDS link to a LinkData object. */
+const opdsLinkToLinkData = (link: OPDSLink | undefined): LinkData => {
+  if (!link) {
+    return link;
+  }
+  const {
+    href,
+    rel,
+    role = undefined,
+    title = undefined,
+    type = undefined,
+  } = link;
+  return { ...link, href, rel, title, type, role };
+};
 
 /** Extract metadata and links from an OPDS entry for use on the
     book details page. */
@@ -10,6 +29,14 @@ export default function adapter(data: OPDSEntry): BookData {
 
   const restoreLink = data.links.find((link) => {
     return link.rel === "http://librarysimplified.org/terms/rel/restore";
+  });
+
+  const suppressPerLibraryLink = data.links.find((link) => {
+    return link.rel === PER_LIBRARY_SUPPRESS_REL;
+  });
+
+  const unsuppressPerLibraryLink = data.links.find((link) => {
+    return link.rel === PER_LIBRARY_UNSUPPRESS_REL;
   });
 
   const refreshLink = data.links.find((link) => {
@@ -68,6 +95,11 @@ export default function adapter(data: OPDSEntry): BookData {
   for (const author of data.authors) {
     authors.push(Object.assign({}, author, { role: "aut" }));
   }
+  const contributors = data.contributors?.map((contributor) => ({
+    name: contributor.name,
+    role: contributor?.role,
+    uri: contributor?.uri,
+  }));
 
   let rating;
   try {
@@ -88,28 +120,27 @@ export default function adapter(data: OPDSEntry): BookData {
   const imageLink = data.links.find((link) => {
     return link.rel === "http://opds-spec.org/image";
   });
-  let coverUrl;
-  if (imageLink) {
-    coverUrl = imageLink.href;
-  }
+  const coverUrl: string | undefined = imageLink?.href;
 
   return {
     id: data.id,
     title: data.title,
     authors: authors,
-    contributors: data.contributors,
+    contributors: contributors,
     subtitle: data.subtitle,
     summary: data.summary.content,
     audience: audience && audience.term,
     targetAgeRange: targetAgeRange,
     fiction: fiction,
     categories: categories,
-    hideLink: hideLink,
-    restoreLink: restoreLink,
-    refreshLink: refreshLink,
-    editLink: editLink,
-    issuesLink: issuesLink,
-    changeCoverLink: changeCoverLink,
+    hideLink: opdsLinkToLinkData(hideLink),
+    restoreLink: opdsLinkToLinkData(restoreLink),
+    refreshLink: opdsLinkToLinkData(refreshLink),
+    suppressPerLibraryLink: opdsLinkToLinkData(suppressPerLibraryLink),
+    unsuppressPerLibraryLink: opdsLinkToLinkData(unsuppressPerLibraryLink),
+    editLink: opdsLinkToLinkData(editLink),
+    issuesLink: opdsLinkToLinkData(issuesLink),
+    changeCoverLink: opdsLinkToLinkData(changeCoverLink),
     series: data.series && data.series.name,
     seriesPosition: data.series && data.series.position,
     medium: medium,

--- a/src/features/api/apiSlice.ts
+++ b/src/features/api/apiSlice.ts
@@ -1,0 +1,8 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const api = createApi({
+  reducerPath: "api",
+  baseQuery: fetchBaseQuery({ baseUrl: "" }),
+  tagTypes: [],
+  endpoints: () => ({}),
+});

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,6 +41,8 @@ export interface BookData {
   hideLink?: LinkData;
   restoreLink?: LinkData;
   refreshLink?: LinkData;
+  suppressPerLibraryLink?: LinkData;
+  unsuppressPerLibraryLink?: LinkData;
   editLink?: LinkData;
   issuesLink?: LinkData;
   changeCoverLink?: LinkData;

--- a/src/store.ts
+++ b/src/store.ts
@@ -2,6 +2,7 @@ import { configureStore } from "@reduxjs/toolkit";
 
 import catalogReducers from "@thepalaceproject/web-opds-client/lib/reducers/index";
 import { State as CatalogState } from "@thepalaceproject/web-opds-client/lib/state";
+import { api } from "./features/api/apiSlice";
 import bookEditorSlice from "./features/book/bookEditorSlice";
 import editorReducers, { State as EditorState } from "./reducers/index";
 
@@ -18,9 +19,14 @@ export default function buildStore(initialState?: CombinedState) {
       editor: editorReducers,
       catalog: catalogReducers,
       bookEditor: bookEditorSlice,
+      [api.reducerPath]: api.reducer,
     },
     preloadedState: initialState,
     devTools: process.env.NODE_ENV !== "production",
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+      }).concat(api.middleware),
   });
 }
 

--- a/tests/jest/components/BookEditor.test.tsx
+++ b/tests/jest/components/BookEditor.test.tsx
@@ -1,0 +1,199 @@
+import * as React from "react";
+import { renderWithProviders } from "../testUtils/withProviders";
+import userEvent from "@testing-library/user-event";
+import {
+  bookEditorApiEndpoints,
+  PER_LIBRARY_SUPPRESS_REL,
+  PER_LIBRARY_UNSUPPRESS_REL,
+} from "../../../src/features/book/bookEditorSlice";
+import { BookDetailsEditor } from "../../../src/components/BookDetailsEditor";
+import { expect } from "chai";
+import { store } from "../../../src/store";
+import * as fetchMock from "fetch-mock-jest";
+
+describe("BookDetails", () => {
+  const suppressPerLibraryLink = {
+    href: "/suppress/href",
+    rel: PER_LIBRARY_SUPPRESS_REL,
+  };
+  const unsuppressPerLibraryLink = {
+    href: "/unsuppress/href",
+    rel: PER_LIBRARY_UNSUPPRESS_REL,
+  };
+
+  let fetchBookData;
+  let fetchRoles;
+  let fetchMedia;
+  let fetchLanguages;
+  let postBookData;
+  let dispatchProps;
+  const suppressBook = jest.fn().mockImplementation((url: string) =>
+    store.dispatch(
+      bookEditorApiEndpoints.endpoints.suppressBook.initiate({
+        url,
+        csrfToken: "token",
+      })
+    )
+  );
+  const unsuppressBook = jest.fn().mockImplementation((url: string) =>
+    store.dispatch(
+      bookEditorApiEndpoints.endpoints.unsuppressBook.initiate({
+        url,
+        csrfToken: "token",
+      })
+    )
+  );
+
+  beforeAll(() => {
+    fetchMock
+      .post("/suppress/href", {
+        status: 200,
+        body: { message: "Successfully suppressed book availability." },
+      })
+      .delete("/unsuppress/href", {
+        status: 200,
+        body: { message: "Successfully unsuppressed book availability." },
+      });
+  });
+  beforeEach(() => {
+    fetchBookData = jest.fn();
+    fetchRoles = jest.fn();
+    fetchMedia = jest.fn();
+    fetchLanguages = jest.fn();
+    postBookData = jest.fn();
+    dispatchProps = {
+      fetchBookData,
+      fetchRoles,
+      fetchMedia,
+      fetchLanguages,
+      postBookData,
+      suppressBook,
+      unsuppressBook,
+    };
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.resetHistory();
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+    fetchMock.restore();
+  });
+
+  it("uses modal for suppress book confirmation", async () => {
+    // Configure standard constructors so that RTK Query works in tests with FetchMockJest
+    Object.assign(fetchMock.config, {
+      fetch,
+      Headers,
+      Request,
+      Response,
+    });
+
+    const user = userEvent.setup();
+
+    const { getByRole, getByText, queryByRole } = renderWithProviders(
+      <BookDetailsEditor
+        bookData={{ id: "id", title: "title", suppressPerLibraryLink }}
+        bookUrl="url"
+        csrfToken="token"
+        {...dispatchProps}
+      />
+    );
+
+    // The `Hide` button should be present.
+    const hideButton = getByRole("button", { name: "Hide" });
+
+    // Clicking `Hide` should show the book suppression modal.
+    await user.click(hideButton);
+    getByRole("heading", { level: 4, name: "Suppressing Availability" });
+    getByText(/to hide this title from your library's catalog/);
+    let confirmButton = getByRole("button", { name: "Suppress Availability" });
+    let cancelButton = getByRole("button", { name: "Cancel" });
+
+    // Clicking `Cancel` should close the modal.
+    await user.click(cancelButton);
+    confirmButton = queryByRole("button", { name: "Suppress Availability" });
+    cancelButton = queryByRole("button", { name: "Cancel" });
+    expect(confirmButton).to.be.null;
+    expect(cancelButton).to.be.null;
+
+    // Clicking `Hide` again should show the modal again.
+    await user.click(hideButton);
+    confirmButton = getByRole("button", { name: "Suppress Availability" });
+
+    // Clicking the confirmation button should invoke the API and show a confirmation.
+    await user.click(confirmButton);
+    getByRole("heading", { level: 4, name: "Result" });
+    getByText(/Successfully suppressed book availability/);
+    getByRole("button", { name: "Dismiss" });
+
+    // Check that the API was invoked.
+    expect(suppressBook.mock.calls.length).to.equal(1);
+    expect(suppressBook.mock.calls[0][0]).to.equal("/suppress/href");
+    const fetchCalls = fetchMock.calls();
+    expect(fetchCalls.length).to.equal(1);
+    const fetchCall = fetchCalls[0];
+    const fetchOptions = fetchCalls[0][1];
+    expect(fetchCall[0]).to.equal("/suppress/href");
+    expect(fetchOptions["headers"]["X-CSRF-Token"]).to.contain("token");
+    expect(fetchOptions["method"]).to.equal("POST");
+  });
+  it("uses modal for unsuppress book confirmation", async () => {
+    // Configure standard constructors so that RTK Query works in tests with FetchMockJest
+    Object.assign(fetchMock.config, {
+      fetch,
+      Headers,
+      Request,
+      Response,
+    });
+
+    const user = userEvent.setup();
+
+    const { getByRole, getByText, queryByRole } = renderWithProviders(
+      <BookDetailsEditor
+        bookData={{ id: "id", title: "title", unsuppressPerLibraryLink }}
+        bookUrl="url"
+        csrfToken="token"
+        {...dispatchProps}
+      />
+    );
+
+    // The `Restore` button should be present.
+    const restoreButton = getByRole("button", { name: "Restore" });
+
+    // Clicking `Restore` should show the book un/suppression modal.
+    await user.click(restoreButton);
+    getByRole("heading", { level: 4, name: "Restoring Availability" });
+    getByText(/to make this title visible in your library's catalog/);
+    let confirmButton = getByRole("button", { name: "Restore Availability" });
+    let cancelButton = getByRole("button", { name: "Cancel" });
+
+    // Clicking `Cancel` should close the modal.
+    await user.click(cancelButton);
+    confirmButton = queryByRole("button", { name: "Restore Availability" });
+    cancelButton = queryByRole("button", { name: "Cancel" });
+    expect(confirmButton).to.be.null;
+    expect(cancelButton).to.be.null;
+
+    // Clicking `Restore` again should show the modal again.
+    await user.click(restoreButton);
+    confirmButton = getByRole("button", { name: "Restore Availability" });
+
+    // Clicking the confirmation button should invoke the API and show a confirmation.
+    await user.click(confirmButton);
+    getByRole("heading", { level: 4, name: "Result" });
+    getByText(/Successfully unsuppressed book availability/);
+    getByRole("button", { name: "Dismiss" });
+
+    // Check that the API was invoked.
+    expect(unsuppressBook.mock.calls.length).to.equal(1);
+    expect(unsuppressBook.mock.calls[0][0]).to.equal("/unsuppress/href");
+    const fetchCalls = fetchMock.calls();
+    expect(fetchCalls.length).to.equal(1);
+    const fetchCall = fetchCalls[0];
+    const fetchOptions = fetchCalls[0][1];
+    expect(fetchCall[0]).to.equal("/unsuppress/href");
+    expect(fetchOptions["headers"]["X-CSRF-Token"]).to.contain("token");
+    expect(fetchOptions["method"]).to.equal("DELETE");
+  });
+});

--- a/tests/jest/testUtils/withProviders.tsx
+++ b/tests/jest/testUtils/withProviders.tsx
@@ -1,18 +1,25 @@
 import * as React from "react";
+import { Provider, ProviderProps } from "react-redux";
 import ContextProvider, {
   ContextProviderProps,
 } from "../../../src/components/ContextProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, RenderOptions, RenderResult } from "@testing-library/react";
 import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
+import { store } from "../../../src/store";
 
 export type TestProviderWrapperOptions = {
+  reduxProviderProps?: ProviderProps;
   contextProviderProps?: Partial<ContextProviderProps>;
   queryClient?: QueryClient;
 };
 export type TestRenderWrapperOptions = TestProviderWrapperOptions & {
   renderOptions?: Omit<RenderOptions, "queries">;
 };
+
+// The `store` argument is required for the Redux Provider and should
+// be the same for both the Redux Provider and the ContextProvider.
+const defaultReduxStore = store;
 
 // The `csrfToken` context provider prop is required, so we provide
 // a default value here, so it can be easily merged with other props.
@@ -26,11 +33,15 @@ const defaultContextProviderProps: ContextProviderProps = {
  * a React element for testing.
  *
  * @param {TestProviderWrapperOptions} options
+ * @param options.reduxProviderProps Props to pass to the Redux `Provider` wrapper
  * @param {ContextProviderProps} options.contextProviderProps Props to pass to the ContextProvider wrapper
  * @param {QueryClient} options.queryClient A `tanstack/react-query` QueryClient
  * @returns {React.FunctionComponent} A React component that wraps children with our providers
  */
 export const componentWithProviders = ({
+  reduxProviderProps = {
+    store: defaultReduxStore,
+  },
   contextProviderProps = {
     csrfToken: "",
     featureFlags: defaultFeatureFlags,
@@ -40,11 +51,16 @@ export const componentWithProviders = ({
   const effectiveContextProviderProps = {
     ...defaultContextProviderProps,
     ...contextProviderProps,
+    ...reduxProviderProps.store, // Context and Redux Provider stores must match.
   };
   const wrapper = ({ children }) => (
-    <ContextProvider {...effectiveContextProviderProps}>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </ContextProvider>
+    <Provider {...reduxProviderProps}>
+      <ContextProvider {...effectiveContextProviderProps}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </ContextProvider>
+    </Provider>
   );
   wrapper.displayName = "TestWrapperComponent";
   return wrapper;


### PR DESCRIPTION
## Description

Adds the ability to suppress/unsuppress book visibility at the library level in the book detail editor.

## Motivation and Context

[Jira [PP-985](https://ebce-lyrasis.atlassian.net/browse/PP-985)]

## How Has This Been Tested?

- Manual functional tests in local development environment.
- All new and existing tests passing locally.
- [CI tests for associated feature branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/9755717515) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
