### PR TITLE
Support hidden configuration settings of all field types. (PP-2090)

### DIFF
--- a/src/components/EditableInput.tsx
+++ b/src/components/EditableInput.tsx
@@ -24,7 +24,6 @@ export interface EditableInputProps extends React.HTMLProps<EditableInput> {
   className?: string;
   minLength?: number;
   maxLength?: number;
-  hidden?: boolean;
 }
 
 export interface EditableInputState {
@@ -41,6 +40,7 @@ export default class EditableInput extends React.Component<
   EditableInputState
 > {
   private elementRef = React.createRef<HTMLInputElement>();
+  static displayName = "EditableInput";
   static defaultProps = {
     optionalText: true,
     readOnly: false,
@@ -66,11 +66,7 @@ export default class EditableInput extends React.Component<
       error,
       label,
       extraContent,
-      hidden,
     } = this.props;
-    if (hidden) {
-      return this.renderHiddenElement();
-    }
     const checkboxOrRadioOrSelect = !!(
       type === "checkbox" ||
       type === "radio" ||
@@ -159,10 +155,6 @@ export default class EditableInput extends React.Component<
       },
       children
     );
-  }
-
-  renderHiddenElement() {
-    return this.renderElement({ ...this.props, readOnly: true });
   }
 
   renderDescription(id: string, description: string) {

--- a/src/components/InputList.tsx
+++ b/src/components/InputList.tsx
@@ -38,7 +38,9 @@ export default class InputList extends React.Component<
   InputListProps,
   InputListState
 > {
+  static displayName = "InputList";
   private addListItemRef = React.createRef<LanguageField>();
+
   constructor(props: InputListProps) {
     super(props);
     const isMenu = props.setting.type === "menu";

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -39,12 +39,14 @@ export default class ProtocolFormField extends React.Component<
   ProtocolFormFieldProps,
   object
 > {
+  static displayName = "ProtocolFormField";
   private inputListRef = React.createRef<InputList>();
   private colorPickerRef = React.createRef<ColorPicker>();
   private elementRef = React.createRef<EditableInput>();
   static defaultProps = {
     readOnly: false,
   };
+
   constructor(props: ProtocolFormFieldProps) {
     super(props);
     this.randomize = this.randomize.bind(this);
@@ -54,36 +56,32 @@ export default class ProtocolFormField extends React.Component<
 
   render(): JSX.Element {
     const setting = this.props.setting as SettingData | CustomListsSetting;
-    if (setting.hidden) {
-      // TODO: Hijacking for any hidden fields for now, but need to handle
-      //  some types (e.g., "menu", "list")  differently.
-      return this.renderHiddenElement(setting);
-    }
-    if (setting.type === "select") {
-      return this.renderSelectSetting(setting);
-    } else if (setting.type === "list" || setting.type === "menu") {
-      return this.renderListSetting(setting);
-    } else if (setting.type === "color-picker") {
-      return this.renderColorPickerSetting(setting);
-    } else {
-      return this.renderSetting(setting);
-    }
+    const element: JSX.Element =
+      setting.type === "select"
+        ? this.renderSelectSetting(setting)
+        : setting.type === "list" || setting.type === "menu"
+        ? this.renderListSetting(setting)
+        : setting.type === "color-picker"
+        ? this.renderColorPickerSetting(setting)
+        : this.renderSetting(setting);
+    // Special handling for hidden settings.
+    return setting.hidden ? this.renderHiddenElement(element) : element;
   }
 
-  renderHiddenElement(setting: SettingData) {
-    const { value, disabled = false, error = null } = this.props;
-    const props = {
-      key: setting.key,
-      hidden: true,
-      elementType: "input",
-      type: "hidden",
-      name: setting.key,
-      value: defaultValueIfMissing(value, setting.default),
-      ref: this.elementRef,
-      disabled,
-      error,
-    };
-    return React.createElement(EditableInput, props, null);
+  renderHiddenElement(element: JSX.Element): JSX.Element {
+    // Wrap hidden element in invisible div to prevent it from affecting layout.
+    return (
+      <div
+        style={{
+          visibility: "hidden",
+          position: "absolute",
+          top: "-9999px",
+          left: "-9999px",
+        }}
+      >
+        {element}
+      </div>
+    );
   }
 
   renderSetting(setting: SettingData): JSX.Element {


### PR DESCRIPTION
## Description

Provides a simpler and unified approach for hidden configuration settings of all supported types.

## Motivation and Context

Follow on to #144, which supported hidden configuration settings; but did so by attempting to shoehorn all field types into a hidden input field.

[Jira [PP-2090](https://ebce-lyrasis.atlassian.net/browse/PP-2090)]

## How Has This Been Tested?

- Manual testing in my local environment.
- All tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation-admin/actions/runs/13254548869) pass.

## Checklist:

- [N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-2090]: https://ebce-lyrasis.atlassian.net/browse/PP-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ