### PR TITLE
Use `asset/resource` type for SASS font support with WebPack 5. (PP-1513)

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -49,7 +49,11 @@ module.exports = {
         use: ["ts-loader"],
       },
       {
-        test: /\.(ttf|woff|eot|svg|png|woff2|gif|jpg)(\?[\s\S]+)?$/,
+        test: /\.(ttf|woff|eot|woff2)(\?[\s\S]+)?$/,
+        type: "asset/resource",
+      },
+      {
+        test: /\.(svg|png|gif|jpg)(\?[\s\S]+)?$/,
         use: ["url-loader?limit=100000"],
       },
     ],
@@ -60,9 +64,9 @@ module.exports = {
     },
     extensions: [".ts", ".tsx", ".js", ".scss"],
     fallback: {
-      "stream": require.resolve("stream-browserify"),
-      "timers": require.resolve("timers-browserify"),
-      "url": require.resolve("url")
-    }
+      stream: require.resolve("stream-browserify"),
+      timers: require.resolve("timers-browserify"),
+      url: require.resolve("url"),
+    },
   },
 };


### PR DESCRIPTION
## Description

Fixes issues rendering Font Awesome fonts.

## Motivation and Context

Fonts were not rendering.

[Jira [PP-1513](https://ebce-lyrasis.atlassian.net/browse/PP-1513)]

## How Has This Been Tested?

- Tested locally via dev-server against development server.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/10411305910) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1513]: https://ebce-lyrasis.atlassian.net/browse/PP-1513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ