### PR TITLE
Send only IDs for custom list manual update entries. (PP-2050)

### DIFF
--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -2518,12 +2518,9 @@ describe("custom list editor reducer", () => {
       expect(formData.get("id")).to.equal("123");
       expect(formData.get("name")).to.equal("My New List");
       expect(formData.get("collections")).to.equal("[1,2]");
-      expect(formData.get("entries")).to.equal(
-        '[{"id":"book2","title":"Little Women"},{"id":"book91","title":"Huckleberry Finn"}]'
-      );
-      expect(formData.get("deletedEntries")).to.equal(
-        '[{"id":"book90","title":"Wuthering Heights"}]'
-      );
+      // The form data entries should have only the ids of the appropriate entries.
+      expect(formData.get("entries")).to.equal('[{"id":"book2"}]');
+      expect(formData.get("deletedEntries")).to.equal('[{"id":"book90"}]');
     });
 
     it("should include an auto update query if the list is auto updating", () => {


### PR DESCRIPTION
## Description

- Send only `id`s for custom list manual update items in the "entries" and "deletedEntries" properties, rather than including all the metadata associated with the them.
- Exclude items that are already members of the list from the updated "entries" payload.

## Motivation and Context

- Payloads included many unnecessary properties for each list item entry, when only the `id` is needed for additions and deletions.
- The update payload included all loaded current entries, even those that were already members of the list; so, if the use loaded many pages of the list, many unneeded members could be included in the request. This would lead to:
- Larger requests.
- Unnecessary processing.

[Jira [PP-2059](https://ebce-lyrasis.atlassian.net/browse/PP-2059)]

## How Has This Been Tested?

- Manually tested multiple scenarios locally.
- Updated tests.
- All tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/12816873734) pass.

## Checklist:

- [N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-2059]: https://ebce-lyrasis.atlassian.net/browse/PP-2059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ