### PR TITLE
Refactor ContextProvider app config settings.

### DIFF
--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -3,6 +3,7 @@ import { Store } from "@reduxjs/toolkit";
 import * as PropTypes from "prop-types";
 import buildStore, { RootState } from "../store";
 import {
+  ConfigurationSettings,
   DashboardCollectionsBarChart,
   FeatureFlags,
   PathFor,
@@ -19,6 +20,7 @@ import AppContextProvider, { AppContextType } from "../context/appContext";
 //  the `ConfigurationSettings` interface.
 export interface ContextProviderProps extends React.Props<ContextProvider> {
   store?: Store<RootState>;
+  config: Partial<ConfigurationSettings>;
   csrfToken: string;
   showCircEventsDownload?: boolean;
   settingUp?: boolean;

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -21,20 +21,6 @@ import AppContextProvider, { AppContextType } from "../context/appContext";
 export interface ContextProviderProps extends React.Props<ContextProvider> {
   store?: Store<RootState>;
   config: Partial<ConfigurationSettings>;
-  csrfToken: string;
-  showCircEventsDownload?: boolean;
-  settingUp?: boolean;
-  email?: string;
-  roles?: {
-    role: string;
-    library?: string;
-  }[];
-  tos_link_text?: string;
-  tos_link_href?: string;
-  support_contact_url?: string;
-  featureFlags: FeatureFlags;
-  quicksightPagePath?: string;
-  dashboardCollectionsBarChart?: DashboardCollectionsBarChart;
 }
 
 /** Provides a redux store, configuration options, and a function to create URLs
@@ -44,13 +30,13 @@ export default class ContextProvider extends React.Component<
 > {
   store: Store<RootState>;
   admin: Admin;
-  config: ConfigurationSettings;
+  appConfig: ConfigurationSettings;
   pathFor: PathFor;
 
   constructor(props) {
     super(props);
     this.store = props.store ?? buildStore();
-    this.config = props.config;
+    this.appConfig = props.config;
     this.admin = new Admin(
       props.config.roles || [],
       props.config.email || null
@@ -73,7 +59,7 @@ export default class ContextProvider extends React.Component<
   storeConfiguration() {
     const actions = new ActionCreator();
 
-    this.store.dispatch(actions.setFeatureFlags(this.config.featureFlags));
+    this.store.dispatch(actions.setFeatureFlags(this.appConfig.featureFlags));
   }
 
   prepareCollectionUrl(url: string): string {
@@ -108,24 +94,24 @@ export default class ContextProvider extends React.Component<
   getChildContext() {
     return {
       editorStore: this.store,
-      csrfToken: this.config.csrfToken,
-      settingUp: this.config.settingUp || false,
+      csrfToken: this.appConfig.csrfToken,
+      settingUp: this.appConfig.settingUp || false,
       admin: this.admin,
-      featureFlags: this.config.featureFlags,
+      featureFlags: this.appConfig.featureFlags,
     };
   }
 
   render() {
     const appContextValue: AppContextType = {
-      csrfToken: this.config.csrfToken,
-      settingUp: this.config.settingUp,
+      csrfToken: this.appConfig.csrfToken,
+      settingUp: this.appConfig.settingUp,
       admin: this.admin,
-      featureFlags: this.config.featureFlags,
-      quicksightPagePath: this.config.quicksightPagePath,
-      dashboardCollectionsBarChart: this.config.dashboardCollectionsBarChart,
-      tos_link_text: this.config.tos_link_text,
-      tos_link_href: this.config.tos_link_href,
-      support_contact_url: this.config.support_contact_url,
+      featureFlags: this.appConfig.featureFlags,
+      quicksightPagePath: this.appConfig.quicksightPagePath,
+      dashboardCollectionsBarChart: this.appConfig.dashboardCollectionsBarChart,
+      tos_link_text: this.appConfig.tos_link_text,
+      tos_link_href: this.appConfig.tos_link_href,
+      support_contact_url: this.appConfig.support_contact_url,
     };
     return (
       <PathForProvider pathFor={this.pathFor}>

--- a/src/components/ContextProvider.tsx
+++ b/src/components/ContextProvider.tsx
@@ -44,12 +44,17 @@ export default class ContextProvider extends React.Component<
 > {
   store: Store<RootState>;
   admin: Admin;
+  config: ConfigurationSettings;
   pathFor: PathFor;
 
   constructor(props) {
     super(props);
     this.store = props.store ?? buildStore();
-    this.admin = new Admin(props.roles || [], props.email || null);
+    this.config = props.config;
+    this.admin = new Admin(
+      props.config.roles || [],
+      props.config.email || null
+    );
     this.pathFor = (collectionUrl: string, bookUrl: string, tab?: string) => {
       let path = "/admin/web";
       path += collectionUrl
@@ -68,7 +73,7 @@ export default class ContextProvider extends React.Component<
   storeConfiguration() {
     const actions = new ActionCreator();
 
-    this.store.dispatch(actions.setFeatureFlags(this.props.featureFlags));
+    this.store.dispatch(actions.setFeatureFlags(this.config.featureFlags));
   }
 
   prepareCollectionUrl(url: string): string {
@@ -103,24 +108,24 @@ export default class ContextProvider extends React.Component<
   getChildContext() {
     return {
       editorStore: this.store,
-      csrfToken: this.props.csrfToken,
-      settingUp: this.props.settingUp || false,
+      csrfToken: this.config.csrfToken,
+      settingUp: this.config.settingUp || false,
       admin: this.admin,
-      featureFlags: this.props.featureFlags,
+      featureFlags: this.config.featureFlags,
     };
   }
 
   render() {
     const appContextValue: AppContextType = {
-      csrfToken: this.props.csrfToken,
-      settingUp: this.props.settingUp,
+      csrfToken: this.config.csrfToken,
+      settingUp: this.config.settingUp,
       admin: this.admin,
-      featureFlags: this.props.featureFlags,
-      quicksightPagePath: this.props.quicksightPagePath,
-      dashboardCollectionsBarChart: this.props.dashboardCollectionsBarChart,
-      tos_link_text: this.props.tos_link_text,
-      tos_link_href: this.props.tos_link_href,
-      support_contact_url: this.props.support_contact_url,
+      featureFlags: this.config.featureFlags,
+      quicksightPagePath: this.config.quicksightPagePath,
+      dashboardCollectionsBarChart: this.config.dashboardCollectionsBarChart,
+      tos_link_text: this.config.tos_link_text,
+      tos_link_href: this.config.tos_link_href,
+      support_contact_url: this.config.support_contact_url,
     };
     return (
       <PathForProvider pathFor={this.pathFor}>

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import * as React from "react";
 import { shallow, mount } from "enzyme";
 
-import ContextProvider, { ContextProviderProps } from "../ContextProvider";
+import ContextProvider from "../ContextProvider";
 import Admin from "../../models/Admin";
 import * as PropTypes from "prop-types";
 import { stub } from "sinon";
@@ -12,29 +12,20 @@ import { ConfigurationSettings } from "../../interfaces";
 
 class FakeChild extends React.Component<object> {}
 
-const contextProviderConfigSettings = (
-  config: Partial<ConfigurationSettings>
-) => ({ ...config, config: config } as ContextProviderProps);
-
 describe("ContextProvider", () => {
   let wrapper;
   let instance;
   let pathFor;
 
-  const basicConfigSettings = {
-    csrfToken: "",
-    featureFlags: defaultFeatureFlags,
-  };
-
   beforeEach(() => {
-    const contextProviderProps = contextProviderConfigSettings({
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "token",
       featureFlags: defaultFeatureFlags,
       roles: [{ role: "system" }],
       email: "email",
-    });
+    };
     wrapper = shallow(
-      <ContextProvider {...contextProviderProps}>
+      <ContextProvider config={appConfigSettings}>
         <FakeChild />
       </ContextProvider>
     );
@@ -54,12 +45,12 @@ describe("ContextProvider", () => {
   });
 
   it("saves the enableAutoList feature flag to the store", () => {
-    const contextProviderProps = contextProviderConfigSettings({
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "token",
       featureFlags: { enableAutoList: true },
-    });
+    };
     wrapper = shallow(
-      <ContextProvider {...contextProviderProps}>
+      <ContextProvider config={appConfigSettings}>
         <FakeChild />
       </ContextProvider>
     );
@@ -100,12 +91,12 @@ describe("ContextProvider", () => {
       }
     }
 
-    const contextProviderProps = contextProviderConfigSettings({
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "token",
       featureFlags: {},
-    });
+    };
     const mockProvider = mount(
-      <MockContextProvider {...contextProviderProps}>
+      <MockContextProvider config={appConfigSettings}>
         <Child />
       </MockContextProvider>
     );

--- a/src/components/__tests__/ContextProvider-test.tsx
+++ b/src/components/__tests__/ContextProvider-test.tsx
@@ -3,26 +3,38 @@ import { expect } from "chai";
 import * as React from "react";
 import { shallow, mount } from "enzyme";
 
-import ContextProvider from "../ContextProvider";
+import ContextProvider, { ContextProviderProps } from "../ContextProvider";
 import Admin from "../../models/Admin";
 import * as PropTypes from "prop-types";
 import { stub } from "sinon";
+import { defaultFeatureFlags } from "../../utils/featureFlags";
+import { ConfigurationSettings } from "../../interfaces";
 
 class FakeChild extends React.Component<object> {}
+
+const contextProviderConfigSettings = (
+  config: Partial<ConfigurationSettings>
+) => ({ ...config, config: config } as ContextProviderProps);
 
 describe("ContextProvider", () => {
   let wrapper;
   let instance;
   let pathFor;
 
+  const basicConfigSettings = {
+    csrfToken: "",
+    featureFlags: defaultFeatureFlags,
+  };
+
   beforeEach(() => {
+    const contextProviderProps = contextProviderConfigSettings({
+      csrfToken: "token",
+      featureFlags: defaultFeatureFlags,
+      roles: [{ role: "system" }],
+      email: "email",
+    });
     wrapper = shallow(
-      <ContextProvider
-        csrfToken="token"
-        featureFlags={{}}
-        roles={[{ role: "system" }]}
-        email="email"
-      >
+      <ContextProvider {...contextProviderProps}>
         <FakeChild />
       </ContextProvider>
     );
@@ -42,13 +54,12 @@ describe("ContextProvider", () => {
   });
 
   it("saves the enableAutoList feature flag to the store", () => {
+    const contextProviderProps = contextProviderConfigSettings({
+      csrfToken: "token",
+      featureFlags: { enableAutoList: true },
+    });
     wrapper = shallow(
-      <ContextProvider
-        csrfToken="token"
-        featureFlags={{
-          enableAutoList: true,
-        }}
-      >
+      <ContextProvider {...contextProviderProps}>
         <FakeChild />
       </ContextProvider>
     );
@@ -89,8 +100,12 @@ describe("ContextProvider", () => {
       }
     }
 
+    const contextProviderProps = contextProviderConfigSettings({
+      csrfToken: "token",
+      featureFlags: {},
+    });
     const mockProvider = mount(
-      <MockContextProvider csrfToken="token" featureFlags={{}}>
+      <MockContextProvider {...contextProviderProps}>
         <Child />
       </MockContextProvider>
     );

--- a/src/components/__tests__/Footer-test.tsx
+++ b/src/components/__tests__/Footer-test.tsx
@@ -9,14 +9,14 @@ const expectedTosText = "Terms of Service Text";
 const expectedTosHref = "terms_of_service";
 const testSupportContactUrl = "helpdesk@example.com";
 const getFooterProviders = ({ hasSupportContactUrl = false } = {}) => {
-  const contextProviderProps = {
+  const appConfigSettings = {
     tos_link_text: expectedTosText,
     tos_link_href: expectedTosHref,
     support_contact_url: hasSupportContactUrl
       ? testSupportContactUrl
       : undefined,
   };
-  return componentWithProviders({ contextProviderProps });
+  return componentWithProviders({ appConfigSettings });
 };
 
 describe("Footer", () => {

--- a/src/components/__tests__/LibraryStats-test.tsx
+++ b/src/components/__tests__/LibraryStats-test.tsx
@@ -19,10 +19,10 @@ import { normalizeStatistics } from "../../features/stats/normalizeStatistics";
 import { ContextProviderProps } from "../ContextProvider";
 
 const getAllProviders = ({ isSysAdmin = false } = {}) => {
-  const contextProviderProps: Partial<ContextProviderProps> = isSysAdmin
+  const appConfigSettings: Partial<ContextProviderProps> = isSysAdmin
     ? { roles: [{ role: "system" }] }
     : {};
-  return componentWithProviders({ contextProviderProps });
+  return componentWithProviders({ appConfigSettings });
 };
 
 global.ResizeObserver = require("resize-observer-polyfill");

--- a/src/components/__tests__/LibraryStats-test.tsx
+++ b/src/components/__tests__/LibraryStats-test.tsx
@@ -16,10 +16,10 @@ import {
 } from "../../../tests/__data__/statisticsApiResponseData";
 
 import { normalizeStatistics } from "../../features/stats/normalizeStatistics";
-import { ContextProviderProps } from "../ContextProvider";
+import { ConfigurationSettings } from "../../interfaces";
 
 const getAllProviders = ({ isSysAdmin = false } = {}) => {
-  const appConfigSettings: Partial<ContextProviderProps> = isSysAdmin
+  const appConfigSettings: Partial<ConfigurationSettings> = isSysAdmin
     ? { roles: [{ role: "system" }] }
     : {};
   return componentWithProviders({ appConfigSettings });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,13 +46,13 @@ class CirculationAdmin {
     const appElement = "opds-catalog";
     const app = config.settingUp ? (
       <Provider store={store}>
-        <ContextProvider {...config} store={store} config={config}>
+        <ContextProvider config={config} store={store}>
           <SetupPage />
         </ContextProvider>
       </Provider>
     ) : (
       <Provider store={store}>
-        <ContextProvider {...config} store={store} config={config}>
+        <ContextProvider config={config} store={store}>
           <QueryClientProvider client={queryClient}>
             <Router history={browserHistory}>
               <Route path={catalogEditorPath} component={CatalogPage} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,13 +46,13 @@ class CirculationAdmin {
     const appElement = "opds-catalog";
     const app = config.settingUp ? (
       <Provider store={store}>
-        <ContextProvider {...config} store={store}>
+        <ContextProvider {...config} store={store} config={config}>
           <SetupPage />
         </ContextProvider>
       </Provider>
     ) : (
       <Provider store={store}>
-        <ContextProvider {...config} store={store}>
+        <ContextProvider {...config} store={store} config={config}>
           <QueryClientProvider client={queryClient}>
             <Router history={browserHistory}>
               <Route path={catalogEditorPath} component={CatalogPage} />

--- a/tests/jest/businessRules/roleBasedAccess.test.ts
+++ b/tests/jest/businessRules/roleBasedAccess.test.ts
@@ -12,13 +12,13 @@ const setupWrapper = ({
   roles,
   featureFlags,
 }: Partial<ConfigurationSettings>) => {
-  const contextProviderProps: ContextProviderProps = {
+  const appConfigSettings: Partial<ContextProviderProps> = {
     featureFlags,
     roles,
     email: "email",
     csrfToken: "token",
   };
-  return componentWithProviders({ contextProviderProps });
+  return componentWithProviders({ appConfigSettings });
 };
 
 describe("Business rules for role-based access", () => {

--- a/tests/jest/businessRules/roleBasedAccess.test.ts
+++ b/tests/jest/businessRules/roleBasedAccess.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { componentWithProviders } from "../testUtils/withProviders";
-import { ContextProviderProps } from "../../../src/components/ContextProvider";
 import { ConfigurationSettings, FeatureFlags } from "../../../src/interfaces";
 import {
   useMayRequestInventoryReports,
@@ -12,7 +11,7 @@ const setupWrapper = ({
   roles,
   featureFlags,
 }: Partial<ConfigurationSettings>) => {
-  const appConfigSettings: Partial<ContextProviderProps> = {
+  const appConfigSettings: Partial<ConfigurationSettings> = {
     featureFlags,
     roles,
     email: "email",

--- a/tests/jest/components/CirculationEventsDownload.test.tsx
+++ b/tests/jest/components/CirculationEventsDownload.test.tsx
@@ -3,8 +3,7 @@ import { screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import CirculationEventsDownload from "../../../src/components/CirculationEventsDownload";
-import { ContextProviderProps } from "../../../src/components/ContextProvider";
-import { FeatureFlags } from "../../../src/interfaces";
+import { ConfigurationSettings, FeatureFlags } from "../../../src/interfaces";
 import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
 import { renderWithProviders } from "../testUtils/withProviders";
 
@@ -14,13 +13,13 @@ describe("CirculationEventsDownload", () => {
       ...defaultFeatureFlags,
       showCircEventsDownload: false,
     };
-    const contextProviderProps: Partial<ContextProviderProps> = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       featureFlags,
     };
     const { container } = renderWithProviders(
       <CirculationEventsDownload library="testlib" />,
       {
-        appConfigSettings: contextProviderProps,
+        appConfigSettings,
       }
     );
     expect(container).toBeEmptyDOMElement();
@@ -32,13 +31,13 @@ describe("CirculationEventsDownload", () => {
       showCircEventsDownload: true,
     };
     const libraryProp = "testlib";
-    const contextProviderProps: Partial<ContextProviderProps> = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       featureFlags,
     };
 
     beforeEach(() => {
       renderWithProviders(<CirculationEventsDownload library={libraryProp} />, {
-        appConfigSettings: contextProviderProps,
+        appConfigSettings,
       });
     });
 

--- a/tests/jest/components/CirculationEventsDownload.test.tsx
+++ b/tests/jest/components/CirculationEventsDownload.test.tsx
@@ -20,7 +20,7 @@ describe("CirculationEventsDownload", () => {
     const { container } = renderWithProviders(
       <CirculationEventsDownload library="testlib" />,
       {
-        contextProviderProps,
+        appConfigSettings: contextProviderProps,
       }
     );
     expect(container).toBeEmptyDOMElement();
@@ -38,7 +38,7 @@ describe("CirculationEventsDownload", () => {
 
     beforeEach(() => {
       renderWithProviders(<CirculationEventsDownload library={libraryProp} />, {
-        contextProviderProps,
+        appConfigSettings: contextProviderProps,
       });
     });
 

--- a/tests/jest/components/CustomLists.test.tsx
+++ b/tests/jest/components/CustomLists.test.tsx
@@ -30,7 +30,7 @@ describe("CustomLists", () => {
   it("adds filters when new filter values are entered", async () => {
     const user = userEvent.setup();
 
-    const configSettings: Partial<ConfigurationSettings> = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -43,7 +43,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      configSettings
+      appConfigSettings
     );
 
     await user.click(screen.getByRole("textbox", { name: "filter value" }));
@@ -70,7 +70,7 @@ describe("CustomLists", () => {
   it("replaces the existing filters when adding a new filter when the clear filters checkbox is checked", async () => {
     const user = userEvent.setup();
 
-    const configSettings: Partial<ConfigurationSettings> = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -83,7 +83,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      configSettings
+      appConfigSettings
     );
 
     await user.click(screen.getByRole("textbox", { name: "filter value" }));
@@ -122,7 +122,7 @@ describe("CustomLists", () => {
 
     const user = userEvent.setup();
 
-    const configSettings: Partial<ConfigurationSettings> = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -135,7 +135,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      configSettings
+      appConfigSettings
     );
 
     await user.click(screen.getByRole("textbox", { name: "filter value" }));
@@ -166,7 +166,7 @@ describe("CustomLists", () => {
 
     const user = userEvent.setup();
 
-    const configSettings: Partial<ConfigurationSettings> = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -179,7 +179,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      configSettings
+      appConfigSettings
     );
 
     await userEvent.selectOptions(

--- a/tests/jest/components/CustomLists.test.tsx
+++ b/tests/jest/components/CustomLists.test.tsx
@@ -6,6 +6,7 @@ import { http, HttpResponse } from "msw";
 import CustomLists from "../../../src/components/CustomLists";
 import renderWithContext from "../testUtils/renderWithContext";
 import buildStore from "../../../src/store";
+import { ConfigurationSettings } from "../../../src/interfaces";
 
 describe("CustomLists", () => {
   // Stub scrollTo, since a component in the render tree will try to call it, and it is not
@@ -29,7 +30,7 @@ describe("CustomLists", () => {
   it("adds filters when new filter values are entered", async () => {
     const user = userEvent.setup();
 
-    const contextProviderProps = {
+    const configSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -42,7 +43,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      contextProviderProps
+      configSettings
     );
 
     await user.click(screen.getByRole("textbox", { name: "filter value" }));
@@ -69,7 +70,7 @@ describe("CustomLists", () => {
   it("replaces the existing filters when adding a new filter when the clear filters checkbox is checked", async () => {
     const user = userEvent.setup();
 
-    const contextProviderProps = {
+    const configSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -82,7 +83,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      contextProviderProps
+      configSettings
     );
 
     await user.click(screen.getByRole("textbox", { name: "filter value" }));
@@ -121,7 +122,7 @@ describe("CustomLists", () => {
 
     const user = userEvent.setup();
 
-    const contextProviderProps = {
+    const configSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -134,7 +135,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      contextProviderProps
+      configSettings
     );
 
     await user.click(screen.getByRole("textbox", { name: "filter value" }));
@@ -165,7 +166,7 @@ describe("CustomLists", () => {
 
     const user = userEvent.setup();
 
-    const contextProviderProps = {
+    const configSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [{ role: "system" }],
@@ -178,7 +179,7 @@ describe("CustomLists", () => {
         library="testlib"
         store={buildStore()}
       />,
-      contextProviderProps
+      configSettings
     );
 
     await userEvent.selectOptions(

--- a/tests/jest/components/IndividualAdminEditForm.test.tsx
+++ b/tests/jest/components/IndividualAdminEditForm.test.tsx
@@ -3,12 +3,13 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import IndividualAdminEditForm from "../../../src/components/IndividualAdminEditForm";
 import renderWithContext from "../testUtils/renderWithContext";
+import { ConfigurationSettings } from "../../../src/interfaces";
 
 describe("IndividualAdminEditForm", () => {
   it("clears the role checkboxes after save", async () => {
     const user = userEvent.setup();
 
-    const contextProviderProps = {
+    const appConfigSettings: Partial<ConfigurationSettings> = {
       csrfToken: "",
       featureFlags: {},
       roles: [
@@ -45,7 +46,7 @@ describe("IndividualAdminEditForm", () => {
 
     const { rerender } = renderWithContext(
       <IndividualAdminEditForm {...props} />,
-      contextProviderProps
+      appConfigSettings
     );
 
     const systemAdminCheckbox = screen.getByRole("checkbox", {

--- a/tests/jest/components/InventoryReportRequestModal.test.tsx
+++ b/tests/jest/components/InventoryReportRequestModal.test.tsx
@@ -359,7 +359,7 @@ describe("InventoryReportRequestModal", () => {
           onHide={onHide}
           library={LIBRARY}
         />,
-        { queryClient, contextProviderProps: EMAIL_CONTEXT_PROVIDER_PROPS }
+        { queryClient, appConfigSettings: EMAIL_CONTEXT_PROVIDER_PROPS }
       );
       let modalBody = getByRole("document").querySelector(".modal-body");
       expect(modalBody).toHaveTextContent(
@@ -373,7 +373,7 @@ describe("InventoryReportRequestModal", () => {
           onHide={onHide}
           library={LIBRARY}
         />,
-        { queryClient, contextProviderProps: NO_EMAIL_CONTEXT_PROVIDER_PROPS }
+        { queryClient, appConfigSettings: NO_EMAIL_CONTEXT_PROVIDER_PROPS }
       ));
       modalBody = getByRole("document").querySelector(".modal-body");
       expect(modalBody).toHaveTextContent(

--- a/tests/jest/components/Stats.test.tsx
+++ b/tests/jest/components/Stats.test.tsx
@@ -6,8 +6,6 @@ import {
   componentWithProviders,
   renderWithProviders,
 } from "../testUtils/withProviders";
-import { ContextProviderProps } from "../../../src/components/ContextProvider";
-
 import {
   statisticsApiResponseData,
   testLibraryKey as sampleLibraryKey,
@@ -23,6 +21,11 @@ import { renderHook } from "@testing-library/react-hooks";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 import { store } from "../../../src/store";
 import { api } from "../../../src/features/api/apiSlice";
+import {
+  AdminRoleData,
+  ConfigurationSettings,
+  RolesData,
+} from "../../../src/interfaces";
 
 const normalizedData = normalizeStatistics(statisticsApiResponseData);
 
@@ -292,9 +295,9 @@ describe("Dashboard Statistics", () => {
     });
 
     describe("shows the correct UI with/out sysadmin role", () => {
-      const systemAdmin = [{ role: "system" }];
-      const managerAll = [{ role: "manager-all" }];
-      const librarianAll = [{ role: "librarian-all" }];
+      const systemAdmin: AdminRoleData[] = [{ role: "system" }];
+      const managerAll: AdminRoleData[] = [{ role: "manager-all" }];
+      const librarianAll: AdminRoleData[] = [{ role: "librarian-all" }];
 
       const collectionNames = [
         "New BiblioBoard Test",
@@ -305,13 +308,13 @@ describe("Dashboard Statistics", () => {
       ];
 
       it("tests BarChart component", () => {
-        const contextProviderProps: Partial<ContextProviderProps> = {
+        const appConfigSettings: Partial<ConfigurationSettings> = {
           roles: systemAdmin,
           dashboardCollectionsBarChart: { width: 800 },
         };
         const { container, getByRole } = renderWithProviders(
           <Stats library={sampleLibraryKey} />,
-          { appConfigSettings: contextProviderProps }
+          { appConfigSettings }
         );
 
         const collectionsHeading = getByRole("heading", {
@@ -335,14 +338,11 @@ describe("Dashboard Statistics", () => {
 
       it("shows collection bar chart for sysadmins, but list for others", () => {
         // We'll use this function to test multiple scenarios.
-        const testFor = (
-          expectBarChart: boolean,
-          roles: { role: string; library?: string }[]
-        ) => {
-          const contextProviderProps: Partial<ContextProviderProps> = { roles };
+        const testFor = (expectBarChart: boolean, roles: AdminRoleData[]) => {
+          const appConfigSettings: Partial<ConfigurationSettings> = { roles };
           const { container, getByRole } = renderWithProviders(
             <Stats library={sampleLibraryKey} />,
-            { appConfigSettings: contextProviderProps }
+            { appConfigSettings }
           );
 
           const collectionsHeading = getByRole("heading", {
@@ -380,11 +380,8 @@ describe("Dashboard Statistics", () => {
         const fakeQuickSightHref = "https://example.com/fakeQS";
 
         // We'll use this function to test multiple scenarios.
-        const renderFor = (
-          onlySysadmins: boolean,
-          roles: { role: string; library?: string }[]
-        ) => {
-          const contextProviderProps: Partial<ContextProviderProps> = {
+        const renderFor = (onlySysadmins: boolean, roles: AdminRoleData[]) => {
+          const appConfigSettings: Partial<ConfigurationSettings> = {
             featureFlags: { reportsOnlyForSysadmins: onlySysadmins },
             roles,
             quicksightPagePath: fakeQuickSightHref,
@@ -395,7 +392,7 @@ describe("Dashboard Statistics", () => {
             queryByRole,
             queryByText,
           } = renderWithProviders(<Stats library={sampleLibraryKey} />, {
-            appConfigSettings: contextProviderProps,
+            appConfigSettings,
           });
 
           // We should always render a Usage reports group when a library is specified.
@@ -439,11 +436,8 @@ describe("Dashboard Statistics", () => {
         const fakeQuickSightHref = "https://example.com/fakeQS";
 
         // We'll use this function to test multiple scenarios.
-        const renderFor = (
-          onlySysadmins: boolean,
-          roles: { role: string; library?: string }[]
-        ) => {
-          const contextProviderProps: Partial<ContextProviderProps> = {
+        const renderFor = (onlySysadmins: boolean, roles: AdminRoleData[]) => {
+          const appConfigSettings: Partial<ConfigurationSettings> = {
             featureFlags: { quicksightOnlyForSysadmins: onlySysadmins },
             roles,
             quicksightPagePath: fakeQuickSightHref,
@@ -454,7 +448,7 @@ describe("Dashboard Statistics", () => {
             queryByRole,
             queryByText,
           } = renderWithProviders(<Stats library={sampleLibraryKey} />, {
-            appConfigSettings: contextProviderProps,
+            appConfigSettings,
           });
 
           // We should always render a Usage reports group when a library is specified.

--- a/tests/jest/components/Stats.test.tsx
+++ b/tests/jest/components/Stats.test.tsx
@@ -311,7 +311,7 @@ describe("Dashboard Statistics", () => {
         };
         const { container, getByRole } = renderWithProviders(
           <Stats library={sampleLibraryKey} />,
-          { contextProviderProps }
+          { appConfigSettings: contextProviderProps }
         );
 
         const collectionsHeading = getByRole("heading", {
@@ -342,7 +342,7 @@ describe("Dashboard Statistics", () => {
           const contextProviderProps: Partial<ContextProviderProps> = { roles };
           const { container, getByRole } = renderWithProviders(
             <Stats library={sampleLibraryKey} />,
-            { contextProviderProps }
+            { appConfigSettings: contextProviderProps }
           );
 
           const collectionsHeading = getByRole("heading", {
@@ -395,7 +395,7 @@ describe("Dashboard Statistics", () => {
             queryByRole,
             queryByText,
           } = renderWithProviders(<Stats library={sampleLibraryKey} />, {
-            contextProviderProps,
+            appConfigSettings: contextProviderProps,
           });
 
           // We should always render a Usage reports group when a library is specified.
@@ -454,7 +454,7 @@ describe("Dashboard Statistics", () => {
             queryByRole,
             queryByText,
           } = renderWithProviders(<Stats library={sampleLibraryKey} />, {
-            contextProviderProps,
+            appConfigSettings: contextProviderProps,
           });
 
           // We should always render a Usage reports group when a library is specified.

--- a/tests/jest/context/AppContext.test.tsx
+++ b/tests/jest/context/AppContext.test.tsx
@@ -9,8 +9,11 @@ import {
   useSupportContactUrl,
 } from "../../../src/context/appContext";
 import { componentWithProviders } from "../testUtils/withProviders";
-import { ContextProviderProps } from "../../../src/components/ContextProvider";
-import { FeatureFlags } from "../../../src/interfaces";
+import {
+  AdminRoleData,
+  ConfigurationSettings,
+  FeatureFlags,
+} from "../../../src/interfaces";
 
 // TODO: These tests may need to be adjusted in the future.
 //  Currently, an AppContext.Provider is injected into the component tree
@@ -26,14 +29,14 @@ describe("AppContext", () => {
     testTrue: true,
     testFalse: false,
   };
-  const expectedRoles = [{ role: "system" }];
+  const expectedRoles: AdminRoleData[] = [{ role: "system" }];
   const expectedTermsOfService = {
     text: "Terms of Service",
     href: "/terms-of-service",
   };
   const expectedSupportContactUrl = "helpdesk@example.com";
 
-  const contextProviderProps: ContextProviderProps = {
+  const appConfigSettings: Partial<ConfigurationSettings> = {
     csrfToken: expectedCsrfToken,
     featureFlags: expectedFeatureFlags,
     roles: expectedRoles,
@@ -42,7 +45,7 @@ describe("AppContext", () => {
     tos_link_href: expectedTermsOfService.href,
     support_contact_url: expectedSupportContactUrl,
   };
-  const wrapper = componentWithProviders({ contextProviderProps });
+  const wrapper = componentWithProviders({ appConfigSettings });
 
   it("provides useAppContext context hook", () => {
     const { result } = renderHook(() => useAppContext(), { wrapper });

--- a/tests/jest/testUtils/renderWithContext.tsx
+++ b/tests/jest/testUtils/renderWithContext.tsx
@@ -10,19 +10,16 @@ import { ConfigurationSettings } from "../../../src/interfaces";
  * also wrapped, so that rerenders will have the identical context.
  *
  * @param ui                   The element to render
- * @param configSettings Props to pass to the ContextProvider wrapper
+ * @param config Props to pass to the ContextProvider wrapper
  * @param renderOptions        Options to pass through to the RTL render function
  * @returns
  */
 export default function renderWithContext(
   ui: React.ReactElement,
-  configSettings: Partial<ConfigurationSettings>,
+  config: Partial<ConfigurationSettings>,
   renderOptions?: Omit<RenderOptions, "queries">
 ): RenderResult {
-  const contextProviderProps = {
-    ...configSettings,
-    config: configSettings,
-  } as ContextProviderProps;
+  const contextProviderProps = { config } as ContextProviderProps;
   const renderResult = render(
     <ContextProvider {...contextProviderProps}>{ui}</ContextProvider>,
     renderOptions

--- a/tests/jest/testUtils/renderWithContext.tsx
+++ b/tests/jest/testUtils/renderWithContext.tsx
@@ -3,21 +3,23 @@ import { render, RenderOptions, RenderResult } from "@testing-library/react";
 import ContextProvider, {
   ContextProviderProps,
 } from "../../../src/components/ContextProvider";
+import { ConfigurationSettings } from "../../../src/interfaces";
 
 /**
  * Renders a given React element, wrapped in a ContextProvider. The resulting rerender function is
  * also wrapped, so that rerenders will have the identical context.
  *
  * @param ui                   The element to render
- * @param contextProviderProps Props to pass to the ContextProvider wrapper
+ * @param configSettings Props to pass to the ContextProvider wrapper
  * @param renderOptions        Options to pass through to the RTL render function
  * @returns
  */
 export default function renderWithContext(
   ui: React.ReactElement,
-  contextProviderProps: ContextProviderProps,
+  configSettings: Partial<ConfigurationSettings>,
   renderOptions?: Omit<RenderOptions, "queries">
 ): RenderResult {
+  const contextProviderProps = configSettings as ContextProviderProps;
   const renderResult = render(
     <ContextProvider {...contextProviderProps}>{ui}</ContextProvider>,
     renderOptions

--- a/tests/jest/testUtils/renderWithContext.tsx
+++ b/tests/jest/testUtils/renderWithContext.tsx
@@ -19,7 +19,10 @@ export default function renderWithContext(
   configSettings: Partial<ConfigurationSettings>,
   renderOptions?: Omit<RenderOptions, "queries">
 ): RenderResult {
-  const contextProviderProps = configSettings as ContextProviderProps;
+  const contextProviderProps = {
+    ...configSettings,
+    config: configSettings,
+  } as ContextProviderProps;
   const renderResult = render(
     <ContextProvider {...contextProviderProps}>{ui}</ContextProvider>,
     renderOptions

--- a/tests/jest/testUtils/withProviders.tsx
+++ b/tests/jest/testUtils/withProviders.tsx
@@ -39,21 +39,17 @@ const requiredAppConfigSettings: Partial<ConfigurationSettings> = {
  * @param {QueryClient} options.queryClient A `tanstack/react-query` QueryClient
  * @returns {React.FunctionComponent} A React component that wraps children with our providers
  */
-export const basicTestServerConfigSettings: Partial<ConfigurationSettings> = {
-  csrfToken: "",
-  featureFlags: defaultFeatureFlags,
-} as const;
 export const componentWithProviders = ({
   reduxProviderProps = {
     store: defaultReduxStore,
   },
-  appConfigSettings = requiredAppConfigSettings,
+  appConfigSettings = {},
   queryClient = new QueryClient(),
 }: TestProviderWrapperOptions = {}): React.FunctionComponent => {
+  const config = { ...requiredAppConfigSettings, ...appConfigSettings };
   const effectiveContextProviderProps = {
-    ...requiredAppConfigSettings,
-    ...appConfigSettings,
-    config: appConfigSettings as ConfigurationSettings,
+    ...config,
+    config: config as ConfigurationSettings,
     ...reduxProviderProps.store, // Context and Redux Provider stores must match.
   } as ContextProviderProps;
   const wrapper = ({ children }) => (

--- a/tests/jest/testUtils/withProviders.tsx
+++ b/tests/jest/testUtils/withProviders.tsx
@@ -7,10 +7,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, RenderOptions, RenderResult } from "@testing-library/react";
 import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
 import { store } from "../../../src/store";
+import { ConfigurationSettings } from "../../../src/interfaces";
 
 export type TestProviderWrapperOptions = {
   reduxProviderProps?: ProviderProps;
-  contextProviderProps?: Partial<ContextProviderProps>;
+  appConfigSettings?: Partial<ContextProviderProps>;
   queryClient?: QueryClient;
 };
 export type TestRenderWrapperOptions = TestProviderWrapperOptions & {
@@ -21,9 +22,9 @@ export type TestRenderWrapperOptions = TestProviderWrapperOptions & {
 // be the same for both the Redux Provider and the ContextProvider.
 const defaultReduxStore = store;
 
-// The `csrfToken` context provider prop is required, so we provide
-// a default value here, so it can be easily merged with other props.
-const requiredContextProviderProps: ContextProviderProps = {
+// Some config settings from the server are required, so we provide
+// default values here, so they can be easily merged with other props.
+const requiredAppConfigSettings: Partial<ConfigurationSettings> = {
   csrfToken: "",
   featureFlags: defaultFeatureFlags,
 };
@@ -34,25 +35,27 @@ const requiredContextProviderProps: ContextProviderProps = {
  *
  * @param {TestProviderWrapperOptions} options
  * @param options.reduxProviderProps Props to pass to the Redux `Provider` wrapper
- * @param {ContextProviderProps} options.contextProviderProps Props to pass to the ContextProvider wrapper
+ * @param {ConfigurationSettings} options.appConfigSettings
  * @param {QueryClient} options.queryClient A `tanstack/react-query` QueryClient
  * @returns {React.FunctionComponent} A React component that wraps children with our providers
  */
+export const basicTestServerConfigSettings: Partial<ConfigurationSettings> = {
+  csrfToken: "",
+  featureFlags: defaultFeatureFlags,
+} as const;
 export const componentWithProviders = ({
   reduxProviderProps = {
     store: defaultReduxStore,
   },
-  contextProviderProps = {
-    csrfToken: "",
-    featureFlags: defaultFeatureFlags,
-  },
+  appConfigSettings = requiredAppConfigSettings,
   queryClient = new QueryClient(),
 }: TestProviderWrapperOptions = {}): React.FunctionComponent => {
   const effectiveContextProviderProps = {
-    ...requiredContextProviderProps,
-    ...contextProviderProps,
+    ...requiredAppConfigSettings,
+    ...appConfigSettings,
+    config: appConfigSettings as ConfigurationSettings,
     ...reduxProviderProps.store, // Context and Redux Provider stores must match.
-  };
+  } as ContextProviderProps;
   const wrapper = ({ children }) => (
     <Provider {...reduxProviderProps}>
       <ContextProvider {...effectiveContextProviderProps}>

--- a/tests/jest/testUtils/withProviders.tsx
+++ b/tests/jest/testUtils/withProviders.tsx
@@ -11,7 +11,7 @@ import { ConfigurationSettings } from "../../../src/interfaces";
 
 export type TestProviderWrapperOptions = {
   reduxProviderProps?: ProviderProps;
-  appConfigSettings?: Partial<ContextProviderProps>;
+  appConfigSettings?: Partial<ConfigurationSettings>;
   queryClient?: QueryClient;
 };
 export type TestRenderWrapperOptions = TestProviderWrapperOptions & {
@@ -48,7 +48,6 @@ export const componentWithProviders = ({
 }: TestProviderWrapperOptions = {}): React.FunctionComponent => {
   const config = { ...requiredAppConfigSettings, ...appConfigSettings };
   const effectiveContextProviderProps = {
-    ...config,
     config: config as ConfigurationSettings,
     ...reduxProviderProps.store, // Context and Redux Provider stores must match.
   } as ContextProviderProps;


### PR DESCRIPTION
## Description

Refactors the `ContextProvider` component to accept a single application `ConfigurationSettings` object in the props, rather than each of its individual members. `ContextProvider`'s Redux `store` prop remains and is unchanged.

## Motivation and Context

I ran into this while working on PP-2768. It was proving challenging to keep types in sync between the legacy `ContextProvider` and other uses of the app configuration settings. There is more work to do within `ContextProvider`, but this was the relatively larger chunk to get the change in and get tests working again.

## How Has This Been Tested?

- Manual testing locally with the dev-server.
- All tests pass locally.
- Tests pass [in CI](https://github.com/ThePalaceProject/circulation-admin/actions/runs/16622556097).

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
