### PR TITLE
Add feature flag for to restrict QuickSight link to sysadmins. (PP-1724)

### DIFF
--- a/src/businessRules/roleBasedAccess.ts
+++ b/src/businessRules/roleBasedAccess.ts
@@ -8,6 +8,14 @@ type HasLibraryKeyProps = {
   [key: string]: unknown;
 };
 
+// If the `quicksightOnlyForSysadmins` feature flag is set, only system
+// admins should see the QuickSight link.
+export const useMaySeeQuickSightLink = (_: HasLibraryKeyProps): boolean => {
+  const admin = useAppAdmin();
+  const onlyForSysAdmins = useAppFeatureFlags().quicksightOnlyForSysadmins;
+  return !onlyForSysAdmins || admin.isSystemAdmin();
+};
+
 // If the `reportsOnlyForSysadmins` feature flag is set, only system admins
 // may request inventory reports.
 export const useMayRequestInventoryReports = (

--- a/src/components/LibraryStats.tsx
+++ b/src/components/LibraryStats.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { LibraryStatistics } from "../interfaces";
 import {
   useMayRequestInventoryReports,
+  useMaySeeQuickSightLink,
   useMayViewCollectionBarChart,
 } from "../businessRules/roleBasedAccess";
 import StatsTotalCirculationsGroup from "./StatsTotalCirculationsGroup";
@@ -45,6 +46,7 @@ const LibraryStats = ({ stats, library }: LibraryStatsProps) => {
   const inventoryReportRequestEnabled = useMayRequestInventoryReports({
     library,
   });
+  const quicksightLinkEnabled = useMaySeeQuickSightLink({ library });
   const quicksightPageUrl = useAppContext().quicksightPagePath;
 
   let statsLayoutClass: string, dashboardTitle: string, implementation: string;
@@ -74,6 +76,7 @@ const LibraryStats = ({ stats, library }: LibraryStatsProps) => {
             <StatsUsageReportsGroup
               library={library}
               inventoryReportsEnabled={inventoryReportRequestEnabled}
+              quicksightLinkEnabled={quicksightLinkEnabled}
               usageDataTarget="_blank" // open in new tab or window
               usageDataHref={quicksightPageUrl}
             />

--- a/src/components/StatsCollectionsGroup.tsx
+++ b/src/components/StatsCollectionsGroup.tsx
@@ -20,7 +20,7 @@ const StatsCollectionsGroup = ({
 }: Props) => {
   const content =
     collections.length === 0 ? (
-      <span className="no-collections">No associated collections.</span>
+      <span className="no-content">No associated collections.</span>
     ) : showBarChart ? (
       <StatsCollectionsBarChart collections={collections} />
     ) : (

--- a/src/components/StatsUsageReportsGroup.tsx
+++ b/src/components/StatsUsageReportsGroup.tsx
@@ -8,6 +8,7 @@ type Props = {
   heading?: string;
   description?: string;
   inventoryReportsEnabled: boolean;
+  quicksightLinkEnabled: boolean;
   library?: string;
   usageDataHref?: string;
   usageDataLabel?: string;
@@ -24,6 +25,7 @@ const StatsUsageReportsGroup = ({
   usageDataLabel = "View Usage",
   usageDataTarget = "_self",
   inventoryReportsEnabled,
+  quicksightLinkEnabled,
   library = undefined,
 }: Props) => {
   const [showReportForm, setShowReportForm] = useState(false);
@@ -41,6 +43,11 @@ const StatsUsageReportsGroup = ({
         <li>
           <StatsGroup heading={heading} description={description}>
             <>
+              {!inventoryReportsEnabled && !quicksightLinkEnabled && (
+                <span className="no-content">
+                  Usage reporting is not available.
+                </span>
+              )}
               {inventoryReportsEnabled && library && (
                 <>
                   <Button
@@ -63,19 +70,21 @@ const StatsUsageReportsGroup = ({
             </>
           </StatsGroup>
         </li>
-        <li>
-          <div className="stat-link">
-            <a
-              href={usageDataHref}
-              target={usageDataTarget}
-              rel="noopener noreferrer"
-            >
-              {usageDataLabel}
-            </a>
-            &nbsp;&nbsp;
-            <i className="fa fa-external-link" />
-          </div>
-        </li>
+        {quicksightLinkEnabled && (
+          <li>
+            <div className="stat-link">
+              <a
+                href={usageDataHref}
+                target={usageDataTarget}
+                rel="noopener noreferrer"
+              >
+                {usageDataLabel}
+              </a>
+              &nbsp;&nbsp;
+              <i className="fa fa-external-link" />
+            </div>
+          </li>
+        )}
       </ul>
     </>
   );

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -48,6 +48,7 @@ export interface TestingFlags {
 export interface FeatureFlags {
   enableAutoList?: boolean;
   reportsOnlyForSysadmins?: boolean;
+  quicksightOnlyForSysadmins?: boolean;
 }
 
 export interface Navigate {

--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -61,12 +61,13 @@
         margin: 0;
         overflow-wrap: normal;
       }
+    }
 
-      .no-collections {
-        margin: 10px;
-        font-style: italic;
-        color: $medium-dark-gray;
-      }
+    .no-content {
+      margin: 10px;
+      font-style: italic;
+      font-weight: bolder;
+      color: $medium-dark-gray;
     }
 
     .stat-group-description {

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -6,4 +6,5 @@ import { FeatureFlags } from "../interfaces";
 export const defaultFeatureFlags: FeatureFlags = {
   enableAutoList: true,
   reportsOnlyForSysadmins: true,
+  quicksightOnlyForSysadmins: true,
 };

--- a/tests/jest/businessRules/roleBasedAccess.test.ts
+++ b/tests/jest/businessRules/roleBasedAccess.test.ts
@@ -4,6 +4,7 @@ import { ContextProviderProps } from "../../../src/components/ContextProvider";
 import { ConfigurationSettings, FeatureFlags } from "../../../src/interfaces";
 import {
   useMayRequestInventoryReports,
+  useMaySeeQuickSightLink,
   useMayViewCollectionBarChart,
 } from "../../../src/businessRules/roleBasedAccess";
 
@@ -65,6 +66,98 @@ describe("Business rules for role-based access", () => {
 
     it("allows all users, if the restriction feature flag is is false", () => {
       const featureFlags: FeatureFlags = { reportsOnlyForSysadmins: false };
+
+      testAccess(true, { roles: [{ role: "system" }], featureFlags });
+
+      testAccess(true, { roles: [{ role: "manager-all" }], featureFlags });
+      testAccess(true, { roles: [{ role: "librarian-all" }], featureFlags });
+
+      testAccess(true, {
+        roles: [{ role: "manager", library: libraryMatch }],
+        featureFlags,
+      });
+      testAccess(true, {
+        roles: [{ role: "manager", library: libraryMismatch }],
+        featureFlags,
+      });
+      testAccess(true, {
+        roles: [{ role: "librarian", library: libraryMatch }],
+        featureFlags,
+      });
+      testAccess(true, {
+        roles: [{ role: "librarian", library: libraryMismatch }],
+        featureFlags,
+      });
+    });
+
+    it("allows all users, if the restriction feature flag is not set", () => {
+      const featureFlags: FeatureFlags = {};
+
+      testAccess(true, { roles: [{ role: "system" }], featureFlags });
+
+      testAccess(true, { roles: [{ role: "manager-all" }], featureFlags });
+      testAccess(true, { roles: [{ role: "librarian-all" }], featureFlags });
+
+      testAccess(true, {
+        roles: [{ role: "manager", library: libraryMatch }],
+        featureFlags,
+      });
+      testAccess(true, {
+        roles: [{ role: "manager", library: libraryMismatch }],
+        featureFlags,
+      });
+      testAccess(true, {
+        roles: [{ role: "librarian", library: libraryMatch }],
+        featureFlags,
+      });
+      testAccess(true, {
+        roles: [{ role: "librarian", library: libraryMismatch }],
+        featureFlags,
+      });
+    });
+  });
+
+  describe("controls access to the quicksight link", () => {
+    const testAccess = (
+      expectedResult: boolean,
+      config: Partial<ConfigurationSettings>
+    ) => {
+      const wrapper = setupWrapper(config);
+      const { result } = renderHook(
+        () => useMaySeeQuickSightLink({ library: libraryMatch }),
+        { wrapper }
+      );
+      expect(result.current).toBe(expectedResult);
+    };
+
+    it("restricts access to only sysadmins, if the restriction feature flag is true", () => {
+      const featureFlags: FeatureFlags = { quicksightOnlyForSysadmins: true };
+
+      testAccess(true, { roles: [{ role: "system" }], featureFlags });
+
+      testAccess(false, { roles: [{ role: "manager-all" }], featureFlags });
+      testAccess(false, { roles: [{ role: "librarian-all" }], featureFlags });
+
+      testAccess(false, {
+        roles: [{ role: "manager", library: libraryMatch }],
+        featureFlags,
+      });
+      testAccess(false, {
+        roles: [{ role: "manager", library: libraryMismatch }],
+        featureFlags,
+      });
+      testAccess(false, {
+        roles: [{ role: "librarian", library: libraryMatch }],
+        featureFlags,
+      });
+      testAccess(false, {
+        roles: [{ role: "librarian", library: libraryMismatch }],
+        featureFlags,
+      });
+    });
+
+    it("allows all users, if the restriction feature flag is is false", () => {
+      const featureFlags: FeatureFlags = { quicksightOnlyForSysadmins: false };
 
       testAccess(true, { roles: [{ role: "system" }], featureFlags });
 


### PR DESCRIPTION
## Description

- Adds a feature flag to hide the dashboard statistics link to the QuickSight page from non-sysadmin users.
- Adds business logic and rendering tests for the new functionality.

## Motivation and Context

Need to be able to hide QuickSight dashboard until it is ready to launch.

[Jira [PP-1724](https://ebce-lyrasis.atlassian.net/browse/PP-1724)]

## How Has This Been Tested?

- Manual testing locally.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/10914450349) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1724]: https://ebce-lyrasis.atlassian.net/browse/PP-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ