### PR TITLE
Add library removal confirmation to service edit form (PP-2408)

### DIFF
--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -10,7 +10,6 @@ import {
   ProtocolData,
   ServiceData,
   ServicesData,
-  SettingData,
 } from "../interfaces";
 import { clearForm } from "../utils/sharedFunctions";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
@@ -27,6 +26,7 @@ export interface ServiceEditFormProps<T> {
   extraFormSection?: any;
   extraFormKey?: string;
   adminLevel?: number;
+  libraryRemovalAllowed?: (library: LibraryWithSettingsData) => boolean;
 }
 
 export interface ServiceEditFormState {
@@ -345,6 +345,7 @@ export default class ServiceEditForm<
               <WithRemoveButton
                 disabled={disabled}
                 onRemove={() => this.removeLibrary(library)}
+                confirmRemoval={() => this.isLibraryRemovalPermitted(library)}
                 ref={library.short_name}
               >
                 {this.props.data &&
@@ -588,6 +589,31 @@ export default class ServiceEditForm<
     return this.state.expandedLibraries.indexOf(library.short_name) !== -1;
   }
 
+  /**
+   * Controls whether library associations may be removed via UI interaction.
+   * Subclasses may override this method to control removal.
+   * @param library The library to remove.
+   */
+  isLibraryRemovalPermitted(library: LibraryWithSettingsData): boolean {
+    // library should be provided on every call.
+    // It is not used here, but might be in subclass implementations.
+    // Removal is permitted by default.
+    return true;
+  }
+
+  /**
+   * Removes the association with the given library from a service's state.
+   *
+   * NB: This method is used indirectly via `onRemove` by `sharedFunctions.clearForm`
+   * to clean up form state; therefore, care should be taken to avoid any side
+   * effects not needed for updating the state. Anything done by this method
+   * can happen whenever user interaction or `clearForm` triggers `onRemove`.
+   *
+   * Update or override `isLibraryRemovalPermitted` to control library removal
+   * via UI interaction.
+   *
+   * @param library
+   */
   removeLibrary(library) {
     const libraries = this.state.libraries.filter(
       (stateLibrary) => stateLibrary.short_name !== library.short_name

--- a/src/components/WithRemoveButton.tsx
+++ b/src/components/WithRemoveButton.tsx
@@ -5,6 +5,7 @@ import TrashIcon from "./icons/TrashIcon";
 export interface WithRemoveButtonProps {
   disabled: boolean;
   onRemove: () => void;
+  confirmRemoval?: () => boolean;
 }
 
 /** When wrapped around an element, renders a remove button next to the element. */
@@ -37,6 +38,12 @@ export default class WithRemoveButton extends React.Component<
 
   onClick(e: Event) {
     e.preventDefault();
+
+    // Don't remove if confirmation function is present and returns false.
+    if (this.props.confirmRemoval && !this.props.confirmRemoval()) {
+      return;
+    }
+    // Otherwise, we can proceed with removal.
     !this.props.disabled && this.props.onRemove();
   }
 }

--- a/src/components/__tests__/WithRemoveButton-test.tsx
+++ b/src/components/__tests__/WithRemoveButton-test.tsx
@@ -43,5 +43,27 @@ describe("WithRemoveButton", () => {
       removeBtn.simulate("click");
       expect(onRemove.callCount).to.equal(0);
     });
+
+    it("calls onRemove when confirmation returns true", () => {
+      const confirmRemoval = stub().returns(true);
+      wrapper.setProps({ confirmRemoval });
+      const removeBtn = wrapper.find(".remove-btn").hostNodes();
+
+      removeBtn.simulate("click");
+
+      expect(confirmRemoval.callCount).to.equal(1);
+      expect(onRemove.callCount).to.equal(1);
+    });
+
+    it("does not call onRemove when confirmation returns false", () => {
+      const confirmRemoval = stub().returns(false);
+      wrapper.setProps({ confirmRemoval });
+      const removeBtn = wrapper.find(".remove-btn").hostNodes();
+
+      removeBtn.simulate("click");
+
+      expect(confirmRemoval.callCount).to.equal(1);
+      expect(onRemove.callCount).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
## Description

- Adds support for allowing/disallowing the disassociation of a library from a service integration via the `ServiceEditForm` and its child components. The check is performed synchronously, in real time, when removal is requested via UI interaction.
- Adds documentation to help avoid accidental misuse of the `ServiceEditForm.removeLibrary` method.

The mechanism separates (1) the function of removing a library association from (2) the function of approving that removal.

The default behavior is to allow disassociation. Subclasses of `ServiceEditForm` may override this behavior.

## Motivation and Context

This capability enables future real-time verification that a removal is allowed or intended (e.g., via confirmation dialog).

[Jira PP-2408]

## How Has This Been Tested?

- New and updated tests.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/17103293415) passed.

## Checklist:

- [x] - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
