### PR TITLE
Fix formatting of long lane names (PP-1962)

### DIFF
--- a/src/stylesheets/input_list.scss
+++ b/src/stylesheets/input_list.scss
@@ -27,7 +27,6 @@
       display: block;
       background: darken($gray-tint, 5);
       padding: 6px 12px;
-      height: 34px;
       width: 192px;
       border: 0;
     }

--- a/src/stylesheets/input_list.scss
+++ b/src/stylesheets/input_list.scss
@@ -27,6 +27,7 @@
       display: block;
       background: darken($gray-tint, 5);
       padding: 6px 12px;
+      min-height: 34px;
       width: 192px;
       border: 0;
     }


### PR DESCRIPTION
## Description

In the work editor long lane names were being formatted poorly. Found this while working on PP-1962.

## Motivation and Context

Before this change:
<img width="679" alt="Screenshot 2024-11-22 at 2 30 42 PM" src="https://github.com/user-attachments/assets/f41dd248-ac81-4dce-a6f0-f1410f31cab5">

After:
<img width="685" alt="Screenshot 2024-11-22 at 2 29 02 PM" src="https://github.com/user-attachments/assets/33db11c9-1bd3-408c-9bb8-48752ded9040">

I took a look around the admin interface after making this change, and I don't see any ill effects, but I'm not 100% sure everywhere this style-sheet is used, so its possible there is a better way to approach this.

## How Has This Been Tested?

- Tested locally

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
