### PR TITLE
Increase WebPack dev-server proxy timeout.

### DIFF
--- a/webpack.dev-server.config.js
+++ b/webpack.dev-server.config.js
@@ -192,11 +192,11 @@ module.exports = (env) => {
         return responseBuffer;
       }
     ),
-    proxyTimeout: 5000,
+    proxyTimeout: 120000,
     secure: false,
     selfHandleResponse: true,
     target: backend,
-    timeout: 5000,
+    timeout: 120000,
   });
 
   const config = merge(dev, {


### PR DESCRIPTION
## Description

Increase the `dev-server` proxy timeout to 120 seconds.

## Motivation and Context

Sometimes the proxy server would time out, especially when performing a catalog request, but sometimes during other functions. These timeouts are not helpful, so bumping up to a high value should eliminate them.

## How Has This Been Tested?

- Tested locally against a library that was consistently causing timeouts.
- This change does not impact any tests in the test suite.

## Checklist:

- N/A - I have updated the documentation accordingly.
- N/A - All new and existing tests passed.
