### PR TITLE
Restore total patron count. (PP-1744)

### DIFF
--- a/src/components/LibraryStats.tsx
+++ b/src/components/LibraryStats.tsx
@@ -65,6 +65,7 @@ const LibraryStats = ({ stats, library }: LibraryStatsProps) => {
       <ul className={`stats ${statsLayoutClass}`}>
         <li className="stat-group stat-patrons-group">
           <StatsPatronGroup
+            total={patrons.total}
             withActiveLoan={patrons.withActiveLoan}
             withActiveLoanOrHold={patrons.withActiveLoanOrHold}
             heading="Current Circulation Activity"

--- a/src/components/SingleStatListItem.tsx
+++ b/src/components/SingleStatListItem.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as numeral from "numeral";
 import { formatNumber, roundedNumber } from "../utils/sharedFunctions";
 
 export interface SingleStatListItemProps {

--- a/src/components/StatsPatronGroup.tsx
+++ b/src/components/StatsPatronGroup.tsx
@@ -24,7 +24,15 @@ const StatsPatronGroup = ({
           <SingleStatListItem
             label="Total Patrons"
             value={total}
-            tooltip="Total number of patrons in the Palace System."
+            tooltip={`
+              Total number of patrons in the Palace System.
+              Please note:
+              this number could be artificially inflated if you have an
+              Aspen integration. We are working to address the issue and
+              will update you when it’s resolved.
+              `
+              .replace(/(?:\s|\r\n|\r|\n)+/g, " ")
+              .trim()}
           />
         )}
         <SingleStatListItem

--- a/src/components/__tests__/LibraryStats-test.tsx
+++ b/src/components/__tests__/LibraryStats-test.tsx
@@ -106,13 +106,14 @@ describe("LibraryStats", () => {
       /* Patrons */
       expect(groups.at(0).text()).to.contain("Current Circulation Activity");
       statItems = groups.at(0).find("SingleStatListItem");
-      expect(statItems.length).to.equal(2);
-      expectStats(statItems.at(0).props(), "Patrons With Active Loans", 21);
+      expectStats(statItems.at(0).props(), "Total Patrons", 132);
+      expectStats(statItems.at(1).props(), "Patrons With Active Loans", 21);
       expectStats(
-        statItems.at(1).props(),
+        statItems.at(2).props(),
         "Patrons With Active Loans or Holds",
         23
       );
+      expect(groups.at(0).text()).to.contain("132Total Patrons");
       expect(groups.at(0).text()).to.contain("21Patrons With Active Loans");
       expect(groups.at(0).text()).to.contain(
         "23Patrons With Active Loans or Holds"


### PR DESCRIPTION
## Description

- Adds total patron count back to the patron statistics group.
- Updates the tooltip on that statistic with a caveat about how to interpret it.
- Updates tests appropriately.

## Motivation and Context

Responding to customer requests.

[Jira [PP-1744](https://ebce-lyrasis.atlassian.net/browse/PP-1744)]

## How Has This Been Tested?

- Manually tested locally with dev server.
- Tests pass locally.
- [CI tests for the branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/11055211590) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1744]: https://ebce-lyrasis.atlassian.net/browse/PP-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ