### PR TITLE
Re-remove Total Patrons from the patron stats group. (PP-1776)

### DIFF
--- a/src/components/LibraryStats.tsx
+++ b/src/components/LibraryStats.tsx
@@ -65,7 +65,6 @@ const LibraryStats = ({ stats, library }: LibraryStatsProps) => {
       <ul className={`stats ${statsLayoutClass}`}>
         <li className="stat-group stat-patrons-group">
           <StatsPatronGroup
-            total={patrons.total}
             withActiveLoan={patrons.withActiveLoan}
             withActiveLoanOrHold={patrons.withActiveLoanOrHold}
             heading="Current Circulation Activity"

--- a/src/components/StatsPatronGroup.tsx
+++ b/src/components/StatsPatronGroup.tsx
@@ -25,11 +25,12 @@ const StatsPatronGroup = ({
             label="Total Patrons"
             value={total}
             tooltip={`
-              Total number of patrons in the Palace System.
-              Please note:
-              this number could be artificially inflated if you have an
-              Aspen integration. We are working to address the issue and
-              will update you when it’s resolved.
+              Total number of patron records currently cached in the Palace System.
+
+              Please note: This value does not necessarily reflect direct patron
+              interaction with the Palace applications. Use of external discovery
+              systems that interact with Palace on a patron's behalf may inflate
+              this number.
               `
               .replace(/(?:\s|\r\n|\r|\n)+/g, " ")
               .trim()}

--- a/src/components/__tests__/LibraryStats-test.tsx
+++ b/src/components/__tests__/LibraryStats-test.tsx
@@ -106,14 +106,12 @@ describe("LibraryStats", () => {
       /* Patrons */
       expect(groups.at(0).text()).to.contain("Current Circulation Activity");
       statItems = groups.at(0).find("SingleStatListItem");
-      expectStats(statItems.at(0).props(), "Total Patrons", 132);
-      expectStats(statItems.at(1).props(), "Patrons With Active Loans", 21);
+      expectStats(statItems.at(0).props(), "Patrons With Active Loans", 21);
       expectStats(
-        statItems.at(2).props(),
+        statItems.at(1).props(),
         "Patrons With Active Loans or Holds",
         23
       );
-      expect(groups.at(0).text()).to.contain("132Total Patrons");
       expect(groups.at(0).text()).to.contain("21Patrons With Active Loans");
       expect(groups.at(0).text()).to.contain(
         "23Patrons With Active Loans or Holds"


### PR DESCRIPTION
## Description

- Remove Total Patrons from the patron stats group.

## Motivation and Context

[Jira [PP-1776](https://ebce-lyrasis.atlassian.net/browse/PP-1776)]

## How Has This Been Tested?

- Manually tested locally.
- Tests pass locally.
- [CI tests for branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/11134123620) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1776]: https://ebce-lyrasis.atlassian.net/browse/PP-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ