### PR TITLE
Fix timezone parsing in tests

### DIFF
--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -182,8 +182,15 @@ describe("SelfTests", () => {
   });
 
   it("should format the date and duration of the most recent tests", () => {
+    // Create a date object from the ISO string to account for local timezone
+    const date = new Date(collections[0].self_test_results.start);
+    const expectedDate = date.toDateString();
+    const hours = date.getHours().toString().padStart(2, "0");
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    const seconds = date.getSeconds().toString().padStart(2, "0");
+    const expectedTime = `${hours}:${minutes}:${seconds}`;
     expect(wrapper.instance().formatDate(collections[0])).to.equal(
-      "Tests last ran on Tue Aug 07 2018 15:34:54 and lasted 1.75s."
+      `Tests last ran on ${expectedDate} ${expectedTime} and lasted 1.75s.`
     );
   });
 
@@ -207,8 +214,15 @@ describe("SelfTests", () => {
       expect(failSVGIcon.length).to.equal(0);
       expect(passSVGIcon.length).to.equal(1);
 
+      // Create a date object from the ISO string to account for local timezone
+      const date = new Date(collections[1].self_test_results.start);
+      const expectedDate = date.toDateString();
+      const hours = date.getHours().toString().padStart(2, "0");
+      const minutes = date.getMinutes().toString().padStart(2, "0");
+      const seconds = date.getSeconds().toString().padStart(2, "0");
+      const expectedTime = `${hours}:${minutes}:${seconds}`;
       expect(description.text().trim()).to.equal(
-        "Tests last ran on Tue Aug 07 2018 15:34:54 and lasted 1.75s."
+        `Tests last ran on ${expectedDate} ${expectedTime} and lasted 1.75s.`
       );
     });
 
@@ -258,8 +272,15 @@ describe("SelfTests", () => {
       expect(failSVGIcon.length).to.equal(1);
       expect(passSVGIcon.length).to.equal(0);
 
+      // Create a date object from the ISO string to account for local timezone
+      const date = new Date(collections[1].self_test_results.start);
+      const expectedDate = date.toDateString();
+      const hours = date.getHours().toString().padStart(2, "0");
+      const minutes = date.getMinutes().toString().padStart(2, "0");
+      const seconds = date.getSeconds().toString().padStart(2, "0");
+      const expectedTime = `${hours}:${minutes}:${seconds}`;
       expect(description.text().trim()).to.equal(
-        "Tests last ran on Tue Aug 07 2018 15:34:54 and lasted 1.75s."
+        `Tests last ran on ${expectedDate} ${expectedTime} and lasted 1.75s.`
       );
     });
 

--- a/src/components/__tests__/SelfTests-test.tsx
+++ b/src/components/__tests__/SelfTests-test.tsx
@@ -121,6 +121,19 @@ const updatedCollection = {
 describe("SelfTests", () => {
   let wrapper;
 
+  // Helper function to generate the expected date string
+  const getExpectedDate = (date: Date): string => {
+    return date.toDateString();
+  };
+
+  // Helper function to generate the expected time string
+  const getExpectedTime = (date: Date): string => {
+    const hours = date.getHours().toString().padStart(2, "0");
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    const seconds = date.getSeconds().toString().padStart(2, "0");
+    return `${hours}:${minutes}:${seconds}`;
+  };
+
   beforeEach(() => {
     wrapper = mount(
       <SelfTests
@@ -182,13 +195,9 @@ describe("SelfTests", () => {
   });
 
   it("should format the date and duration of the most recent tests", () => {
-    // Create a date object from the ISO string to account for local timezone
     const date = new Date(collections[0].self_test_results.start);
-    const expectedDate = date.toDateString();
-    const hours = date.getHours().toString().padStart(2, "0");
-    const minutes = date.getMinutes().toString().padStart(2, "0");
-    const seconds = date.getSeconds().toString().padStart(2, "0");
-    const expectedTime = `${hours}:${minutes}:${seconds}`;
+    const expectedDate = getExpectedDate(date);
+    const expectedTime = getExpectedTime(date);
     expect(wrapper.instance().formatDate(collections[0])).to.equal(
       `Tests last ran on ${expectedDate} ${expectedTime} and lasted 1.75s.`
     );
@@ -214,13 +223,9 @@ describe("SelfTests", () => {
       expect(failSVGIcon.length).to.equal(0);
       expect(passSVGIcon.length).to.equal(1);
 
-      // Create a date object from the ISO string to account for local timezone
       const date = new Date(collections[1].self_test_results.start);
-      const expectedDate = date.toDateString();
-      const hours = date.getHours().toString().padStart(2, "0");
-      const minutes = date.getMinutes().toString().padStart(2, "0");
-      const seconds = date.getSeconds().toString().padStart(2, "0");
-      const expectedTime = `${hours}:${minutes}:${seconds}`;
+      const expectedDate = getExpectedDate(date);
+      const expectedTime = getExpectedTime(date);
       expect(description.text().trim()).to.equal(
         `Tests last ran on ${expectedDate} ${expectedTime} and lasted 1.75s.`
       );
@@ -272,13 +277,9 @@ describe("SelfTests", () => {
       expect(failSVGIcon.length).to.equal(1);
       expect(passSVGIcon.length).to.equal(0);
 
-      // Create a date object from the ISO string to account for local timezone
       const date = new Date(collections[1].self_test_results.start);
-      const expectedDate = date.toDateString();
-      const hours = date.getHours().toString().padStart(2, "0");
-      const minutes = date.getMinutes().toString().padStart(2, "0");
-      const seconds = date.getSeconds().toString().padStart(2, "0");
-      const expectedTime = `${hours}:${minutes}:${seconds}`;
+      const expectedDate = getExpectedDate(date);
+      const expectedTime = getExpectedTime(date);
       expect(description.text().trim()).to.equal(
         `Tests last ran on ${expectedDate} ${expectedTime} and lasted 1.75s.`
       );


### PR DESCRIPTION
 ## Description

  Fixed failing tests related to time zone handling in SelfTests component tests. Updated the test expectations to dynamically compute expected date/time strings based on the actual date object from the test data, rather than hardcoding specific time values.

##  Motivation and Context

  Previously, the SelfTests component tests were failing because they expected a specific hardcoded time output ("Tests last ran on Tue Aug 07 2018 15:34:54 and lasted 1.75s.") without accounting for the developer's local timezone. This caused tests to fail depending on the timezone of the developer's machine.

The admin UI outputs the localized time, which is the correct behavior, but since the tests were not adjusting for timezones, it meant that anyone running the tests whose local timezone wasn't US eastern would get a test failure.

These tests have been failing on my machine for a long time, finally decided to fix it.

## How Has This Been Tested?

  Ran the test suite locally to verify that the previously failing tests now pass. The fix maintains the integrity of the test expectations while making them work in any timezone.

## Checklist

  - [x] I have updated the documentation accordingly.
  - [x] All new and existing tests passed.