### PR TITLE
Avoid unintended side-effects on non-interactive library disassociations (PP-2408)

### DIFF
--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -39,19 +39,17 @@ export class CollectionEditForm extends ServiceWithRegistrationsEditForm<
 > {
   /**
    * Override to display a confirmation message before removing a library
-   * association. We display the confirmation and, if successful, call the
-   * superclass method to actually remove the library from our state.
-   * @param library
+   * association. We display the confirmation and return `true` if the
+   * action is confirmed or `false` otherwise.
+   * @param library The library to remove.
    */
-  removeLibrary(library: LibraryWithSettingsData) {
+  isLibraryRemovalPermitted(library: LibraryWithSettingsData): boolean {
     const libraryData = this.getLibrary(library.short_name);
     const libraryName = libraryData ? libraryData.name : library.short_name;
     const confirmationMessage =
       `Disassociating library "${libraryName}" from this collection will ` +
       "remove all loans and holds for its patrons. Do you wish to continue?";
-    if (window.confirm(confirmationMessage)) {
-      super.removeLibrary(library);
-    }
+    return window.confirm(confirmationMessage);
   }
 }
 

--- a/src/components/ServiceEditForm.tsx
+++ b/src/components/ServiceEditForm.tsx
@@ -10,7 +10,6 @@ import {
   ProtocolData,
   ServiceData,
   ServicesData,
-  SettingData,
 } from "../interfaces";
 import { clearForm } from "../utils/sharedFunctions";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
@@ -27,6 +26,7 @@ export interface ServiceEditFormProps<T> {
   extraFormSection?: any;
   extraFormKey?: string;
   adminLevel?: number;
+  libraryRemovalAllowed?: (library: LibraryWithSettingsData) => boolean;
 }
 
 export interface ServiceEditFormState {
@@ -345,6 +345,7 @@ export default class ServiceEditForm<
               <WithRemoveButton
                 disabled={disabled}
                 onRemove={() => this.removeLibrary(library)}
+                confirmRemoval={() => this.isLibraryRemovalPermitted(library)}
                 ref={library.short_name}
               >
                 {this.props.data &&
@@ -588,6 +589,31 @@ export default class ServiceEditForm<
     return this.state.expandedLibraries.indexOf(library.short_name) !== -1;
   }
 
+  /**
+   * Controls whether library associations may be removed via UI interaction.
+   * Subclasses may override this method to control removal.
+   * @param library The library to remove.
+   */
+  isLibraryRemovalPermitted(library: LibraryWithSettingsData): boolean {
+    // library should be provided on every call.
+    // It is not used here, but might be in subclass implementations.
+    // Removal is permitted by default.
+    return true;
+  }
+
+  /**
+   * Removes the association with the given library from a service's state.
+   *
+   * NB: This method is used indirectly via `onRemove` by `sharedFunctions.clearForm`
+   * to clean up form state; therefore, care should be taken to avoid any side
+   * effects not needed for updating the state. Anything done by this method
+   * can happen whenever user interaction or `clearForm` triggers `onRemove`.
+   *
+   * Update or override `isLibraryRemovalPermitted` to control library removal
+   * via UI interaction.
+   *
+   * @param library
+   */
   removeLibrary(library) {
     const libraries = this.state.libraries.filter(
       (stateLibrary) => stateLibrary.short_name !== library.short_name

--- a/src/components/WithRemoveButton.tsx
+++ b/src/components/WithRemoveButton.tsx
@@ -5,6 +5,7 @@ import TrashIcon from "./icons/TrashIcon";
 export interface WithRemoveButtonProps {
   disabled: boolean;
   onRemove: () => void;
+  confirmRemoval?: () => boolean;
 }
 
 /** When wrapped around an element, renders a remove button next to the element. */
@@ -37,6 +38,12 @@ export default class WithRemoveButton extends React.Component<
 
   onClick(e: Event) {
     e.preventDefault();
+
+    // Don't remove if confirmation function is present and returns false.
+    if (this.props.confirmRemoval && !this.props.confirmRemoval()) {
+      return;
+    }
+    // Otherwise, we can proceed with removal.
     !this.props.disabled && this.props.onRemove();
   }
 }

--- a/src/components/__tests__/WithRemoveButton-test.tsx
+++ b/src/components/__tests__/WithRemoveButton-test.tsx
@@ -43,5 +43,27 @@ describe("WithRemoveButton", () => {
       removeBtn.simulate("click");
       expect(onRemove.callCount).to.equal(0);
     });
+
+    it("calls onRemove when confirmation returns true", () => {
+      const confirmRemoval = stub().returns(true);
+      wrapper.setProps({ confirmRemoval });
+      const removeBtn = wrapper.find(".remove-btn").hostNodes();
+
+      removeBtn.simulate("click");
+
+      expect(confirmRemoval.callCount).to.equal(1);
+      expect(onRemove.callCount).to.equal(1);
+    });
+
+    it("does not call onRemove when confirmation returns false", () => {
+      const confirmRemoval = stub().returns(false);
+      wrapper.setProps({ confirmRemoval });
+      const removeBtn = wrapper.find(".remove-btn").hostNodes();
+
+      removeBtn.simulate("click");
+
+      expect(confirmRemoval.callCount).to.equal(1);
+      expect(onRemove.callCount).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
## Description

Use newly-added `isLibraryRemovalPermitted` (instead of `removeLibrary`) to confirm interactive removals of library associations from collections.

NB: This PR is ready for review; however, it depends on #170 for `isLibraryRemovalPermitted`, so this PR should not be merged until that one is landed.

## Motivation and Context

Confirmation popups were rendering for each associated library when the `CollectionEditForm` was being cleared. This is because `removeLibrary` is used both interactively -- when library `Delete` button is clicked -- and non-interactively, when the form is cleared.

[Jira PP-2408]

## How Has This Been Tested?

- Testing in local environment.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/17103881259) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
