### PR TITLE
Remove max_cache_age parameter (PP-1962)

### DIFF
--- a/src/components/CatalogPage.tsx
+++ b/src/components/CatalogPage.tsx
@@ -103,11 +103,7 @@ export default class CatalogPage extends React.Component<CatalogPageProps, {}> {
   }
 
   expandCollectionUrl(url: string): string {
-    return url
-      ? `${document.location.origin}/${url}${
-          url.includes("?") ? "&" : "?"
-        }max_cache_age=0`
-      : url;
+    return url ? `${document.location.origin}/${url}` : url;
   }
 
   expandBookUrl(url: string): string {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -108,7 +108,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
 
     // Links that will be rendered in a NavItem Bootstrap component.
     const libraryNavItems = [
-      { label: "Catalog", href: "%2Fgroups?max_cache_age=0" },
+      { label: "Catalog", href: "%2Fgroups" },
       { label: "Hidden Books", href: "%2Fadmin%2Fsuppressed" },
     ];
     // Other links that will be rendered in a Link router component and are library specific.
@@ -231,7 +231,7 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
     let library = this.libraryRef.current.getValue();
     if (library) {
       this.context.router.push(
-        "/admin/web/collection/" + library + "%2Fgroups?max_cache_age=0"
+        "/admin/web/collection/" + library + "%2Fgroups"
       );
       this.forceUpdate();
     }

--- a/src/components/__tests__/CatalogPage-test.tsx
+++ b/src/components/__tests__/CatalogPage-test.tsx
@@ -29,7 +29,7 @@ describe("CatalogPage", () => {
   it("renders OPDSCatalog", () => {
     const catalog = wrapper.find(OPDSCatalog);
     expect(catalog.prop("collectionUrl")).to.equal(
-      host + "/library/collectionurl?max_cache_age=0"
+      host + "/library/collectionurl"
     );
     expect(catalog.prop("bookUrl")).to.equal(host + "/library/works/bookurl");
     expect(catalog.prop("BookDetailsContainer").name).to.equal(
@@ -45,7 +45,7 @@ describe("CatalogPage", () => {
   it("handles the case in which the URL already contains a query string", () => {
     const queryUrl = "library/collectionurl?samplequery=test";
     expect(wrapper.instance().expandCollectionUrl(queryUrl)).to.equal(
-      host + "/library/collectionurl?samplequery=test&max_cache_age=0"
+      host + "/library/collectionurl?samplequery=test"
     );
   });
 

--- a/src/components/__tests__/Header-test.tsx
+++ b/src/components/__tests__/Header-test.tsx
@@ -255,7 +255,7 @@ describe("Header", () => {
 
       expect(fullContext.router.push.callCount).to.equal(1);
       expect(fullContext.router.push.args[0][0]).to.equal(
-        "/admin/web/collection/bpl%2Fgroups?max_cache_age=0"
+        "/admin/web/collection/bpl%2Fgroups"
       );
     });
 


### PR DESCRIPTION
## Description

The code was doing some questionable things to add the `max_cache_age` parameter to URLs. In PP-1962 I found this is causing some issues. We could do some work to fix up how we include the parameter in URLs, but since we are no longer using this parameter in the CM, it doesn't seem worth including it.

## Motivation and Context

Issues I was seeing with this code: 
- max_cache_age would get repeatedly included creating urls like this: `http://localhost:6500/admin/web/collection/GA0011%3Fmax_cache_age%3D0%26max_cache_age%3D0%26max_cache_age%3D0%26max_cache_age%3D0/book/GA0011%2FISBN%2F9780593457580/tab/lists` 🤮 
- Clicking the **Create New List** button in the admin UI would go to a URL like this `http://localhost:6500/admin/web/lists/GA0011?max_cache_age=0&max_cache_age=0&max_cache_age=0&max_cache_age=0/create` which isn't a routable URL so it resulted in a white screen. The URL we wanted was `http://localhost:6500/admin/web/lists/GA0011/create`.
- I saw a couple other weird URL generation quirks while looking at this that I didn't note down. But removing the `max_cache_age` stuff fixed them

It seems like we might want to do some refactoring work to how the admin UI is generating URLs in the future, but this at least solves the issues I was seeing with the work lane editor screens.

## How Has This Been Tested?

- Tested locally
- Running unit tests

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
