### PR TITLE
Correctly reset state on manual custom list detail load. (PP-2447, PP-2076)

### DIFF
--- a/src/components/AdvancedSearchBuilder.tsx
+++ b/src/components/AdvancedSearchBuilder.tsx
@@ -52,9 +52,7 @@ export const fields: FieldType[] = [
     operators: ["eq"],
   },
 ]
-  // This is a work-around to get the functionality of `Array.toSorted`.
-  .slice()
-  .sort((a: FieldType, b: FieldType) => a.label.localeCompare(b.label))
+  .toSorted((a: FieldType, b: FieldType) => a.label.localeCompare(b.label))
   .map((props) => ({
     ...props,
     label: capitalizeEachWord(props.label),

--- a/src/components/AdvancedSearchBuilder.tsx
+++ b/src/components/AdvancedSearchBuilder.tsx
@@ -52,7 +52,9 @@ export const fields: FieldType[] = [
     operators: ["eq"],
   },
 ]
-  .toSorted((a: FieldType, b: FieldType) => a.label.localeCompare(b.label))
+  // This is a work-around to get the functionality of `Array.toSorted`.
+  .slice()
+  .sort((a: FieldType, b: FieldType) => a.label.localeCompare(b.label))
   .map((props) => ({
     ...props,
     label: capitalizeEachWord(props.label),

--- a/src/reducers/__tests__/customListEditor-test.ts
+++ b/src/reducers/__tests__/customListEditor-test.ts
@@ -523,18 +523,21 @@ describe("custom list editor reducer", () => {
         expect(nextState.entries.baseline).to.deep.equal(listDetailsData.books);
       });
 
-      it("applies the current delta to the books in the list details data", () => {
+      it("cleans up local changes, since the server already got them on save", () => {
         const state = {
           ...initialState,
           entries: {
             ...initialState.entries,
-            baselineTotalCount: 5,
+            // It doesn't really matter what the added/removed books are, in
+            // this case, just that there is something there for the reducer
+            // to clean up.
             added: {
-              book90: { id: "book90", title: "Wuthering Heights" },
-              book91: { id: "book91", title: "Huckleberry Finn" },
+              // An already saved added book.
+              book1: { id: "book1", title: "A Farewell to Arms" },
             },
             removed: {
-              book1: true as const,
+              // An already saved removed book.
+              an_already_removed_book: true as const,
             },
           },
         };
@@ -544,15 +547,12 @@ describe("custom list editor reducer", () => {
           data: listDetailsData,
         });
 
+        expect(nextState.entries.added).to.deep.equal({});
+        expect(nextState.entries.removed).to.deep.equal({});
+
         expect(nextState.entries.baseline).to.deep.equal(listDetailsData.books);
-
-        expect(nextState.entries.current).to.deep.equal([
-          { id: "book91", title: "Huckleberry Finn" },
-          { id: "book90", title: "Wuthering Heights" },
-          { id: "book2", title: "Little Women" },
-        ]);
-
-        expect(nextState.entries.currentTotalCount).to.equal(6); // 5 + 2 - 1
+        expect(nextState.entries.current).to.deep.equal(listDetailsData.books);
+        expect(nextState.entries.currentTotalCount).to.equal(2);
       });
     }
   );

--- a/src/reducers/customListEditor.ts
+++ b/src/reducers/customListEditor.ts
@@ -397,7 +397,7 @@ const parseSearchFacets = (json: string): Record<string, string> => {
  */
 export interface CustomListEditorEntriesData {
   /**
-   * The visible entries in the list, when the last was last saved. This can be used to restore
+   * The visible entries in the list, when the list was last saved. This can be used to restore
    * the editor to the last save point, and to detect changes since the last save. Note that this
    * does not necessarily contain all of the entries, but only the entries in the pages that have
    * been retrieved from the CM.
@@ -1020,6 +1020,12 @@ const handleCustomListDetailsLoad = validatedHandler(
     return produce(state, (draftState) => {
       const { entries } = draftState;
 
+      // Reset local added / removed entries, since they should already
+      // be reflected in fresh state just synced from the server.
+      entries.added = {};
+      entries.removed = {};
+
+      // Update the baseline with the newly fetched entries.
       entries.baseline = action.data.books;
 
       applyEntriesDelta(entries);


### PR DESCRIPTION
## Description

Correctly reset locally added / removed entries when reloading a manual custom list after save, since the associated changes should already be reflected in fresh state just synced from the server. 

## Motivation and Context

- Attempting more than one save of a manual custom list without reloading the page between saves would result in all attempts after the first one to fail.
- If items were added, they would appear both as unsaved additions (indented at the top of the list) and lower down, unindented in the saved items list.

[Jira PP-2447, PP-2076]

## How Has This Been Tested?

- Manually testing via dev-server against a staging instance.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/15357194217) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
