### PR TITLE
Show support contact URL in footer, when present. (PP-2542)

### DIFF
--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -29,6 +29,7 @@ export interface ContextProviderProps extends React.Props<ContextProvider> {
   }[];
   tos_link_text?: string;
   tos_link_href?: string;
+  support_contact_url?: string;
   featureFlags: FeatureFlags;
   quicksightPagePath?: string;
   dashboardCollectionsBarChart?: DashboardCollectionsBarChart;
@@ -117,6 +118,7 @@ export default class ContextProvider extends React.Component<
       dashboardCollectionsBarChart: this.props.dashboardCollectionsBarChart,
       tos_link_text: this.props.tos_link_text,
       tos_link_href: this.props.tos_link_href,
+      support_contact_url: this.props.support_contact_url,
     };
     return (
       <PathForProvider pathFor={this.pathFor}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useTermsOfService } from "../context/appContext";
+import { useSupportContactUrl, useTermsOfService } from "../context/appContext";
 
 export interface FooterProps {
   className?: string;
@@ -10,14 +10,23 @@ that registry. Make sure to also configure the registry to provide a `terms-of-s
 process. */
 const Footer = ({ className }: FooterProps) => {
   const { text, href } = useTermsOfService();
+  const supportContactUrl = useSupportContactUrl();
 
   return (
     <footer className={className}>
-      <p>
+      <div style={{ textAlign: "center" }}>
         <a href={href} target="_blank" rel="noreferrer">
           {decode(text)}
         </a>
-      </p>
+        {supportContactUrl && (
+          <>
+            <br />
+            <a href={supportContactUrl}>
+              <strong>Need help? Contact support.</strong>
+            </a>
+          </>
+        )}
+      </div>
     </footer>
   );
 };

--- a/src/components/__tests__/Footer-test.tsx
+++ b/src/components/__tests__/Footer-test.tsx
@@ -7,28 +7,60 @@ import { componentWithProviders } from "../../../tests/jest/testUtils/withProvid
 
 const expectedTosText = "Terms of Service Text";
 const expectedTosHref = "terms_of_service";
-const getFooterProviders = () => {
+const testSupportContactUrl = "helpdesk@example.com";
+const getFooterProviders = ({ hasSupportContactUrl = false } = {}) => {
   const contextProviderProps = {
     tos_link_text: expectedTosText,
     tos_link_href: expectedTosHref,
+    support_contact_url: hasSupportContactUrl
+      ? testSupportContactUrl
+      : undefined,
   };
   return componentWithProviders({ contextProviderProps });
 };
 
 describe("Footer", () => {
-  it("displays a link", () => {
-    const wrapper = mount(<Footer />, {
-      wrappingComponent: getFooterProviders(),
-    });
-    const linkElement = wrapper.find("p").find("a");
-    expect(linkElement.length).to.equal(1);
-    expect(linkElement.text()).to.equal(expectedTosText);
-    expect(linkElement.prop("href")).to.equal(expectedTosHref);
-  });
   it("accepts an optional className prop", () => {
     const wrapper = mount(<Footer className="customClass" />, {
       wrappingComponent: getFooterProviders(),
     });
     expect(wrapper.hasClass("customClass")).to.be.true;
+  });
+  it("displays a terms of service link", () => {
+    const wrapper = mount(<Footer />, {
+      wrappingComponent: getFooterProviders(),
+    });
+    const linkElements = wrapper.find("div").find("a");
+    expect(linkElements.length).to.equal(1);
+
+    const TosLinkElement = linkElements.at(0);
+    expect(TosLinkElement.text()).to.equal(expectedTosText);
+    expect(TosLinkElement.prop("href")).to.equal(expectedTosHref);
+  });
+
+  describe("support contact link", () => {
+    it("displays a support contact link, when URL present", () => {
+      const wrapper = mount(<Footer />, {
+        wrappingComponent: getFooterProviders({ hasSupportContactUrl: true }),
+      });
+      const linkElements = wrapper.find("div").find("a");
+      expect(linkElements.length).to.equal(2);
+
+      // The second link should be the support contact link.
+      const supportContactLink = linkElements.at(1);
+      expect(supportContactLink.prop("href")).to.equal(testSupportContactUrl);
+      expect(supportContactLink.text()).to.equal("Need help? Contact support.");
+    });
+    it("displays a omits contact link, when URL missing", () => {
+      const wrapper = mount(<Footer />, {
+        wrappingComponent: getFooterProviders({ hasSupportContactUrl: false }),
+      });
+      const linkElements = wrapper.find("div").find("a");
+      expect(linkElements.length).to.equal(1);
+
+      // The second link should be the support contact link.
+      const otherLink = linkElements.at(0);
+      expect(otherLink.prop("href")).to.not.equal(testSupportContactUrl);
+    });
   });
 });

--- a/src/context/appContext.ts
+++ b/src/context/appContext.ts
@@ -8,6 +8,7 @@ export type AppContextType = {
   admin: Admin;
   tos_link_text?: string;
   tos_link_href?: string;
+  support_contact_url?: string;
   featureFlags: FeatureFlags;
   quicksightPagePath: string;
   dashboardCollectionsBarChart?: DashboardCollectionsBarChart;
@@ -41,5 +42,6 @@ export const useTermsOfService = (): TermsOfServiceContext => ({
   text: useAppContext().tos_link_text,
   href: useAppContext().tos_link_href,
 });
+export const useSupportContactUrl = () => useAppContext().support_contact_url;
 
 export default AppContext.Provider;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,6 +26,12 @@ export interface ConfigurationSettings {
   tos_link_text?: string;
   tos_link_href?: string;
 
+  /** A URL for the application's support contact. For example:
+   * - mailto:helpdesk@example.com
+   * - https://example.com/support
+   */
+  support_contact_url?: string;
+
   featureFlags: FeatureFlags;
 
   /** `quickSightPagePath` contains the URL to the QuickSight dashboard page.

--- a/tests/jest/context/AppContext.test.tsx
+++ b/tests/jest/context/AppContext.test.tsx
@@ -6,6 +6,7 @@ import {
   useAppFeatureFlags,
   useCsrfToken,
   useTermsOfService,
+  useSupportContactUrl,
 } from "../../../src/context/appContext";
 import { componentWithProviders } from "../testUtils/withProviders";
 import { ContextProviderProps } from "../../../src/components/ContextProvider";
@@ -30,6 +31,7 @@ describe("AppContext", () => {
     text: "Terms of Service",
     href: "/terms-of-service",
   };
+  const expectedSupportContactUrl = "helpdesk@example.com";
 
   const contextProviderProps: ContextProviderProps = {
     csrfToken: expectedCsrfToken,
@@ -38,6 +40,7 @@ describe("AppContext", () => {
     email: expectedEmail,
     tos_link_text: expectedTermsOfService.text,
     tos_link_href: expectedTermsOfService.href,
+    support_contact_url: expectedSupportContactUrl,
   };
   const wrapper = componentWithProviders({ contextProviderProps });
 
@@ -48,6 +51,7 @@ describe("AppContext", () => {
     expect(value.admin.email).toEqual(expectedEmail);
     expect(value.admin.roles).toEqual(expectedRoles);
     expect(value.featureFlags).toEqual(expectedFeatureFlags);
+    expect(value.support_contact_url).toEqual(expectedSupportContactUrl);
   });
 
   it("provides useAppAdmin context hook", () => {
@@ -86,5 +90,12 @@ describe("AppContext", () => {
     expect(tosLink).toEqual(expectedTermsOfService);
     expect(text).toEqual(expectedTermsOfService.text);
     expect(href).toEqual(expectedTermsOfService.href);
+  });
+  it("provides useSupportContactUrl context hook", () => {
+    const { result } = renderHook(() => useSupportContactUrl(), {
+      wrapper,
+    });
+    const supportContactUrl = result.current;
+    expect(supportContactUrl).toEqual(expectedSupportContactUrl);
   });
 });


### PR DESCRIPTION
## Description

Display a link to the support contact URL at the bottom of the footer, if a support contact URL is provided.

## Motivation and Context

When possible, make access to support more obvious.

## How Has This Been Tested?

- Manual testing against a Palace Manager back end using dev-server in local environment.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/15958498450) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
