### PR TITLE
Add confirmation when disassociating collection libraries (PP-2408)

### DIFF
--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -12,8 +12,8 @@ import {
   CollectionsData,
   CollectionData,
   LibraryData,
+  LibraryWithSettingsData,
   LibraryRegistrationsData,
-  ServiceData,
 } from "../interfaces";
 import ServiceWithRegistrationsEditForm from "./ServiceWithRegistrationsEditForm";
 import TrashIcon from "./icons/TrashIcon";
@@ -36,7 +36,24 @@ export interface CollectionsProps
 
 export class CollectionEditForm extends ServiceWithRegistrationsEditForm<
   CollectionsData
-> {}
+> {
+  /**
+   * Override to display a confirmation message before removing a library
+   * association. We display the confirmation and, if successful, call the
+   * superclass method to actually remove the library from our state.
+   * @param library
+   */
+  removeLibrary(library: LibraryWithSettingsData) {
+    const libraryData = this.getLibrary(library.short_name);
+    const libraryName = libraryData ? libraryData.name : library.short_name;
+    const confirmationMessage =
+      `Disassociating library "${libraryName}" from this collection will ` +
+      "remove all loans and holds for its patrons. Do you wish to continue?";
+    if (window.confirm(confirmationMessage)) {
+      super.removeLibrary(library);
+    }
+  }
+}
 
 /**
  * Right panel for collections on the system configuration page.


### PR DESCRIPTION
## Description

Adds a confirmation dialog when disassociating a library from a collection.

## Motivation and Context

When a library is disassociated from a collection, all patron loans and holds are immediately removed when the change is saved. The confirmation reduces the risk of accidental disassociation by reminding the user of the repercussions of the action before it is effected.

## How Has This Been Tested?

- Manually tested locally.
- New tests.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/17078864736) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
