### PR TITLE
Hide inventory report text when button hidden. (PP-1649)

### DIFF
--- a/src/components/StatsUsageReportsGroup.tsx
+++ b/src/components/StatsUsageReportsGroup.tsx
@@ -42,22 +42,24 @@ const StatsUsageReportsGroup = ({
           <StatsGroup heading={heading} description={description}>
             <>
               {inventoryReportsEnabled && library && (
-                <Button
-                  callback={(() => setShowReportForm(true)) as any}
-                  content={
-                    <>
-                      Request Report &nbsp;&nbsp;
-                      <i className="fa fa-regular fa-envelope" />
-                    </>
-                  }
-                  title="Request an inventory report."
-                  disabled={showReportForm}
-                />
+                <>
+                  <Button
+                    callback={(() => setShowReportForm(true)) as any}
+                    content={
+                      <>
+                        Request Report &nbsp;&nbsp;
+                        <i className="fa fa-regular fa-envelope" />
+                      </>
+                    }
+                    title="Request an inventory report."
+                    disabled={showReportForm}
+                  />
+                  <div className="stat-group-description">
+                    These reports provide up-to-date data on both inventory and
+                    holds for library at the time of the request.
+                  </div>
+                </>
               )}
-              <div className="stat-group-description">
-                These reports provide up-to-date data on both inventory and
-                holds for library at the time of the request.
-              </div>
             </>
           </StatsGroup>
         </li>

--- a/tests/jest/components/Stats.test.tsx
+++ b/tests/jest/components/Stats.test.tsx
@@ -389,12 +389,14 @@ describe("Dashboard Statistics", () => {
             roles,
             quicksightPagePath: fakeQuickSightHref,
           };
-          const { container, getByRole, queryByRole } = renderWithProviders(
-            <Stats library={sampleLibraryKey} />,
-            {
-              contextProviderProps,
-            }
-          );
+          const {
+            container,
+            getByRole,
+            queryByRole,
+            queryByText,
+          } = renderWithProviders(<Stats library={sampleLibraryKey} />, {
+            contextProviderProps,
+          });
 
           // We should always render a Usage reports group when a library is specified.
           getByRole("heading", {
@@ -404,11 +406,23 @@ describe("Dashboard Statistics", () => {
           const usageReportLink = getByRole("link", { name: /View Usage/i });
           expect(usageReportLink).toHaveAttribute("href", fakeQuickSightHref);
 
-          const result = queryByRole("button", { name: /Request Report/i });
+          const requestButton = queryByRole("button", {
+            name: /Request Report/i,
+          });
+          const blurb = queryByText(
+            /These reports provide up-to-date data on both inventory and holds/i
+          );
+
+          // The inventory report blurb should be visible only when the button is.
+          if (requestButton) {
+            expect(blurb).not.toBeNull();
+          } else {
+            expect(blurb).toBeNull();
+          }
 
           // Clean up the container after each render.
           document.body.removeChild(container);
-          return result;
+          return requestButton;
         };
 
         // If the feature flag is set, the button should be visible only to sysadmins.


### PR DESCRIPTION
## Description

- Hides the inventory request description text when the request button is hidden.
- Add verification tests to the test suite.

## Motivation and Context

Having an explanation for a control that is not visible is confusing.

[Jira [PP-1649](https://ebce-lyrasis.atlassian.net/browse/PP-1649)]

## How Has This Been Tested?

- Manually tested locally.
- Tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/10566881352) pass for associated branch.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1649]: https://ebce-lyrasis.atlassian.net/browse/PP-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ