### PR TITLE
Show / hide configuration associations (PP-4022)

### DIFF
--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -4,6 +4,7 @@ import {
   EditableConfigListStateProps,
   EditableConfigListDispatchProps,
   EditableConfigListOwnProps,
+  AssociatedEntry,
 } from "./EditableConfigList";
 import { connect } from "react-redux";
 import * as PropTypes from "prop-types";
@@ -117,9 +118,9 @@ export class Collections extends GenericEditableConfigList<
     return {
       registerLibrary: (library: LibraryData) => {
         if (this.itemToEdit()) {
-          const data = new (window as any).FormData();
+          const data = new FormData();
           data.append("library_short_name", library.short_name);
-          data.append("collection_id", this.itemToEdit().id);
+          data.append("collection_id", String(this.itemToEdit().id));
           this.props.registerLibrary(data).then(() => {
             if (this.props.fetchLibraryRegistrations) {
               this.props.fetchLibraryRegistrations();
@@ -131,8 +132,12 @@ export class Collections extends GenericEditableConfigList<
     };
   }
 
-  UNSAFE_componentWillMount() {
-    super.UNSAFE_componentWillMount();
+  protected getAllLibraries() {
+    return this.props.data?.allLibraries ?? [];
+  }
+
+  componentDidMount() {
+    super.componentDidMount();
     if (this.props.fetchLibraryRegistrations) {
       this.props.fetchLibraryRegistrations();
     }
@@ -149,10 +154,16 @@ export class Collections extends GenericEditableConfigList<
     };
   }
 
-  renderLi(item, index): JSX.Element {
+  renderLi(
+    item: CollectionData,
+    precomputedEntries: AssociatedEntry[] | undefined | null = null
+  ): JSX.Element {
     if (item.marked_for_deletion) {
       return (
-        <li className="deleted-collection" key={index}>
+        <li
+          className="deleted-collection"
+          key={String(item[this.identifierKey])}
+        >
           <TrashIcon />
           <h4>{this.label(item)}</h4>
           <p>
@@ -163,7 +174,7 @@ export class Collections extends GenericEditableConfigList<
         </li>
       );
     }
-    return super.renderLi(item, index);
+    return super.renderLi(item, precomputedEntries);
   }
 
   async delete(item: CollectionData): Promise<void> {

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -59,11 +59,12 @@ export class DiscoveryServices extends GenericEditableConfigList<
   getChildContext() {
     return {
       registerLibrary: (library: LibraryData, registration_stage: string) => {
-        if (this.itemToEdit()) {
-          const data = new (window as any).FormData();
+        const item = this.itemToEdit();
+        if (item) {
+          const data = new FormData();
           data.append("library_short_name", library.short_name);
           data.append("registration_stage", registration_stage);
-          data.append("integration_id", this.itemToEdit().id);
+          data.append("integration_id", String(item.id));
           this.props.registerLibrary(data).then(() => {
             if (this.props.fetchLibraryRegistrations) {
               this.props.fetchLibraryRegistrations();
@@ -83,12 +84,6 @@ export class DiscoveryServices extends GenericEditableConfigList<
     return (serviceReg?.libraries ?? []).filter((l) => l.status === "success");
   }
 
-  protected getAssociatedItems(
-    item: DiscoveryServiceData
-  ): Array<any> | undefined {
-    return this.registeredLibraries(item);
-  }
-
   protected formatAssociatedCount(count: number): string {
     return count === 0
       ? "no registered libraries"
@@ -99,8 +94,9 @@ export class DiscoveryServices extends GenericEditableConfigList<
 
   protected getAssociatedEntries(
     item: DiscoveryServiceData
-  ): Array<{ label: string; suffix?: string; href?: string }> {
-    const registered = this.registeredLibraries(item) ?? [];
+  ): Array<{ label: string; suffix?: string; href?: string }> | undefined {
+    const registered = this.registeredLibraries(item);
+    if (registered === undefined) return undefined;
     const allLibraries = this.props.data?.allLibraries ?? [];
     return registered.map((lib) => {
       const meta = allLibraries.find((l) => l.short_name === lib.short_name);
@@ -113,8 +109,8 @@ export class DiscoveryServices extends GenericEditableConfigList<
     });
   }
 
-  UNSAFE_componentWillMount() {
-    super.UNSAFE_componentWillMount();
+  componentDidMount() {
+    super.componentDidMount();
     if (this.props.fetchLibraryRegistrations) {
       this.props.fetchLibraryRegistrations();
     }

--- a/src/components/DiscoveryServices.tsx
+++ b/src/components/DiscoveryServices.tsx
@@ -12,6 +12,7 @@ import {
   DiscoveryServicesData,
   DiscoveryServiceData,
   LibraryData,
+  LibraryDataWithStatus,
   LibraryRegistrationsData,
 } from "../interfaces";
 import ServiceWithRegistrationsEditForm from "./ServiceWithRegistrationsEditForm";
@@ -71,6 +72,45 @@ export class DiscoveryServices extends GenericEditableConfigList<
         }
       },
     };
+  }
+
+  private registeredLibraries(
+    item: DiscoveryServiceData
+  ): LibraryDataWithStatus[] | undefined {
+    const registrations = this.props.data?.libraryRegistrations;
+    if (!registrations) return undefined;
+    const serviceReg = registrations.find((r) => r.id === item.id);
+    return (serviceReg?.libraries ?? []).filter((l) => l.status === "success");
+  }
+
+  protected getAssociatedItems(
+    item: DiscoveryServiceData
+  ): Array<any> | undefined {
+    return this.registeredLibraries(item);
+  }
+
+  protected formatAssociatedCount(count: number): string {
+    return count === 0
+      ? "no registered libraries"
+      : count === 1
+      ? "1 registered library"
+      : `${count} registered libraries`;
+  }
+
+  protected getAssociatedEntries(
+    item: DiscoveryServiceData
+  ): Array<{ label: string; suffix?: string; href?: string }> {
+    const registered = this.registeredLibraries(item) ?? [];
+    const allLibraries = this.props.data?.allLibraries ?? [];
+    return registered.map((lib) => {
+      const meta = allLibraries.find((l) => l.short_name === lib.short_name);
+      const uuid = meta?.uuid ?? lib.uuid;
+      return {
+        label: meta?.name ?? lib.name ?? lib.short_name,
+        suffix: lib.stage ? ` - registered - ${lib.stage}` : " - registered",
+        href: uuid ? `/admin/web/config/libraries/edit/${uuid}` : undefined,
+      };
+    });
   }
 
   UNSAFE_componentWillMount() {

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -10,6 +10,7 @@ import ErrorMessage from "./ErrorMessage";
 import PencilIcon from "./icons/PencilIcon";
 import TrashIcon from "./icons/TrashIcon";
 import VisibleIcon from "./icons/VisibleIcon";
+import DisclosureIcon from "./icons/DisclosureIcon";
 import Admin from "../models/Admin";
 import * as PropTypes from "prop-types";
 
@@ -76,11 +77,15 @@ export interface ExtraFormSectionProps<T, U> {
 
     GenericEditableConfigList allows subclasses to define additional props. Subclasses of
     EditableConfigList cannot change the props and do not have to specify a type for them. */
+interface EditableConfigListState {
+  expandedItems: Record<string, boolean>;
+}
+
 export abstract class GenericEditableConfigList<
   T,
   U,
   V extends EditableConfigListProps<T>
-> extends React.Component<V> {
+> extends React.Component<V, EditableConfigListState> {
   context: { admin: Admin };
   static contextTypes = {
     admin: PropTypes.object.isRequired,
@@ -106,12 +111,18 @@ export abstract class GenericEditableConfigList<
   extraFormKey?: string;
   private editFormRef = React.createRef<any>();
 
+  state: EditableConfigListState = {
+    expandedItems: {},
+  };
+
   constructor(props) {
     super(props);
     this.editItem = this.editItem.bind(this);
     this.save = this.save.bind(this);
     this.label = this.label.bind(this);
     this.renderLi = this.renderLi.bind(this);
+    this.toggleLibraries = this.toggleLibraries.bind(this);
+    this.toggleAllLibraries = this.toggleAllLibraries.bind(this);
   }
 
   UNSAFE_componentWillMount() {
@@ -221,38 +232,76 @@ export abstract class GenericEditableConfigList<
 
   renderLi(item, index): JSX.Element {
     const AdditionalContent = this.AdditionalContent || null;
+    const libraries: Array<{ short_name: string }> | undefined =
+      item?.libraries;
+    const libraryCount = Array.isArray(libraries) ? libraries.length : null;
+    const itemKey = String(item[this.identifierKey]);
+    const isExpanded = libraryCount > 0 && !!this.state.expandedItems[itemKey];
 
     return (
       <li key={index}>
-        <a
-          className="btn small edit-item"
-          href={this.urlBase + "edit/" + item[this.identifierKey]}
-        >
-          {this.canEdit(item) ? (
-            <span>
-              Edit <PencilIcon />
-            </span>
-          ) : (
-            <span>
-              View <VisibleIcon />
-            </span>
-          )}
-        </a>
-
-        <h3>{this.label(item)}</h3>
-
-        {this.canDelete() && (
-          <Button
-            className="danger delete-item small"
-            callback={() => this.delete(item)}
-            content={
+        <div className="item-header">
+          <a
+            className="btn small edit-item"
+            href={this.urlBase + "edit/" + item[this.identifierKey]}
+          >
+            {this.canEdit(item) ? (
               <span>
-                Delete
-                <TrashIcon />
+                Edit <PencilIcon />
               </span>
-            }
-          />
-        )}
+            ) : (
+              <span>
+                View <VisibleIcon />
+              </span>
+            )}
+          </a>
+
+          <h3>
+            {libraryCount !== null && (
+              <button
+                className="library-toggle"
+                onClick={(e) =>
+                  e.altKey
+                    ? this.toggleAllLibraries()
+                    : this.toggleLibraries(itemKey)
+                }
+                aria-expanded={isExpanded}
+                disabled={libraryCount === 0}
+              >
+                <DisclosureIcon expanded={isExpanded} />
+              </button>
+            )}
+            <span>
+              {this.label(item)}
+              {libraryCount !== null && (
+                <span className="library-count">
+                  {" "}
+                  (
+                  {libraryCount === 0
+                    ? "no libraries"
+                    : libraryCount === 1
+                    ? "1 library"
+                    : `${libraryCount} libraries`}
+                  )
+                </span>
+              )}
+            </span>
+          </h3>
+
+          {this.canDelete() && (
+            <Button
+              className="danger delete-item small"
+              callback={() => this.delete(item)}
+              content={
+                <span>
+                  Delete
+                  <TrashIcon />
+                </span>
+              }
+            />
+          )}
+        </div>
+        {isExpanded && this.renderAssociatedLibraries(item)}
         {AdditionalContent && (
           <AdditionalContent
             type={this.itemTypeName}
@@ -262,6 +311,63 @@ export abstract class GenericEditableConfigList<
           />
         )}
       </li>
+    );
+  }
+
+  toggleLibraries(itemKey: string): void {
+    this.setState((prev) => ({
+      expandedItems: {
+        ...prev.expandedItems,
+        [itemKey]: !prev.expandedItems[itemKey],
+      },
+    }));
+  }
+
+  toggleAllLibraries(): void {
+    const items: any[] = (this.props.data as any)?.[this.listDataKey] || [];
+    const itemsWithLibraries = items.filter(
+      (item) => Array.isArray(item.libraries) && item.libraries.length > 0
+    );
+    if (itemsWithLibraries.length === 0) return;
+
+    const anyCollapsed = itemsWithLibraries.some(
+      (item) => !this.state.expandedItems[String(item[this.identifierKey])]
+    );
+
+    const newExpandedItems: Record<string, boolean> = {};
+    if (anyCollapsed) {
+      for (const item of itemsWithLibraries) {
+        newExpandedItems[String(item[this.identifierKey])] = true;
+      }
+    }
+    this.setState({ expandedItems: newExpandedItems });
+  }
+
+  renderAssociatedLibraries(item: any): JSX.Element {
+    const libraries: Array<{ short_name: string }> = item.libraries;
+    const allLibraries: Array<{
+      short_name: string;
+      name?: string;
+      uuid?: string;
+    }> = (this.props.data as any)?.allLibraries || [];
+
+    return (
+      <ul className="associated-libraries">
+        {libraries.map((lib) => {
+          const libraryData = allLibraries.find(
+            (l) => l.short_name === lib.short_name
+          );
+          const name = libraryData?.name || lib.short_name;
+          const href = libraryData?.uuid
+            ? `/admin/web/config/libraries/edit/${libraryData.uuid}`
+            : null;
+          return (
+            <li key={lib.short_name}>
+              {href ? <a href={href}>{name}</a> : name}
+            </li>
+          );
+        })}
+      </ul>
     );
   }
 

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -202,11 +202,10 @@ export abstract class GenericEditableConfigList<
                 this.renderLi(item, entries)
               )}
             </ul>
-            {/* aria-hidden: the bottom controls are a visual convenience
-                duplicate of the controls above the list. Screen readers and
-                keyboard users should interact with the first set only. */}
+            {/* Extra expand / collapse buttons as a convenience for sighted
+                users. Hide from accessibility tree & remove from tab order. */}
             <div aria-hidden="true">
-              {this.renderExpandCollapseControls(expandable)}
+              {this.renderExpandCollapseControls(expandable, true)}
             </div>
           </div>
         )}
@@ -500,7 +499,10 @@ export abstract class GenericEditableConfigList<
     });
   }
 
-  private renderExpandCollapseControls(expandable: U[]): JSX.Element | null {
+  private renderExpandCollapseControls(
+    expandable: U[],
+    visualOnly = false
+  ): JSX.Element | null {
     if (expandable.length === 0) return null;
     const allExpanded = expandable.every(
       (item) => !!this.state.expandedItems[String(item[this.identifierKey])]
@@ -508,12 +510,14 @@ export abstract class GenericEditableConfigList<
     const noneExpanded = expandable.every(
       (item) => !this.state.expandedItems[String(item[this.identifierKey])]
     );
+    const tabIndex = visualOnly ? -1 : undefined;
     return (
       <div className="expand-collapse-controls">
         <button
           className="expand-all"
           onClick={this.expandAll}
           disabled={allExpanded}
+          tabIndex={tabIndex}
         >
           Expand all
         </button>
@@ -521,6 +525,7 @@ export abstract class GenericEditableConfigList<
           className="collapse-all"
           onClick={this.collapseAll}
           disabled={noneExpanded}
+          tabIndex={tabIndex}
         >
           Collapse all
         </button>

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -241,21 +241,6 @@ export abstract class GenericEditableConfigList<
     return (
       <li key={index}>
         <div className="item-header">
-          <a
-            className="btn small edit-item"
-            href={this.urlBase + "edit/" + item[this.identifierKey]}
-          >
-            {this.canEdit(item) ? (
-              <span>
-                Edit <PencilIcon />
-              </span>
-            ) : (
-              <span>
-                View <VisibleIcon />
-              </span>
-            )}
-          </a>
-
           <h3>
             {libraryCount !== null && (
               <button
@@ -287,6 +272,21 @@ export abstract class GenericEditableConfigList<
               )}
             </span>
           </h3>
+
+          <a
+            className="btn small edit-item"
+            href={this.urlBase + "edit/" + item[this.identifierKey]}
+          >
+            {this.canEdit(item) ? (
+              <span>
+                Edit <PencilIcon />
+              </span>
+            ) : (
+              <span>
+                View <VisibleIcon />
+              </span>
+            )}
+          </a>
 
           {this.canDelete() && (
             <Button

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -242,8 +242,42 @@ export abstract class GenericEditableConfigList<
       : `${count} libraries`;
   }
 
+  protected getAssociatedEntries(
+    item: any
+  ): Array<{ label: string; suffix?: string; href?: string }> {
+    const libraries: Array<{ short_name: string }> = item?.libraries || [];
+    const allLibraries: Array<{
+      short_name: string;
+      name?: string;
+      uuid?: string;
+    }> = (this.props.data as any)?.allLibraries || [];
+    return libraries.map((lib) => {
+      const libraryData = allLibraries.find(
+        (l) => l.short_name === lib.short_name
+      );
+      return {
+        label: libraryData?.name || lib.short_name,
+        href: libraryData?.uuid
+          ? `/admin/web/config/libraries/edit/${libraryData.uuid}`
+          : undefined,
+      };
+    });
+  }
+
   protected renderAssociatedSection(item: any): JSX.Element {
-    return this.renderAssociatedLibraries(item);
+    const entries = this.getAssociatedEntries(item).sort((a, b) =>
+      a.label.localeCompare(b.label)
+    );
+    return (
+      <ul className="associated-libraries">
+        {entries.map((entry, i) => (
+          <li key={i}>
+            {entry.href ? <a href={entry.href}>{entry.label}</a> : entry.label}
+            {entry.suffix}
+          </li>
+        ))}
+      </ul>
+    );
   }
 
   renderLi(item, index): JSX.Element {
@@ -353,34 +387,6 @@ export abstract class GenericEditableConfigList<
       }
     }
     this.setState({ expandedItems: newExpandedItems });
-  }
-
-  renderAssociatedLibraries(item: any): JSX.Element {
-    const libraries: Array<{ short_name: string }> = item.libraries;
-    const allLibraries: Array<{
-      short_name: string;
-      name?: string;
-      uuid?: string;
-    }> = (this.props.data as any)?.allLibraries || [];
-
-    return (
-      <ul className="associated-libraries">
-        {libraries.map((lib) => {
-          const libraryData = allLibraries.find(
-            (l) => l.short_name === lib.short_name
-          );
-          const name = libraryData?.name || lib.short_name;
-          const href = libraryData?.uuid
-            ? `/admin/web/config/libraries/edit/${libraryData.uuid}`
-            : null;
-          return (
-            <li key={lib.short_name}>
-              {href ? <a href={href}>{name}</a> : name}
-            </li>
-          );
-        })}
-      </ul>
-    );
   }
 
   label(item): string {

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Store } from "@reduxjs/toolkit";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
-import { SettingData } from "../interfaces";
+import { LibraryData, SettingData } from "../interfaces";
 import { Alert } from "react-bootstrap";
 import { RootState } from "../store";
 import { Button } from "library-simplified-reusable-components";
@@ -71,6 +71,14 @@ export interface ExtraFormSectionProps<T, U> {
   currentValue?: string;
 }
 
+/** A single entry in the associated-items disclosure panel. */
+export interface AssociatedEntry {
+  label: string;
+  suffix?: string;
+  href?: string;
+  pinned?: boolean;
+}
+
 /** Shows a list of configuration services of a particular type and allows creating a new
     service or editing or deleting an existing services. Used for many of the tabs on the
     system configuration page.
@@ -121,11 +129,13 @@ export abstract class GenericEditableConfigList<
     this.save = this.save.bind(this);
     this.label = this.label.bind(this);
     this.renderLi = this.renderLi.bind(this);
-    this.toggleLibraries = this.toggleLibraries.bind(this);
-    this.toggleAllLibraries = this.toggleAllLibraries.bind(this);
+    this.toggleAssociations = this.toggleAssociations.bind(this);
+    this.toggleAllAssociations = this.toggleAllAssociations.bind(this);
+    this.expandAll = this.expandAll.bind(this);
+    this.collapseAll = this.collapseAll.bind(this);
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     const { fetchData, isFetching } = this.props;
 
     if (fetchData && !isFetching) {
@@ -145,6 +155,16 @@ export abstract class GenericEditableConfigList<
     const ExtraFormSection = this.ExtraFormSection;
     const itemToEdit = this.itemToEdit();
     const canEditItem = itemToEdit && this.canEdit(itemToEdit);
+    const itemsWithEntries: Array<[
+      U,
+      AssociatedEntry[] | undefined
+    ]> = this.getItems().map((item) => [item, this.getAssociatedEntries(item)]);
+    const expandable: U[] = itemsWithEntries
+      .filter((pair): pair is [U, AssociatedEntry[]] => {
+        const [, e] = pair;
+        return e != null && e.length > 0;
+      })
+      .map(([item]) => item);
     return (
       <div className={this.getClassName()}>
         <h2>{headers["h2"]}</h2>
@@ -176,11 +196,18 @@ export abstract class GenericEditableConfigList<
                 )}
               <div>{this.props.data[this.listDataKey].length} configured</div>
             </header>
+            {this.renderExpandCollapseControls(expandable)}
             <ul>
-              {this.props.data[this.listDataKey].map((item, index) =>
-                this.renderLi(item, index)
+              {itemsWithEntries.map(([item, entries]) =>
+                this.renderLi(item, entries)
               )}
             </ul>
+            {/* aria-hidden: the bottom controls are a visual convenience
+                duplicate of the controls above the list. Screen readers and
+                keyboard users should interact with the first set only. */}
+            <div aria-hidden="true">
+              {this.renderExpandCollapseControls(expandable)}
+            </div>
           </div>
         )}
         {this.props.editOrCreate === "create" && (
@@ -230,10 +257,37 @@ export abstract class GenericEditableConfigList<
     );
   }
 
-  protected getAssociatedItems(item: any): Array<any> | undefined {
-    return item?.libraries;
+  /**
+   * Returns the raw list of items from the current data, or `[]` when data
+   * has not yet loaded.  Centralises the `any` cast required because `T` is
+   * not constrained to include `listDataKey`.
+   */
+  protected getItems(): U[] {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.props.data as any)?.[this.listDataKey] ?? [];
   }
 
+  /**
+   * Returns the full list of libraries known to the server, used to resolve
+   * short names to display names and UUIDs for the associated-items panel.
+   *
+   * The base implementation accesses `data.allLibraries` via an `any` cast
+   * because the generic `T` is not constrained to include that field (e.g.
+   * `LibrariesData` does not have it). Subclasses whose data type declares
+   * `allLibraries` (e.g. `Collections`, `IndividualAdmins`) should override
+   * this method with a type-safe accessor to avoid the cast.
+   */
+  protected getAllLibraries(): LibraryData[] {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.props.data as any)?.allLibraries ?? [];
+  }
+
+  /**
+   * Returns a human-readable summary of the association count shown next to
+   * the item label (e.g. "3 libraries", "no libraries").  Override in
+   * subclasses that use different terminology (e.g. "registered libraries",
+   * "roles").
+   */
   protected formatAssociatedCount(count: number): string {
     return count === 0
       ? "no libraries"
@@ -242,15 +296,32 @@ export abstract class GenericEditableConfigList<
       : `${count} libraries`;
   }
 
-  protected getAssociatedEntries(
-    item: any
-  ): Array<{ label: string; suffix?: string; href?: string }> {
-    const libraries: Array<{ short_name: string }> = item?.libraries || [];
-    const allLibraries: Array<{
-      short_name: string;
-      name?: string;
-      uuid?: string;
-    }> = (this.props.data as any)?.allLibraries || [];
+  /**
+   * Returns the list of display entries to show in the associated-items panel
+   * for a given item, or `undefined` if the panel does not apply to this item.
+   *
+   * Return semantics (used by `renderLi` to drive toggle visibility):
+   * - `undefined`  → the feature does not apply; no toggle is rendered.
+   * - `[]`         → the feature applies but there are no associations;
+   *                  a disabled toggle is rendered.
+   * - `[…entries]` → associations exist; an enabled toggle is rendered.
+   *
+   * The base implementation reads the item's `libraries` field (an array of
+   * `{ short_name }` objects) and resolves each entry against `getAllLibraries`.
+   * Subclasses may override to supply different data sources or terminology
+   * (see `DiscoveryServices.getAssociatedEntries`,
+   * `IndividualAdmins.getAssociatedEntries`).
+   *
+   * Subclasses that do not support the feature should *not* override this
+   * method; simply ensure that the item type has no `libraries` field so the
+   * base implementation returns `undefined` for every item (see `Libraries`).
+   */
+  protected getAssociatedEntries(item: U): AssociatedEntry[] | undefined {
+    const libraries: Array<{ short_name: string }> | undefined =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (item as any)?.libraries;
+    if (libraries === undefined) return undefined;
+    const allLibraries = this.getAllLibraries();
     return libraries.map((lib) => {
       const libraryData = allLibraries.find(
         (l) => l.short_name === lib.short_name
@@ -264,14 +335,21 @@ export abstract class GenericEditableConfigList<
     });
   }
 
-  protected renderAssociatedSection(item: any): JSX.Element {
-    const entries = this.getAssociatedEntries(item).sort((a, b) =>
-      a.label.localeCompare(b.label)
-    );
+  /**
+   * Renders the expanded associated-items `<ul>`.  Pinned entries (e.g.
+   * sitewide roles) are sorted before per-item entries; within each group
+   * entries are sorted alphabetically by label.
+   */
+  protected renderAssociatedSection(entries: AssociatedEntry[]): JSX.Element {
+    const sorted = [...entries].sort((a, b) => {
+      // Pinned entries (e.g. sitewide roles) always appear before per-item entries.
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
     return (
-      <ul className="associated-libraries">
-        {entries.map((entry, i) => (
-          <li key={i}>
+      <ul className="associated-items">
+        {sorted.map((entry, i) => (
+          <li key={entry.href ?? `${entry.label}-${i}`}>
             {entry.href ? <a href={entry.href}>{entry.label}</a> : entry.label}
             {entry.suffix}
           </li>
@@ -280,34 +358,52 @@ export abstract class GenericEditableConfigList<
     );
   }
 
-  renderLi(item, index): JSX.Element {
+  renderLi(
+    item: U,
+    precomputedEntries: AssociatedEntry[] | undefined | null = null
+  ): JSX.Element {
     const AdditionalContent = this.AdditionalContent || null;
-    const associatedItems = this.getAssociatedItems(item);
-    const libraryCount = Array.isArray(associatedItems)
-      ? associatedItems.length
-      : null;
+    const associatedEntries =
+      precomputedEntries !== null
+        ? precomputedEntries
+        : this.getAssociatedEntries(item);
+    const libraryCount =
+      associatedEntries != null ? associatedEntries.length : null;
     const itemKey = String(item[this.identifierKey]);
-    const isExpanded = libraryCount > 0 && !!this.state.expandedItems[itemKey];
+    const isExpanded =
+      libraryCount !== null &&
+      libraryCount > 0 &&
+      !!this.state.expandedItems[itemKey];
 
     return (
-      <li key={index}>
+      <li key={itemKey}>
         <div className="item-header">
-          <h3>
+          <div className="item-label">
             {libraryCount !== null && (
               <button
-                className="library-toggle"
+                className="association-toggle"
                 onClick={(e) =>
                   e.altKey
-                    ? this.toggleAllLibraries()
-                    : this.toggleLibraries(itemKey)
+                    ? this.toggleAllAssociations()
+                    : this.toggleAssociations(itemKey)
                 }
-                aria-expanded={isExpanded}
+                {...(libraryCount > 0 ? { "aria-expanded": isExpanded } : {})}
+                aria-label={`${
+                  isExpanded ? "Collapse" : "Expand"
+                } associations for ${this.label(item)} (Alt+Click to ${
+                  isExpanded ? "collapse" : "expand"
+                } all)`}
+                title={`${
+                  isExpanded ? "Collapse" : "Expand"
+                } associations for ${this.label(item)} (Alt+Click to ${
+                  isExpanded ? "collapse" : "expand"
+                } all)`}
                 disabled={libraryCount === 0}
               >
                 <DisclosureIcon expanded={isExpanded} />
               </button>
             )}
-            <span>
+            <h3>
               {this.label(item)}
               {libraryCount !== null && (
                 <span className="library-count">
@@ -315,8 +411,8 @@ export abstract class GenericEditableConfigList<
                   ({this.formatAssociatedCount(libraryCount)})
                 </span>
               )}
-            </span>
-          </h3>
+            </h3>
+          </div>
 
           <a
             className="btn small edit-item"
@@ -346,7 +442,7 @@ export abstract class GenericEditableConfigList<
             />
           )}
         </div>
-        {isExpanded && this.renderAssociatedSection(item)}
+        {isExpanded && this.renderAssociatedSection(associatedEntries)}
         {AdditionalContent && (
           <AdditionalContent
             type={this.itemTypeName}
@@ -359,7 +455,7 @@ export abstract class GenericEditableConfigList<
     );
   }
 
-  toggleLibraries(itemKey: string): void {
+  toggleAssociations(itemKey: string): void {
     this.setState((prev) => ({
       expandedItems: {
         ...prev.expandedItems,
@@ -368,25 +464,69 @@ export abstract class GenericEditableConfigList<
     }));
   }
 
-  toggleAllLibraries(): void {
-    const items: any[] = (this.props.data as any)?.[this.listDataKey] || [];
-    const itemsWithAssociations = items.filter((item) => {
-      const associated = this.getAssociatedItems(item);
-      return Array.isArray(associated) && associated.length > 0;
-    });
-    if (itemsWithAssociations.length === 0) return;
-
-    const anyCollapsed = itemsWithAssociations.some(
-      (item) => !this.state.expandedItems[String(item[this.identifierKey])]
-    );
-
+  expandAll(): void {
     const newExpandedItems: Record<string, boolean> = {};
-    if (anyCollapsed) {
-      for (const item of itemsWithAssociations) {
-        newExpandedItems[String(item[this.identifierKey])] = true;
-      }
+    for (const item of this.getExpandableItems()) {
+      newExpandedItems[String(item[this.identifierKey])] = true;
     }
     this.setState({ expandedItems: newExpandedItems });
+  }
+
+  collapseAll(): void {
+    this.setState({ expandedItems: {} });
+  }
+
+  toggleAllAssociations(): void {
+    const expandable = this.getExpandableItems();
+    if (expandable.length === 0) return;
+    const anyCollapsed = expandable.some(
+      (item) => !this.state.expandedItems[String(item[this.identifierKey])]
+    );
+    if (anyCollapsed) {
+      const expandedItems: Record<string, boolean> = {};
+      for (const item of expandable) {
+        expandedItems[String(item[this.identifierKey])] = true;
+      }
+      this.setState({ expandedItems });
+    } else {
+      this.collapseAll();
+    }
+  }
+
+  /** Returns items that have at least one associated entry (i.e. are expandable). */
+  private getExpandableItems(): U[] {
+    return this.getItems().filter((item) => {
+      const entries = this.getAssociatedEntries(item);
+      return entries != null && entries.length > 0;
+    });
+  }
+
+  private renderExpandCollapseControls(expandable: U[]): JSX.Element | null {
+    if (expandable.length === 0) return null;
+    const allExpanded = expandable.every(
+      (item) => !!this.state.expandedItems[String(item[this.identifierKey])]
+    );
+    const noneExpanded = expandable.every(
+      (item) => !this.state.expandedItems[String(item[this.identifierKey])]
+    );
+    return (
+      <div className="expand-collapse-controls">
+        <button
+          className="expand-all"
+          onClick={this.expandAll}
+          disabled={allExpanded}
+        >
+          Expand all
+        </button>
+        <button
+          className="collapse-all"
+          onClick={this.collapseAll}
+          disabled={noneExpanded}
+        >
+          Collapse all
+        </button>
+      </div>
+    );
   }
 
   label(item): string {
@@ -485,15 +625,20 @@ export abstract class GenericEditableConfigList<
   }
 
   save(data: FormData) {
-    this.editItem(data).then(() => {
-      if (this.limitOne && this.props.editOrCreate === "create") {
-        // Wait for two seconds so that the user can see the success message,
-        // then go to the edit page
-        setTimeout(() => {
-          window.location.href = `${this.urlBase}edit/${this.props.responseBody}`;
-        }, 2000);
-      }
-    });
+    this.editItem(data)
+      .then(() => {
+        if (this.limitOne && this.props.editOrCreate === "create") {
+          // Wait for two seconds so that the user can see the success message,
+          // then go to the edit page
+          setTimeout(() => {
+            window.location.href = `${this.urlBase}edit/${this.props.responseBody}`;
+          }, 2000);
+        }
+      })
+      .catch(() => {
+        // Error already surfaced via the Redux formError prop; suppress the
+        // unhandled-rejection warning.
+      });
   }
 
   async editItem(data: FormData): Promise<void> {

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -230,11 +230,28 @@ export abstract class GenericEditableConfigList<
     );
   }
 
+  protected getAssociatedItems(item: any): Array<any> | undefined {
+    return item?.libraries;
+  }
+
+  protected formatAssociatedCount(count: number): string {
+    return count === 0
+      ? "no libraries"
+      : count === 1
+      ? "1 library"
+      : `${count} libraries`;
+  }
+
+  protected renderAssociatedSection(item: any): JSX.Element {
+    return this.renderAssociatedLibraries(item);
+  }
+
   renderLi(item, index): JSX.Element {
     const AdditionalContent = this.AdditionalContent || null;
-    const libraries: Array<{ short_name: string }> | undefined =
-      item?.libraries;
-    const libraryCount = Array.isArray(libraries) ? libraries.length : null;
+    const associatedItems = this.getAssociatedItems(item);
+    const libraryCount = Array.isArray(associatedItems)
+      ? associatedItems.length
+      : null;
     const itemKey = String(item[this.identifierKey]);
     const isExpanded = libraryCount > 0 && !!this.state.expandedItems[itemKey];
 
@@ -261,13 +278,7 @@ export abstract class GenericEditableConfigList<
               {libraryCount !== null && (
                 <span className="library-count">
                   {" "}
-                  (
-                  {libraryCount === 0
-                    ? "no libraries"
-                    : libraryCount === 1
-                    ? "1 library"
-                    : `${libraryCount} libraries`}
-                  )
+                  ({this.formatAssociatedCount(libraryCount)})
                 </span>
               )}
             </span>
@@ -301,7 +312,7 @@ export abstract class GenericEditableConfigList<
             />
           )}
         </div>
-        {isExpanded && this.renderAssociatedLibraries(item)}
+        {isExpanded && this.renderAssociatedSection(item)}
         {AdditionalContent && (
           <AdditionalContent
             type={this.itemTypeName}
@@ -325,18 +336,19 @@ export abstract class GenericEditableConfigList<
 
   toggleAllLibraries(): void {
     const items: any[] = (this.props.data as any)?.[this.listDataKey] || [];
-    const itemsWithLibraries = items.filter(
-      (item) => Array.isArray(item.libraries) && item.libraries.length > 0
-    );
-    if (itemsWithLibraries.length === 0) return;
+    const itemsWithAssociations = items.filter((item) => {
+      const associated = this.getAssociatedItems(item);
+      return Array.isArray(associated) && associated.length > 0;
+    });
+    if (itemsWithAssociations.length === 0) return;
 
-    const anyCollapsed = itemsWithLibraries.some(
+    const anyCollapsed = itemsWithAssociations.some(
       (item) => !this.state.expandedItems[String(item[this.identifierKey])]
     );
 
     const newExpandedItems: Record<string, boolean> = {};
     if (anyCollapsed) {
-      for (const item of itemsWithLibraries) {
+      for (const item of itemsWithAssociations) {
         newExpandedItems[String(item[this.identifierKey])] = true;
       }
     }

--- a/src/components/EditableConfigList.tsx
+++ b/src/components/EditableConfigList.tsx
@@ -259,7 +259,7 @@ export abstract class GenericEditableConfigList<
 
   /**
    * Returns the raw list of items from the current data, or `[]` when data
-   * has not yet loaded.  Centralises the `any` cast required because `T` is
+   * has not yet loaded.  Centralizes the `any` cast required because `T` is
    * not constrained to include `listDataKey`.
    */
   protected getItems(): U[] {
@@ -375,6 +375,16 @@ export abstract class GenericEditableConfigList<
       libraryCount > 0 &&
       !!this.state.expandedItems[itemKey];
 
+    const itemLabel = this.label(item);
+    const expandVerb = isExpanded ? "Collapse" : "Expand";
+    const expandAction = isExpanded ? "collapse" : "expand";
+    const toggleButtonLabel = `${expandVerb} associations for ${itemLabel} (Alt+Click to ${expandAction} all)`;
+    const ariaExpandedProp =
+      libraryCount > 0 ? { "aria-expanded": isExpanded } : {};
+    const editHref = this.urlBase + "edit/" + item[this.identifierKey];
+    const canEdit = this.canEdit(item);
+    const canDelete = this.canDelete();
+
     return (
       <li key={itemKey}>
         <div className="item-header">
@@ -387,24 +397,16 @@ export abstract class GenericEditableConfigList<
                     ? this.toggleAllAssociations()
                     : this.toggleAssociations(itemKey)
                 }
-                {...(libraryCount > 0 ? { "aria-expanded": isExpanded } : {})}
-                aria-label={`${
-                  isExpanded ? "Collapse" : "Expand"
-                } associations for ${this.label(item)} (Alt+Click to ${
-                  isExpanded ? "collapse" : "expand"
-                } all)`}
-                title={`${
-                  isExpanded ? "Collapse" : "Expand"
-                } associations for ${this.label(item)} (Alt+Click to ${
-                  isExpanded ? "collapse" : "expand"
-                } all)`}
+                {...ariaExpandedProp}
+                aria-label={toggleButtonLabel}
+                title={toggleButtonLabel}
                 disabled={libraryCount === 0}
               >
                 <DisclosureIcon expanded={isExpanded} />
               </button>
             )}
             <h3>
-              {this.label(item)}
+              {itemLabel}
               {libraryCount !== null && (
                 <span className="library-count">
                   {" "}
@@ -414,11 +416,8 @@ export abstract class GenericEditableConfigList<
             </h3>
           </div>
 
-          <a
-            className="btn small edit-item"
-            href={this.urlBase + "edit/" + item[this.identifierKey]}
-          >
-            {this.canEdit(item) ? (
+          <a className="btn small edit-item" href={editHref}>
+            {canEdit ? (
               <span>
                 Edit <PencilIcon />
               </span>
@@ -429,7 +428,7 @@ export abstract class GenericEditableConfigList<
             )}
           </a>
 
-          {this.canDelete() && (
+          {canDelete && (
             <Button
               className="danger delete-item small"
               callback={() => this.delete(item)}

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -7,7 +7,11 @@ import EditableConfigList, {
 } from "./EditableConfigList";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
-import { IndividualAdminsData, IndividualAdminData } from "../interfaces";
+import {
+  IndividualAdminsData,
+  IndividualAdminData,
+  AdminRoleData,
+} from "../interfaces";
 import Admin from "../models/Admin";
 import IndividualAdminEditForm from "./IndividualAdminEditForm";
 
@@ -29,6 +33,88 @@ export class IndividualAdmins extends EditableConfigList<
   static contextTypes = {
     admin: PropTypes.object.isRequired,
   };
+
+  private getRolesSummary(
+    item: IndividualAdminData
+  ): Array<{ label: string; suffix?: string; href?: string }> {
+    const roles: AdminRoleData[] = item.roles || [];
+
+    if (roles.some((r) => r.role === "system")) {
+      return [{ label: "sysadmin" }];
+    }
+
+    const allLibraries: Array<{
+      short_name: string;
+      name?: string;
+      uuid?: string;
+    }> = (this.props.data as any)?.allLibraries || [];
+
+    const getLibraryName = (shortName: string) =>
+      allLibraries.find((l) => l.short_name === shortName)?.name || shortName;
+
+    const getLibraryHref = (shortName: string) => {
+      const uuid = allLibraries.find((l) => l.short_name === shortName)?.uuid;
+      return uuid ? `/admin/web/config/libraries/edit/${uuid}` : undefined;
+    };
+
+    const result: Array<{ label: string; suffix?: string; href?: string }> = [];
+
+    if (roles.some((r) => r.role === "manager-all")) {
+      result.push({ label: "All libraries", suffix: " - Manager" });
+    } else if (roles.some((r) => r.role === "librarian-all")) {
+      result.push({ label: "All libraries", suffix: " - Librarian" });
+    }
+
+    const libraryHighestRole: Record<string, "manager" | "librarian"> = {};
+    for (const r of roles) {
+      if (r.library) {
+        if (r.role === "manager") {
+          libraryHighestRole[r.library] = "manager";
+        } else if (
+          r.role === "librarian" &&
+          libraryHighestRole[r.library] !== "manager"
+        ) {
+          libraryHighestRole[r.library] = "librarian";
+        }
+      }
+    }
+
+    for (const [shortName, role] of Object.entries(libraryHighestRole)) {
+      result.push({
+        label: getLibraryName(shortName),
+        suffix: role === "manager" ? " - Manager" : " - Librarian",
+        href: getLibraryHref(shortName),
+      });
+    }
+
+    result.sort((a, b) => a.label.localeCompare(b.label));
+    return result;
+  }
+
+  protected getAssociatedItems(
+    item: IndividualAdminData
+  ): Array<any> | undefined {
+    if (!item.roles) return undefined;
+    return this.getRolesSummary(item);
+  }
+
+  protected formatAssociatedCount(count: number): string {
+    return count === 0 ? "no roles" : count === 1 ? "1 role" : `${count} roles`;
+  }
+
+  protected renderAssociatedSection(item: IndividualAdminData): JSX.Element {
+    const summary = this.getRolesSummary(item);
+    return (
+      <ul className="associated-libraries">
+        {summary.map((entry, i) => (
+          <li key={i}>
+            {entry.href ? <a href={entry.href}>{entry.label}</a> : entry.label}
+            {entry.suffix}
+          </li>
+        ))}
+      </ul>
+    );
+  }
 
   canCreate() {
     return (

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -87,7 +87,6 @@ export class IndividualAdmins extends EditableConfigList<
       });
     }
 
-    result.sort((a, b) => a.label.localeCompare(b.label));
     return result;
   }
 
@@ -102,18 +101,10 @@ export class IndividualAdmins extends EditableConfigList<
     return count === 0 ? "no roles" : count === 1 ? "1 role" : `${count} roles`;
   }
 
-  protected renderAssociatedSection(item: IndividualAdminData): JSX.Element {
-    const summary = this.getRolesSummary(item);
-    return (
-      <ul className="associated-libraries">
-        {summary.map((entry, i) => (
-          <li key={i}>
-            {entry.href ? <a href={entry.href}>{entry.label}</a> : entry.label}
-            {entry.suffix}
-          </li>
-        ))}
-      </ul>
-    );
+  protected getAssociatedEntries(
+    item: IndividualAdminData
+  ): Array<{ label: string; suffix?: string; href?: string }> {
+    return this.getRolesSummary(item);
   }
 
   canCreate() {

--- a/src/components/IndividualAdmins.tsx
+++ b/src/components/IndividualAdmins.tsx
@@ -36,18 +36,14 @@ export class IndividualAdmins extends EditableConfigList<
 
   private getRolesSummary(
     item: IndividualAdminData
-  ): Array<{ label: string; suffix?: string; href?: string }> {
+  ): Array<{
+    label: string;
+    suffix?: string;
+    href?: string;
+    pinned?: boolean;
+  }> {
     const roles: AdminRoleData[] = item.roles || [];
-
-    if (roles.some((r) => r.role === "system")) {
-      return [{ label: "sysadmin" }];
-    }
-
-    const allLibraries: Array<{
-      short_name: string;
-      name?: string;
-      uuid?: string;
-    }> = (this.props.data as any)?.allLibraries || [];
+    const allLibraries = this.getAllLibraries();
 
     const getLibraryName = (shortName: string) =>
       allLibraries.find((l) => l.short_name === shortName)?.name || shortName;
@@ -57,12 +53,25 @@ export class IndividualAdmins extends EditableConfigList<
       return uuid ? `/admin/web/config/libraries/edit/${uuid}` : undefined;
     };
 
-    const result: Array<{ label: string; suffix?: string; href?: string }> = [];
+    const result: Array<{
+      label: string;
+      suffix?: string;
+      href?: string;
+      pinned?: boolean;
+    }> = [];
 
     if (roles.some((r) => r.role === "manager-all")) {
-      result.push({ label: "All libraries", suffix: " - Manager" });
+      result.push({
+        label: "All libraries",
+        suffix: " - Manager",
+        pinned: true,
+      });
     } else if (roles.some((r) => r.role === "librarian-all")) {
-      result.push({ label: "All libraries", suffix: " - Librarian" });
+      result.push({
+        label: "All libraries",
+        suffix: " - Librarian",
+        pinned: true,
+      });
     }
 
     const libraryHighestRole: Record<string, "manager" | "librarian"> = {};
@@ -90,11 +99,8 @@ export class IndividualAdmins extends EditableConfigList<
     return result;
   }
 
-  protected getAssociatedItems(
-    item: IndividualAdminData
-  ): Array<any> | undefined {
-    if (!item.roles) return undefined;
-    return this.getRolesSummary(item);
+  protected getAllLibraries() {
+    return this.props.data?.allLibraries ?? [];
   }
 
   protected formatAssociatedCount(count: number): string {
@@ -103,7 +109,15 @@ export class IndividualAdmins extends EditableConfigList<
 
   protected getAssociatedEntries(
     item: IndividualAdminData
-  ): Array<{ label: string; suffix?: string; href?: string }> {
+  ):
+    | Array<{ label: string; suffix?: string; href?: string; pinned?: boolean }>
+    | undefined {
+    if (!item.roles) return undefined;
+    // System admins have a single implicit role that isn't library-scoped;
+    // show a synthetic "sysadmin" entry rather than the library-role summary.
+    if (item.roles.some((r) => r.role === "system")) {
+      return [{ label: "sysadmin" }];
+    }
     return this.getRolesSummary(item);
   }
 
@@ -117,7 +131,9 @@ export class IndividualAdmins extends EditableConfigList<
     return this.context.admin && this.context.admin.isSystemAdmin();
   }
 
-  canEdit() {
+  // Override: editability is determined by the current user's role, not the
+  // per-item level field used by the base class.
+  canEdit(_item?: IndividualAdminData): boolean {
     return (
       this.context.admin && this.context.admin.isLibraryManagerOfSomeLibrary()
     );
@@ -139,14 +155,18 @@ export class IndividualAdmins extends EditableConfigList<
   }
 
   save(data: FormData) {
-    this.editItem(data).then(() => {
-      // If we're setting up an admin for the first time, refresh the page
-      // to go to login.
-      if (this.props.settingUp) {
-        window.location.reload();
-        return;
-      }
-    });
+    this.editItem(data)
+      .then(() => {
+        // If we're setting up an admin for the first time, refresh the page
+        // to go to login.
+        if (this.props.settingUp) {
+          window.location.reload();
+        }
+      })
+      .catch(() => {
+        // Error already surfaced via the Redux formError prop; suppress the
+        // unhandled-rejection warning.
+      });
   }
 }
 

--- a/src/components/Libraries.tsx
+++ b/src/components/Libraries.tsx
@@ -48,9 +48,15 @@ export class Libraries extends GenericEditableConfigList<
     admin: PropTypes.object.isRequired,
   };
 
-  UNSAFE_componentWillMount() {
-    super.UNSAFE_componentWillMount();
+  componentDidMount() {
+    super.componentDidMount();
     this.props.fetchLanguages();
+  }
+
+  /** Libraries are top-level items, not associated with other libraries.
+   *  Returning undefined suppresses the disclosure toggle for every row. */
+  protected getAssociatedEntries(_item: LibraryData): undefined {
+    return undefined;
   }
 
   label(item): string {

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -596,4 +596,81 @@ describe("EditableConfigList", () => {
     wrapper.setContext({ admin: librarian });
     expect(wrapper.instance().getAdminLevel()).to.equal(1);
   });
+
+  describe("renderAssociatedLibraries", () => {
+    const allLibraries = [
+      { short_name: "nypl", name: "New York Public Library" },
+      { short_name: "bpl", name: "Brooklyn Public Library" },
+    ];
+
+    it("renders nothing when the item has no libraries property", () => {
+      const libraries = wrapper.find(".associated-libraries");
+      expect(libraries.length).to.equal(0);
+    });
+
+    it("renders nothing when the item has an empty libraries array", () => {
+      wrapper = mount(
+        <ThingEditableConfigList
+          data={{ things: [{ ...thingData, libraries: [] }] } as any}
+          fetchData={fetchData}
+          editItem={editItem}
+          deleteItem={deleteItem}
+          csrfToken="token"
+          isFetching={false}
+        />,
+        { context: { admin: systemAdmin }, childContextTypes }
+      );
+      const libraries = wrapper.find(".associated-libraries");
+      expect(libraries.length).to.equal(0);
+    });
+
+    it("renders library names when allLibraries is available", () => {
+      const thingWithLibraries = {
+        ...thingData,
+        libraries: [{ short_name: "nypl" }, { short_name: "bpl" }],
+      };
+      wrapper = mount(
+        <ThingEditableConfigList
+          data={{ things: [thingWithLibraries], allLibraries } as any}
+          fetchData={fetchData}
+          editItem={editItem}
+          deleteItem={deleteItem}
+          csrfToken="token"
+          isFetching={false}
+        />,
+        { context: { admin: systemAdmin }, childContextTypes }
+      );
+      wrapper.find(".library-toggle").simulate("click");
+      const libraryList = wrapper.find(".associated-libraries");
+      expect(libraryList.length).to.equal(1);
+      const items = libraryList.find("li");
+      expect(items.length).to.equal(2);
+      expect(items.at(0).text()).to.equal("New York Public Library");
+      expect(items.at(1).text()).to.equal("Brooklyn Public Library");
+    });
+
+    it("falls back to short_name when allLibraries is not available", () => {
+      const thingWithLibraries = {
+        ...thingData,
+        libraries: [{ short_name: "nypl" }],
+      };
+      wrapper = mount(
+        <ThingEditableConfigList
+          data={{ things: [thingWithLibraries] } as any}
+          fetchData={fetchData}
+          editItem={editItem}
+          deleteItem={deleteItem}
+          csrfToken="token"
+          isFetching={false}
+        />,
+        { context: { admin: systemAdmin }, childContextTypes }
+      );
+      wrapper.find(".library-toggle").simulate("click");
+      const libraryList = wrapper.find(".associated-libraries");
+      expect(libraryList.length).to.equal(1);
+      const items = libraryList.find("li");
+      expect(items.length).to.equal(1);
+      expect(items.at(0).text()).to.equal("nypl");
+    });
+  });
 });

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -359,7 +359,7 @@ describe("EditableConfigList", () => {
       { context: { admin: libraryManager } }
     );
     expect(wrapper.instance().canEdit(viewableThing)).to.be.false;
-    const viewLink = wrapper.find("span");
+    const viewLink = wrapper.find(".edit-item span");
     expect(viewLink.text()).to.contain("View");
     expect(viewLink.text()).not.to.contain("Edit");
   });
@@ -604,7 +604,7 @@ describe("EditableConfigList", () => {
     ];
 
     it("renders nothing when the item has no libraries property", () => {
-      const libraries = wrapper.find(".associated-libraries");
+      const libraries = wrapper.find(".associated-items");
       expect(libraries.length).to.equal(0);
     });
 
@@ -620,7 +620,7 @@ describe("EditableConfigList", () => {
         />,
         { context: { admin: systemAdmin }, childContextTypes }
       );
-      const libraries = wrapper.find(".associated-libraries");
+      const libraries = wrapper.find(".associated-items");
       expect(libraries.length).to.equal(0);
     });
 
@@ -640,13 +640,13 @@ describe("EditableConfigList", () => {
         />,
         { context: { admin: systemAdmin }, childContextTypes }
       );
-      wrapper.find(".library-toggle").simulate("click");
-      const libraryList = wrapper.find(".associated-libraries");
+      wrapper.find(".association-toggle").simulate("click");
+      const libraryList = wrapper.find(".associated-items");
       expect(libraryList.length).to.equal(1);
       const items = libraryList.find("li");
       expect(items.length).to.equal(2);
-      expect(items.at(0).text()).to.equal("New York Public Library");
-      expect(items.at(1).text()).to.equal("Brooklyn Public Library");
+      expect(items.at(0).text()).to.equal("Brooklyn Public Library");
+      expect(items.at(1).text()).to.equal("New York Public Library");
     });
 
     it("falls back to short_name when allLibraries is not available", () => {
@@ -665,8 +665,8 @@ describe("EditableConfigList", () => {
         />,
         { context: { admin: systemAdmin }, childContextTypes }
       );
-      wrapper.find(".library-toggle").simulate("click");
-      const libraryList = wrapper.find(".associated-libraries");
+      wrapper.find(".association-toggle").simulate("click");
+      const libraryList = wrapper.find(".associated-items");
       expect(libraryList.length).to.equal(1);
       const items = libraryList.find("li");
       expect(items.length).to.equal(1);

--- a/src/components/__tests__/EditableConfigList-test.tsx
+++ b/src/components/__tests__/EditableConfigList-test.tsx
@@ -359,7 +359,7 @@ describe("EditableConfigList", () => {
       { context: { admin: libraryManager } }
     );
     expect(wrapper.instance().canEdit(viewableThing)).to.be.false;
-    const viewLink = wrapper.find(".edit-item span");
+    const viewLink = wrapper.find("span");
     expect(viewLink.text()).to.contain("View");
     expect(viewLink.text()).not.to.contain("Edit");
   });
@@ -595,82 +595,5 @@ describe("EditableConfigList", () => {
     expect(wrapper.instance().getAdminLevel()).to.equal(2);
     wrapper.setContext({ admin: librarian });
     expect(wrapper.instance().getAdminLevel()).to.equal(1);
-  });
-
-  describe("renderAssociatedLibraries", () => {
-    const allLibraries = [
-      { short_name: "nypl", name: "New York Public Library" },
-      { short_name: "bpl", name: "Brooklyn Public Library" },
-    ];
-
-    it("renders nothing when the item has no libraries property", () => {
-      const libraries = wrapper.find(".associated-items");
-      expect(libraries.length).to.equal(0);
-    });
-
-    it("renders nothing when the item has an empty libraries array", () => {
-      wrapper = mount(
-        <ThingEditableConfigList
-          data={{ things: [{ ...thingData, libraries: [] }] } as any}
-          fetchData={fetchData}
-          editItem={editItem}
-          deleteItem={deleteItem}
-          csrfToken="token"
-          isFetching={false}
-        />,
-        { context: { admin: systemAdmin }, childContextTypes }
-      );
-      const libraries = wrapper.find(".associated-items");
-      expect(libraries.length).to.equal(0);
-    });
-
-    it("renders library names when allLibraries is available", () => {
-      const thingWithLibraries = {
-        ...thingData,
-        libraries: [{ short_name: "nypl" }, { short_name: "bpl" }],
-      };
-      wrapper = mount(
-        <ThingEditableConfigList
-          data={{ things: [thingWithLibraries], allLibraries } as any}
-          fetchData={fetchData}
-          editItem={editItem}
-          deleteItem={deleteItem}
-          csrfToken="token"
-          isFetching={false}
-        />,
-        { context: { admin: systemAdmin }, childContextTypes }
-      );
-      wrapper.find(".association-toggle").simulate("click");
-      const libraryList = wrapper.find(".associated-items");
-      expect(libraryList.length).to.equal(1);
-      const items = libraryList.find("li");
-      expect(items.length).to.equal(2);
-      expect(items.at(0).text()).to.equal("Brooklyn Public Library");
-      expect(items.at(1).text()).to.equal("New York Public Library");
-    });
-
-    it("falls back to short_name when allLibraries is not available", () => {
-      const thingWithLibraries = {
-        ...thingData,
-        libraries: [{ short_name: "nypl" }],
-      };
-      wrapper = mount(
-        <ThingEditableConfigList
-          data={{ things: [thingWithLibraries] } as any}
-          fetchData={fetchData}
-          editItem={editItem}
-          deleteItem={deleteItem}
-          csrfToken="token"
-          isFetching={false}
-        />,
-        { context: { admin: systemAdmin }, childContextTypes }
-      );
-      wrapper.find(".association-toggle").simulate("click");
-      const libraryList = wrapper.find(".associated-items");
-      expect(libraryList.length).to.equal(1);
-      const items = libraryList.find("li");
-      expect(items.length).to.equal(1);
-      expect(items.at(0).text()).to.equal("nypl");
-    });
   });
 });

--- a/src/components/icons/DisclosureIcon.tsx
+++ b/src/components/icons/DisclosureIcon.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+interface DisclosureIconProps {
+  expanded: boolean;
+}
+
+const DisclosureIcon = ({ expanded }: DisclosureIconProps): JSX.Element => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 12 12"
+    aria-hidden="true"
+    className={`disclosure-icon${expanded ? " expanded" : ""}`}
+  >
+    <polygon points="2,1 10,6 2,11" fill="currentColor" />
+  </svg>
+);
+
+export default DisclosureIcon;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -390,7 +390,9 @@ export interface ServicesWithRegistrationsData extends ServicesData {
   libraryRegistrations?: LibraryRegistrationData[];
 }
 
-export interface CollectionData extends ServiceData {}
+export interface CollectionData extends ServiceData {
+  marked_for_deletion?: boolean;
+}
 
 export interface CollectionsData extends ServicesWithRegistrationsData {
   collections: CollectionData[];

--- a/src/stylesheets/config_tab_container.scss
+++ b/src/stylesheets/config_tab_container.scss
@@ -55,17 +55,76 @@ $dangercolor: #D9534F;
           padding-left: 10px;
           li {
             display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            align-items: center;
+            flex-direction: column;
             margin: 20px 0px;
             padding-bottom: 5px;
             border-bottom: 1px solid $pagetextcolor;
 
-            h3 {
-              margin-right: 20px;
-              flex-grow: 1;
-              font-size: 18px;
+            .item-header {
+              display: flex;
+              flex-direction: row;
+              justify-content: space-between;
+              align-items: center;
+
+              h3 {
+                display: flex;
+                align-items: center;
+                gap: 0.5em;
+                margin: 0 20px 0 0;
+                flex-grow: 1;
+                font-size: 18px;
+
+                .library-count {
+                  font-size: 0.85em;
+                  font-weight: normal;
+                  color: $pagetextcolorlight;
+                }
+
+                .library-toggle {
+                  background: none;
+                  border: none;
+                  cursor: pointer;
+                  color: $linkcolor;
+                  padding: 0;
+                  flex-shrink: 0;
+                  width: 1.1em;
+                  height: 1.1em;
+
+                  &:hover:not(:disabled) {
+                    color: $linkhovercolor;
+                  }
+
+                  &:disabled {
+                    visibility: hidden;
+                  }
+
+                  .disclosure-icon {
+                    display: block;
+                    width: 100%;
+                    height: 100%;
+                    transition: transform 0.15s ease;
+                    transform: rotate(0deg);
+                    transform-origin: center center;
+
+                    &.expanded {
+                      transform: rotate(90deg);
+                    }
+                  }
+                }
+              }
+            }
+
+            .associated-libraries {
+              list-style: disc;
+              margin: 4px 0 6px 0;
+              padding-left: 3em;
+
+              li {
+                display: list-item;
+                margin: 2px 0;
+                padding-bottom: 0;
+                border-bottom: none;
+              }
             }
           }
         }

--- a/src/stylesheets/config_tab_container.scss
+++ b/src/stylesheets/config_tab_container.scss
@@ -51,6 +51,44 @@ $dangercolor: #D9534F;
           }
         }
 
+        .expand-collapse-controls {
+          display: flex;
+          gap: 0.75em;
+          margin-bottom: 8px;
+
+          button {
+            background: none;
+            border: 1px solid $linkcolor;
+            color: $linkcolor;
+            font-size: 0.85em;
+            padding: 2px 8px;
+            cursor: pointer;
+            border-radius: 3px;
+
+            &:hover:not(:disabled) {
+              color: $linkhovercolor;
+              border-color: $linkhovercolor;
+            }
+
+            &:disabled {
+              opacity: 0.4;
+              cursor: default;
+            }
+
+            // Bootstrap 3 applies a focus ring on both mouse and keyboard
+            // clicks. Suppress it here and restore it only for keyboard
+            // navigation via :focus-visible below.
+            &:focus {
+              outline: none;
+            }
+
+            &:focus-visible {
+              outline: 2px solid $linkcolor;
+              outline-offset: 2px;
+            }
+          }
+        }
+
         > ul {
           padding-left: 10px;
           li {
@@ -66,21 +104,25 @@ $dangercolor: #D9534F;
               justify-content: space-between;
               align-items: center;
 
-              h3 {
+              .item-label {
                 display: flex;
                 align-items: center;
                 gap: 0.5em;
                 margin: 0 20px 0 0;
                 flex-grow: 1;
-                font-size: 18px;
 
-                .library-count {
-                  font-size: 0.85em;
-                  font-weight: normal;
-                  color: $pagetextcolorlight;
+                h3 {
+                  font-size: 18px;
+                  margin: 0;
+
+                  .library-count {
+                    font-size: 0.85em;
+                    font-weight: normal;
+                    color: $pagetextcolorlight;
+                  }
                 }
 
-                .library-toggle {
+                .association-toggle {
                   background: none;
                   border: none;
                   cursor: pointer;
@@ -89,6 +131,20 @@ $dangercolor: #D9534F;
                   flex-shrink: 0;
                   width: 1.1em;
                   height: 1.1em;
+
+                  // Bootstrap 3 applies a focus ring on both mouse and
+                  // keyboard clicks. Suppress it here and restore it only
+                  // for keyboard navigation via :focus-visible below.
+                  &:focus {
+                    outline: none;
+                    box-shadow: none;
+                  }
+
+                  &:focus-visible {
+                    outline: 2px solid $linkcolor;
+                    outline-offset: 2px;
+                    border-radius: 2px;
+                  }
 
                   &:hover:not(:disabled) {
                     color: $linkhovercolor;
@@ -114,7 +170,7 @@ $dangercolor: #D9534F;
               }
             }
 
-            .associated-libraries {
+            .associated-items {
               list-style: disc;
               margin: 4px 0 6px 0;
               padding-left: 3em;

--- a/tests/jest/components/Collections.test.tsx
+++ b/tests/jest/components/Collections.test.tsx
@@ -1,0 +1,220 @@
+import * as React from "react";
+import { fireEvent } from "@testing-library/react";
+import { Collections } from "../../../src/components/Collections";
+import renderWithContext from "../testUtils/renderWithContext";
+import {
+  CollectionsData,
+  ConfigurationSettings,
+} from "../../../src/interfaces";
+import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
+
+// NB: This adds tests to the already existing tests in:
+// - `src/components/__tests__/Collections-test.tsx`.
+//
+// Those tests should eventually be migrated here and
+// adapted to the Jest/React Testing Library paradigm.
+
+describe("Collections - associated library disclosure", () => {
+  // ── Shared fixtures ───────────────────────────────────────────────────────
+
+  const allLibraries = [
+    { short_name: "gamma", name: "Gamma Library", uuid: "uuid-gamma" },
+    { short_name: "alpha", name: "Alpha Library", uuid: "uuid-alpha" },
+    { short_name: "beta", name: "Beta Library", uuid: "uuid-beta" },
+    { short_name: "delta", name: "Delta Library" }, // no uuid
+  ];
+
+  const sysAdminConfig: Partial<ConfigurationSettings> = {
+    csrfToken: "",
+    featureFlags: defaultFeatureFlags,
+    roles: [{ role: "system" }],
+  };
+
+  const renderCollections = (data: Partial<CollectionsData>) =>
+    renderWithContext(
+      <Collections
+        data={
+          {
+            collections: [],
+            protocols: [],
+            allLibraries,
+            ...data,
+          } as CollectionsData
+        }
+        fetchData={jest.fn()}
+        editItem={jest.fn().mockResolvedValue(undefined)}
+        deleteItem={jest.fn().mockResolvedValue(undefined)}
+        registerLibrary={jest.fn().mockResolvedValue(undefined)}
+        importCollection={jest.fn().mockResolvedValue(undefined)}
+        csrfToken="token"
+        isFetching={false}
+      />,
+      sysAdminConfig
+    );
+
+  // ── Toggle visibility ─────────────────────────────────────────────────────
+
+  it("shows no toggle for a collection without a libraries field", () => {
+    const { container } = renderCollections({
+      collections: [{ id: 1, protocol: "p", name: "My Collection" } as any],
+    });
+    expect(container.querySelector(".association-toggle")).toBeNull();
+    expect(container.querySelector(".library-count")).toBeNull();
+  });
+
+  it("shows a disabled toggle and 'no libraries' for a collection with an empty libraries array", () => {
+    const { container } = renderCollections({
+      collections: [
+        { id: 1, protocol: "p", name: "My Collection", libraries: [] } as any,
+      ],
+    });
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".association-toggle"
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle.disabled).toBe(true);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (no libraries)"
+    );
+  });
+
+  it("shows '1 library' for a collection with one associated library", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [{ short_name: "alpha" }],
+        } as any,
+      ],
+    });
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".association-toggle"
+    );
+    expect(toggle.disabled).toBe(false);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (1 library)"
+    );
+  });
+
+  it("shows 'N libraries' for a collection with multiple associated libraries", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [
+            { short_name: "alpha" },
+            { short_name: "beta" },
+            { short_name: "gamma" },
+          ],
+        } as any,
+      ],
+    });
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (3 libraries)"
+    );
+  });
+
+  // ── Expand / collapse ─────────────────────────────────────────────────────
+
+  it("expands the library list on toggle click and collapses on a second click", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [{ short_name: "alpha" }, { short_name: "beta" }],
+        } as any,
+      ],
+    });
+    const toggle = container.querySelector(".association-toggle");
+    expect(container.querySelector(".associated-items")).toBeNull();
+    fireEvent.click(toggle);
+    expect(container.querySelector(".associated-items")).not.toBeNull();
+    fireEvent.click(toggle);
+    expect(container.querySelector(".associated-items")).toBeNull();
+  });
+
+  // ── allLibraries injection from mapStateToProps ───────────────────────────
+
+  it("resolves library display names from allLibraries", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [{ short_name: "alpha" }, { short_name: "beta" }],
+        } as any,
+      ],
+    });
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    const items = container.querySelectorAll(".associated-items li");
+    // Sorted alphabetically: Alpha, Beta
+    expect(items[0].textContent).toBe("Alpha Library");
+    expect(items[1].textContent).toBe("Beta Library");
+  });
+
+  it("links a library name to its config page when a uuid is available", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [{ short_name: "alpha" }],
+        } as any,
+      ],
+    });
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      ".associated-items a"
+    );
+    expect(link).not.toBeNull();
+    expect(link.textContent).toBe("Alpha Library");
+    expect(link.href).toContain("/admin/web/config/libraries/edit/uuid-alpha");
+  });
+
+  it("renders a library without a uuid as plain text", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [{ short_name: "delta" }],
+        } as any,
+      ],
+    });
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    expect(container.querySelector(".associated-items a")).toBeNull();
+    expect(container.querySelector(".associated-items li").textContent).toBe(
+      "Delta Library"
+    );
+  });
+
+  it("falls back to short_name when the library is not in allLibraries", () => {
+    const { container } = renderCollections({
+      collections: [
+        {
+          id: 1,
+          protocol: "p",
+          name: "My Collection",
+          libraries: [{ short_name: "unknown" }],
+        } as any,
+      ],
+    });
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    expect(container.querySelector(".associated-items li").textContent).toBe(
+      "unknown"
+    );
+  });
+});

--- a/tests/jest/components/DiscoveryServices.test.tsx
+++ b/tests/jest/components/DiscoveryServices.test.tsx
@@ -58,8 +58,37 @@ describe("DiscoveryServices - registered library disclosure", () => {
       discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
       // libraryRegistrations omitted → undefined
     });
-    expect(container.querySelector(".library-toggle")).toBeNull();
+    expect(container.querySelector(".association-toggle")).toBeNull();
     expect(container.querySelector(".library-count")).toBeNull();
+  });
+
+  it("shows a disabled toggle when libraryRegistrations is loaded but the service has no entry in it", () => {
+    // libraryRegistrations is present (so getAssociatedEntries returns [] not
+    // undefined), but service id=99 has no corresponding record in the array.
+    // Result: disabled toggle + "no registered libraries", not "no toggle".
+    const { container } = renderServices({
+      discovery_services: [{ id: 99, protocol: "p", name: "Service X" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+      ],
+    });
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".association-toggle"
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle.disabled).toBe(true);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (no registered libraries)"
+    );
   });
 
   it("shows a disabled toggle and 'no registered libraries' when none are registered", () => {
@@ -82,7 +111,7 @@ describe("DiscoveryServices - registered library disclosure", () => {
       ],
     });
     const toggle = container.querySelector<HTMLButtonElement>(
-      ".library-toggle"
+      ".association-toggle"
     );
     expect(toggle).not.toBeNull();
     expect(toggle.disabled).toBe(true);
@@ -108,7 +137,7 @@ describe("DiscoveryServices - registered library disclosure", () => {
       ],
     });
     const toggle = container.querySelector<HTMLButtonElement>(
-      ".library-toggle"
+      ".association-toggle"
     );
     expect(toggle.disabled).toBe(false);
     expect(container.querySelector(".library-count").textContent).toBe(
@@ -159,9 +188,9 @@ describe("DiscoveryServices - registered library disclosure", () => {
         },
       ],
     });
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toContain("Alpha Library");
   });
@@ -184,9 +213,9 @@ describe("DiscoveryServices - registered library disclosure", () => {
         },
       ],
     });
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const item = container.querySelector(".associated-libraries li");
+    const item = container.querySelector(".associated-items li");
     expect(item.textContent).toBe("Alpha Library - registered - production");
   });
 
@@ -200,9 +229,9 @@ describe("DiscoveryServices - registered library disclosure", () => {
         },
       ],
     });
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const item = container.querySelector(".associated-libraries li");
+    const item = container.querySelector(".associated-items li");
     expect(item.textContent).toBe("Alpha Library - registered");
   });
 
@@ -230,9 +259,9 @@ describe("DiscoveryServices - registered library disclosure", () => {
         },
       ],
     });
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items[0].textContent).toContain("Alpha Library");
     expect(items[1].textContent).toContain("Beta Library");
     expect(items[2].textContent).toContain("Gamma Library");
@@ -256,10 +285,10 @@ describe("DiscoveryServices - registered library disclosure", () => {
         },
       ],
     });
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
     const link = container.querySelector<HTMLAnchorElement>(
-      ".associated-libraries a"
+      ".associated-items a"
     );
     expect(link).not.toBeNull();
     expect(link.textContent).toBe("Alpha Library");
@@ -280,12 +309,12 @@ describe("DiscoveryServices - registered library disclosure", () => {
         },
       ],
     });
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    expect(container.querySelector(".associated-libraries a")).toBeNull();
-    expect(
-      container.querySelector(".associated-libraries li").textContent
-    ).toBe("Delta Library - registered - testing");
+    expect(container.querySelector(".associated-items a")).toBeNull();
+    expect(container.querySelector(".associated-items li").textContent).toBe(
+      "Delta Library - registered - testing"
+    );
   });
 
   // ── Per-service isolation ─────────────────────────────────────────────────
@@ -326,12 +355,116 @@ describe("DiscoveryServices - registered library disclosure", () => {
     );
 
     const toggles = container.querySelectorAll<HTMLButtonElement>(
-      ".library-toggle"
+      ".association-toggle"
     );
     expect(toggles).toHaveLength(2);
     expect(
       toggles[1].closest("li").querySelector(".library-count").textContent
     ).toBe(" (2 registered libraries)");
+  });
+
+  // ── Expand all / Collapse all buttons ────────────────────────────────────
+
+  it("Expand all expands all services that have registered libraries", () => {
+    const { container } = renderServices({
+      discovery_services: [
+        { id: 1, protocol: "p", name: "Service A" } as any,
+        { id: 2, protocol: "p", name: "Service B" } as any,
+        { id: 3, protocol: "p", name: "Service C" } as any,
+      ],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+        {
+          id: 2,
+          libraries: [], // no registrations → disabled toggle
+        },
+        {
+          id: 3,
+          libraries: [
+            { short_name: "beta", status: "success", stage: "testing" } as any,
+          ],
+        },
+      ],
+    });
+
+    fireEvent.click(container.querySelector(".expand-all"));
+
+    // Services 1 and 3 have registered libraries; service 2 has none.
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+  });
+
+  it("shows no expand/collapse controls when libraryRegistrations has not yet loaded", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      // libraryRegistrations omitted → getAssociatedEntries returns undefined
+      // for every item, so expandableItems() is empty and no controls render.
+    });
+    expect(container.querySelector(".expand-collapse-controls")).toBeNull();
+  });
+
+  it("shows no expand/collapse controls when no services have successfully registered libraries", () => {
+    const { container } = renderServices({
+      discovery_services: [
+        { id: 1, protocol: "p", name: "Service A" } as any,
+        { id: 2, protocol: "p", name: "Service B" } as any,
+      ],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [{ short_name: "alpha", status: "warning" } as any],
+        },
+        {
+          id: 2,
+          libraries: [],
+        },
+      ],
+    });
+    expect(container.querySelector(".expand-collapse-controls")).toBeNull();
+  });
+
+  it("Collapse all collapses all expanded services", () => {
+    const { container } = renderServices({
+      discovery_services: [
+        { id: 1, protocol: "p", name: "Service A" } as any,
+        { id: 2, protocol: "p", name: "Service B" } as any,
+      ],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+        {
+          id: 2,
+          libraries: [
+            { short_name: "beta", status: "success", stage: "testing" } as any,
+          ],
+        },
+      ],
+    });
+
+    fireEvent.click(container.querySelector(".expand-all"));
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+
+    fireEvent.click(container.querySelector(".collapse-all"));
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(0);
+    expect(
+      container.querySelector<HTMLButtonElement>(".collapse-all").disabled
+    ).toBe(true);
   });
 
   // ── Alt+click toggle-all ──────────────────────────────────────────────────
@@ -367,10 +500,46 @@ describe("DiscoveryServices - registered library disclosure", () => {
       ],
     });
 
-    const toggles = container.querySelectorAll(".library-toggle");
+    const toggles = container.querySelectorAll(".association-toggle");
     fireEvent.click(toggles[0], { altKey: true });
 
     // Services 1 and 3 have registered libraries; service 2 has none.
-    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+  });
+
+  it("alt+click collapses all when all services are already expanded", () => {
+    const { container } = renderServices({
+      discovery_services: [
+        { id: 1, protocol: "p", name: "Service A" } as any,
+        { id: 2, protocol: "p", name: "Service B" } as any,
+      ],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+        {
+          id: 2,
+          libraries: [
+            { short_name: "beta", status: "success", stage: "testing" } as any,
+          ],
+        },
+      ],
+    });
+    const toggles = container.querySelectorAll(".association-toggle");
+
+    // Expand all first.
+    fireEvent.click(toggles[0], { altKey: true });
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+
+    // Alt+click again should collapse all.
+    fireEvent.click(toggles[0], { altKey: true });
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(0);
   });
 });

--- a/tests/jest/components/DiscoveryServices.test.tsx
+++ b/tests/jest/components/DiscoveryServices.test.tsx
@@ -1,0 +1,376 @@
+import * as React from "react";
+import { fireEvent } from "@testing-library/react";
+import { DiscoveryServices } from "../../../src/components/DiscoveryServices";
+import renderWithContext from "../testUtils/renderWithContext";
+import {
+  ConfigurationSettings,
+  DiscoveryServicesData,
+} from "../../../src/interfaces";
+import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
+
+// NB: This adds tests to the already existing tests in:
+// - `src/components/__tests__/DiscoveryServices-test.tsx`.
+//
+// Those tests should eventually be migrated here and
+// adapted to the Jest/React Testing Library paradigm.
+
+describe("DiscoveryServices - registered library disclosure", () => {
+  // ── Shared fixtures ───────────────────────────────────────────────────────
+
+  const allLibraries = [
+    { short_name: "gamma", name: "Gamma Library", uuid: "uuid-gamma" },
+    { short_name: "alpha", name: "Alpha Library", uuid: "uuid-alpha" },
+    { short_name: "beta", name: "Beta Library", uuid: "uuid-beta" },
+    { short_name: "delta", name: "Delta Library" }, // no uuid
+  ];
+
+  const sysAdminConfig: Partial<ConfigurationSettings> = {
+    csrfToken: "",
+    featureFlags: defaultFeatureFlags,
+    roles: [{ role: "system" }],
+  };
+
+  const renderServices = (data: Partial<DiscoveryServicesData>) =>
+    renderWithContext(
+      <DiscoveryServices
+        data={
+          {
+            discovery_services: [],
+            allLibraries,
+            ...data,
+          } as DiscoveryServicesData
+        }
+        fetchData={jest.fn()}
+        editItem={jest.fn().mockResolvedValue(undefined)}
+        deleteItem={jest.fn().mockResolvedValue(undefined)}
+        registerLibrary={jest.fn().mockResolvedValue(undefined)}
+        fetchLibraryRegistrations={jest.fn().mockResolvedValue(undefined)}
+        csrfToken="token"
+        isFetching={false}
+      />,
+      sysAdminConfig
+    );
+
+  // ── Toggle visibility ─────────────────────────────────────────────────────
+
+  it("shows no toggle when libraryRegistrations data has not yet loaded", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      // libraryRegistrations omitted → undefined
+    });
+    expect(container.querySelector(".library-toggle")).toBeNull();
+    expect(container.querySelector(".library-count")).toBeNull();
+  });
+
+  it("shows a disabled toggle and 'no registered libraries' when none are registered", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "warning",
+            } as any,
+            {
+              short_name: "beta",
+              status: "failure",
+            } as any,
+          ],
+        },
+      ],
+    });
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".library-toggle"
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle.disabled).toBe(true);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (no registered libraries)"
+    );
+  });
+
+  it("shows '1 registered library' when exactly one library is registered", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+      ],
+    });
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".library-toggle"
+    );
+    expect(toggle.disabled).toBe(false);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (1 registered library)"
+    );
+  });
+
+  it("shows 'N registered libraries' when multiple are registered", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+            { short_name: "beta", status: "success", stage: "testing" } as any,
+            { short_name: "gamma", status: "warning" } as any,
+          ],
+        },
+      ],
+    });
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (2 registered libraries)"
+    );
+  });
+
+  // ── Content filtering ─────────────────────────────────────────────────────
+
+  it("shows only registered (status=success) libraries in the expanded list", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+            { short_name: "beta", status: "warning", stage: "testing" } as any,
+            { short_name: "gamma", status: "failure" } as any,
+          ],
+        },
+      ],
+    });
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toContain("Alpha Library");
+  });
+
+  // ── Stage suffix ──────────────────────────────────────────────────────────
+
+  it("shows the registration stage in the suffix", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+      ],
+    });
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const item = container.querySelector(".associated-libraries li");
+    expect(item.textContent).toBe("Alpha Library - registered - production");
+  });
+
+  it("shows '- registered' without a stage when stage is absent", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [{ short_name: "alpha", status: "success" } as any],
+        },
+      ],
+    });
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const item = container.querySelector(".associated-libraries li");
+    expect(item.textContent).toBe("Alpha Library - registered");
+  });
+
+  // ── Sorting ───────────────────────────────────────────────────────────────
+
+  it("sorts registered libraries alphabetically by display name", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "gamma",
+              status: "success",
+              stage: "production",
+            } as any,
+            { short_name: "alpha", status: "success", stage: "testing" } as any,
+            {
+              short_name: "beta",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+      ],
+    });
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items[0].textContent).toContain("Alpha Library");
+    expect(items[1].textContent).toContain("Beta Library");
+    expect(items[2].textContent).toContain("Gamma Library");
+  });
+
+  // ── Links ─────────────────────────────────────────────────────────────────
+
+  it("links the library name to its config page when a uuid is available", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+      ],
+    });
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      ".associated-libraries a"
+    );
+    expect(link).not.toBeNull();
+    expect(link.textContent).toBe("Alpha Library");
+    expect(link.href).toContain("/admin/web/config/libraries/edit/uuid-alpha");
+    // The suffix should not be inside the link.
+    expect(link.nextSibling.textContent).toBe(" - registered - production");
+  });
+
+  it("renders the library name as plain text when no uuid is available", () => {
+    const { container } = renderServices({
+      discovery_services: [{ id: 1, protocol: "p", name: "Service A" } as any],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            { short_name: "delta", status: "success", stage: "testing" } as any,
+          ],
+        },
+      ],
+    });
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    expect(container.querySelector(".associated-libraries a")).toBeNull();
+    expect(
+      container.querySelector(".associated-libraries li").textContent
+    ).toBe("Delta Library - registered - testing");
+  });
+
+  // ── Per-service isolation ─────────────────────────────────────────────────
+
+  it("shows each service's own registered libraries independently", () => {
+    const { container } = renderServices({
+      discovery_services: [
+        { id: 1, protocol: "p", name: "Service A" } as any,
+        { id: 2, protocol: "p", name: "Service B" } as any,
+      ],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+        {
+          id: 2,
+          libraries: [
+            { short_name: "beta", status: "success", stage: "testing" } as any,
+            {
+              short_name: "gamma",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+      ],
+    });
+
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (1 registered library)"
+    );
+
+    const toggles = container.querySelectorAll<HTMLButtonElement>(
+      ".library-toggle"
+    );
+    expect(toggles).toHaveLength(2);
+    expect(
+      toggles[1].closest("li").querySelector(".library-count").textContent
+    ).toBe(" (2 registered libraries)");
+  });
+
+  // ── Alt+click toggle-all ──────────────────────────────────────────────────
+
+  it("alt+click expands all services that have registered libraries", () => {
+    const { container } = renderServices({
+      discovery_services: [
+        { id: 1, protocol: "p", name: "Service A" } as any,
+        { id: 2, protocol: "p", name: "Service B" } as any,
+        { id: 3, protocol: "p", name: "Service C" } as any,
+      ],
+      libraryRegistrations: [
+        {
+          id: 1,
+          libraries: [
+            {
+              short_name: "alpha",
+              status: "success",
+              stage: "production",
+            } as any,
+          ],
+        },
+        {
+          id: 2,
+          libraries: [], // no registrations → disabled toggle
+        },
+        {
+          id: 3,
+          libraries: [
+            { short_name: "beta", status: "success", stage: "testing" } as any,
+          ],
+        },
+      ],
+    });
+
+    const toggles = container.querySelectorAll(".library-toggle");
+    fireEvent.click(toggles[0], { altKey: true });
+
+    // Services 1 and 3 have registered libraries; service 2 has none.
+    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+  });
+});

--- a/tests/jest/components/EditableConfigList.test.tsx
+++ b/tests/jest/components/EditableConfigList.test.tsx
@@ -83,7 +83,7 @@ describe("EditableConfigList - library association disclosure", () => {
 
   it("shows no toggle for an item without a libraries field", () => {
     const { container } = renderList([{ id: 1, name: "Service A" }]);
-    expect(container.querySelector(".library-toggle")).toBeNull();
+    expect(container.querySelector(".association-toggle")).toBeNull();
     expect(container.querySelector(".library-count")).toBeNull();
   });
 
@@ -92,10 +92,12 @@ describe("EditableConfigList - library association disclosure", () => {
       { id: 1, name: "Service A", libraries: [] },
     ]);
     const toggle = container.querySelector<HTMLButtonElement>(
-      ".library-toggle"
+      ".association-toggle"
     );
     expect(toggle).not.toBeNull();
     expect(toggle.disabled).toBe(true);
+    // aria-expanded is omitted on a permanently-disabled toggle (it can never change state).
+    expect(toggle.getAttribute("aria-expanded")).toBeNull();
     expect(container.querySelector(".library-count").textContent).toBe(
       " (no libraries)"
     );
@@ -106,7 +108,7 @@ describe("EditableConfigList - library association disclosure", () => {
       { id: 1, name: "Service A", libraries: [{ short_name: "alpha" }] },
     ]);
     const toggle = container.querySelector<HTMLButtonElement>(
-      ".library-toggle"
+      ".association-toggle"
     );
     expect(toggle.disabled).toBe(false);
     expect(container.querySelector(".library-count").textContent).toBe(
@@ -141,23 +143,83 @@ describe("EditableConfigList - library association disclosure", () => {
         libraries: [{ short_name: "alpha" }, { short_name: "beta" }],
       },
     ]);
-    const toggle = container.querySelector(".library-toggle");
+    const toggle = container.querySelector(".association-toggle");
 
-    expect(container.querySelector(".associated-libraries")).toBeNull();
+    expect(container.querySelector(".associated-items")).toBeNull();
     fireEvent.click(toggle);
-    expect(container.querySelector(".associated-libraries")).not.toBeNull();
+    expect(container.querySelector(".associated-items")).not.toBeNull();
     fireEvent.click(toggle);
-    expect(container.querySelector(".associated-libraries")).toBeNull();
+    expect(container.querySelector(".associated-items")).toBeNull();
   });
 
   it("sets aria-expanded correctly as the list is toggled", () => {
     const { container } = renderList([
       { id: 1, name: "Service A", libraries: [{ short_name: "alpha" }] },
     ]);
-    const toggle = container.querySelector(".library-toggle");
+    const toggle = container.querySelector(".association-toggle");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     fireEvent.click(toggle);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  // ── Expand all / Collapse all buttons ────────────────────────────────────
+
+  it("shows no expand/collapse controls when no items have libraries", () => {
+    const { container } = renderList([
+      { id: 1, name: "A", libraries: [] },
+      { id: 2, name: "B" },
+    ]);
+    expect(container.querySelector(".expand-collapse-controls")).toBeNull();
+  });
+
+  it("shows expand/collapse controls when at least one item has libraries", () => {
+    const { container } = renderList([
+      { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
+    ]);
+    expect(container.querySelector(".expand-collapse-controls")).not.toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>(".expand-all").disabled
+    ).toBe(false);
+    expect(
+      container.querySelector<HTMLButtonElement>(".collapse-all").disabled
+    ).toBe(true);
+  });
+
+  it("Expand all expands all items that have libraries", () => {
+    const { container } = renderList([
+      { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
+      { id: 2, name: "B", libraries: [] }, // no libraries → toggle disabled
+      { id: 3, name: "C", libraries: [{ short_name: "beta" }] },
+      { id: 4, name: "D" }, // no libraries field → no toggle
+    ]);
+
+    fireEvent.click(container.querySelector(".expand-all"));
+
+    const lists = container.querySelectorAll(".associated-items");
+    // Items 1 and 3 have libraries; item 2 is empty so no list shown even when expanded.
+    expect(lists).toHaveLength(2);
+    expect(
+      container.querySelector<HTMLButtonElement>(".expand-all").disabled
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLButtonElement>(".collapse-all").disabled
+    ).toBe(false);
+  });
+
+  it("Collapse all collapses all expanded items", () => {
+    const { container } = renderList([
+      { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
+      { id: 2, name: "B", libraries: [{ short_name: "beta" }] },
+    ]);
+
+    fireEvent.click(container.querySelector(".expand-all"));
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+
+    fireEvent.click(container.querySelector(".collapse-all"));
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(0);
+    expect(
+      container.querySelector<HTMLButtonElement>(".collapse-all").disabled
+    ).toBe(true);
   });
 
   // ── Alt+click toggle-all ──────────────────────────────────────────────────
@@ -169,13 +231,13 @@ describe("EditableConfigList - library association disclosure", () => {
       { id: 3, name: "C", libraries: [{ short_name: "beta" }] },
       { id: 4, name: "D" }, // no libraries field → no toggle
     ]);
-    const toggles = container.querySelectorAll(".library-toggle");
+    const toggles = container.querySelectorAll(".association-toggle");
     // Items 1, 2 and 3 have a libraries array → 3 toggles; item 4 has none.
     expect(toggles).toHaveLength(3);
 
     fireEvent.click(toggles[0], { altKey: true });
 
-    const lists = container.querySelectorAll(".associated-libraries");
+    const lists = container.querySelectorAll(".associated-items");
     // Items 1 and 3 have libraries; item 2 is empty so no list shown even when "expanded".
     expect(lists).toHaveLength(2);
   });
@@ -185,15 +247,15 @@ describe("EditableConfigList - library association disclosure", () => {
       { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
       { id: 2, name: "B", libraries: [{ short_name: "beta" }] },
     ]);
-    const toggles = container.querySelectorAll(".library-toggle");
+    const toggles = container.querySelectorAll(".association-toggle");
 
     // Expand all first.
     fireEvent.click(toggles[0], { altKey: true });
-    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
 
     // Alt+click again should collapse all.
     fireEvent.click(toggles[0], { altKey: true });
-    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(0);
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(0);
   });
 
   // ── Sorted library list ───────────────────────────────────────────────────
@@ -210,9 +272,9 @@ describe("EditableConfigList - library association disclosure", () => {
         ],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(3);
     expect(items[0].textContent).toBe("Alpha Library");
     expect(items[1].textContent).toBe("Beta Library");
@@ -223,10 +285,10 @@ describe("EditableConfigList - library association disclosure", () => {
     const { container } = renderList([
       { id: 1, name: "Service A", libraries: [{ short_name: "alpha" }] },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
     const link = container.querySelector<HTMLAnchorElement>(
-      ".associated-libraries a"
+      ".associated-items a"
     );
     expect(link).not.toBeNull();
     expect(link.textContent).toBe("Alpha Library");
@@ -237,22 +299,40 @@ describe("EditableConfigList - library association disclosure", () => {
     const { container } = renderList([
       { id: 1, name: "Service A", libraries: [{ short_name: "delta" }] },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    expect(container.querySelector(".associated-libraries a")).toBeNull();
-    expect(
-      container.querySelector(".associated-libraries li").textContent
-    ).toBe("Delta Library");
+    expect(container.querySelector(".associated-items a")).toBeNull();
+    expect(container.querySelector(".associated-items li").textContent).toBe(
+      "Delta Library"
+    );
   });
 
   it("falls back to short_name when no display name is available in allLibraries", () => {
     const { container } = renderList([
       { id: 1, name: "Service A", libraries: [{ short_name: "unknown" }] },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    expect(
-      container.querySelector(".associated-libraries li").textContent
-    ).toBe("unknown");
+    expect(container.querySelector(".associated-items li").textContent).toBe(
+      "unknown"
+    );
+  });
+
+  it("renders multiple libraries that are not in allLibraries, each falling back to its short_name", () => {
+    // Neither library is in allLibraries, so both fall back to their short_name
+    // as the display label. Distinct short_names → distinct labels → no key collision.
+    const { container } = renderList([
+      {
+        id: 1,
+        name: "Service A",
+        libraries: [{ short_name: "dup-a" }, { short_name: "dup-b" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    const items = container.querySelectorAll(".associated-items li");
+    expect(items).toHaveLength(2);
+    expect(items[0].textContent).toBe("dup-a");
+    expect(items[1].textContent).toBe("dup-b");
   });
 });

--- a/tests/jest/components/EditableConfigList.test.tsx
+++ b/tests/jest/components/EditableConfigList.test.tsx
@@ -352,4 +352,48 @@ describe("EditableConfigList - library association disclosure", () => {
     expect(items[0].textContent).toBe("dup-a");
     expect(items[1].textContent).toBe("dup-b");
   });
+
+  describe("renderAssociatedLibraries", () => {
+    it("renders no associated-items panel when the item has no libraries property", () => {
+      const { container } = renderList([{ id: 1, name: "A" }]);
+      expect(container.querySelector(".associated-items")).toBeNull();
+    });
+
+    it("renders no associated-items panel when the item has an empty libraries array", () => {
+      const { container } = renderList([{ id: 1, name: "A", libraries: [] }]);
+      expect(container.querySelector(".associated-items")).toBeNull();
+    });
+
+    it("renders library names resolved from allLibraries on expand", () => {
+      const { container } = renderList([
+        {
+          id: 1,
+          name: "Service A",
+          libraries: [{ short_name: "alpha" }, { short_name: "beta" }],
+        },
+      ]);
+      fireEvent.click(container.querySelector(".association-toggle"));
+      const items = container.querySelectorAll(".associated-items li");
+      expect(items).toHaveLength(2);
+      // Sorted alphabetically by resolved display name.
+      expect(items[0].textContent).toBe("Alpha Library");
+      expect(items[1].textContent).toBe("Beta Library");
+    });
+
+    it("falls back to short_name when allLibraries is absent from the data", () => {
+      const { container } = renderWithContext(
+        <TestServiceList
+          data={{ services: [{ id: 1, name: "Service A", libraries: [{ short_name: "nypl" }] }] }}
+          fetchData={jest.fn()}
+          editItem={jest.fn().mockResolvedValue(undefined)}
+          deleteItem={jest.fn().mockResolvedValue(undefined)}
+          csrfToken="token"
+          isFetching={false}
+        />,
+        config
+      );
+      fireEvent.click(container.querySelector(".association-toggle"));
+      expect(container.querySelector(".associated-items li").textContent).toBe("nypl");
+    });
+  });
 });

--- a/tests/jest/components/EditableConfigList.test.tsx
+++ b/tests/jest/components/EditableConfigList.test.tsx
@@ -1,0 +1,258 @@
+import * as React from "react";
+import { fireEvent } from "@testing-library/react";
+import {
+  EditableConfigList,
+  EditFormProps,
+} from "../../../src/components/EditableConfigList";
+import renderWithContext from "../testUtils/renderWithContext";
+import { ConfigurationSettings } from "../../../src/interfaces";
+import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
+
+// NB: This adds tests to the already existing tests in:
+// - `src/components/__tests__/EditableConfigList-test.tsx`.
+//
+// Those tests should eventually be migrated here and
+// adapted to the Jest/React Testing Library paradigm.
+
+describe("EditableConfigList - library association disclosure", () => {
+  // ── Test doubles ──────────────────────────────────────────────────────────
+
+  interface ServiceItem {
+    id: number;
+    name: string;
+    libraries?: Array<{ short_name: string }>;
+  }
+
+  interface ServicesData {
+    services: ServiceItem[];
+    allLibraries?: Array<{ short_name: string; name?: string; uuid?: string }>;
+  }
+
+  class TestEditForm extends React.Component<
+    EditFormProps<ServicesData, ServiceItem>
+  > {
+    render() {
+      return <div />;
+    }
+  }
+
+  class TestServiceList extends EditableConfigList<ServicesData, ServiceItem> {
+    EditForm = TestEditForm;
+    listDataKey = "services";
+    itemTypeName = "service";
+    urlBase = "/admin/services/";
+    identifierKey = "id";
+    labelKey = "name";
+    canCreate() {
+      return false;
+    }
+    canDelete() {
+      return false;
+    }
+  }
+
+  // ── Shared fixtures ───────────────────────────────────────────────────────
+
+  const allLibraries = [
+    { short_name: "gamma", name: "Gamma Library", uuid: "uuid-gamma" },
+    { short_name: "alpha", name: "Alpha Library", uuid: "uuid-alpha" },
+    { short_name: "beta", name: "Beta Library", uuid: "uuid-beta" },
+    { short_name: "delta", name: "Delta Library" }, // no uuid
+  ];
+
+  const config: Partial<ConfigurationSettings> = {
+    csrfToken: "",
+    featureFlags: defaultFeatureFlags,
+    roles: [{ role: "system" }],
+  };
+
+  const renderList = (items: ServiceItem[]) =>
+    renderWithContext(
+      <TestServiceList
+        data={{ services: items, allLibraries }}
+        fetchData={jest.fn()}
+        editItem={jest.fn().mockResolvedValue(undefined)}
+        deleteItem={jest.fn().mockResolvedValue(undefined)}
+        csrfToken="token"
+        isFetching={false}
+      />,
+      config
+    );
+
+  // ── Toggle visibility ─────────────────────────────────────────────────────
+
+  it("shows no toggle for an item without a libraries field", () => {
+    const { container } = renderList([{ id: 1, name: "Service A" }]);
+    expect(container.querySelector(".library-toggle")).toBeNull();
+    expect(container.querySelector(".library-count")).toBeNull();
+  });
+
+  it("shows a disabled toggle and 'no libraries' for an item with an empty libraries array", () => {
+    const { container } = renderList([
+      { id: 1, name: "Service A", libraries: [] },
+    ]);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".library-toggle"
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle.disabled).toBe(true);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (no libraries)"
+    );
+  });
+
+  it("shows an enabled toggle and '1 library' for an item with one library", () => {
+    const { container } = renderList([
+      { id: 1, name: "Service A", libraries: [{ short_name: "alpha" }] },
+    ]);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".library-toggle"
+    );
+    expect(toggle.disabled).toBe(false);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (1 library)"
+    );
+  });
+
+  it("shows 'N libraries' for an item with multiple libraries", () => {
+    const { container } = renderList([
+      {
+        id: 1,
+        name: "Service A",
+        libraries: [
+          { short_name: "alpha" },
+          { short_name: "beta" },
+          { short_name: "gamma" },
+        ],
+      },
+    ]);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (3 libraries)"
+    );
+  });
+
+  // ── Expand / collapse ─────────────────────────────────────────────────────
+
+  it("expands the library list on toggle click and collapses on a second click", () => {
+    const { container } = renderList([
+      {
+        id: 1,
+        name: "Service A",
+        libraries: [{ short_name: "alpha" }, { short_name: "beta" }],
+      },
+    ]);
+    const toggle = container.querySelector(".library-toggle");
+
+    expect(container.querySelector(".associated-libraries")).toBeNull();
+    fireEvent.click(toggle);
+    expect(container.querySelector(".associated-libraries")).not.toBeNull();
+    fireEvent.click(toggle);
+    expect(container.querySelector(".associated-libraries")).toBeNull();
+  });
+
+  it("sets aria-expanded correctly as the list is toggled", () => {
+    const { container } = renderList([
+      { id: 1, name: "Service A", libraries: [{ short_name: "alpha" }] },
+    ]);
+    const toggle = container.querySelector(".library-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  // ── Alt+click toggle-all ──────────────────────────────────────────────────
+
+  it("alt+click on any toggle expands all items that have libraries", () => {
+    const { container } = renderList([
+      { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
+      { id: 2, name: "B", libraries: [] }, // no libraries → toggle disabled
+      { id: 3, name: "C", libraries: [{ short_name: "beta" }] },
+      { id: 4, name: "D" }, // no libraries field → no toggle
+    ]);
+    const toggles = container.querySelectorAll(".library-toggle");
+    // Items 1, 2 and 3 have a libraries array → 3 toggles; item 4 has none.
+    expect(toggles).toHaveLength(3);
+
+    fireEvent.click(toggles[0], { altKey: true });
+
+    const lists = container.querySelectorAll(".associated-libraries");
+    // Items 1 and 3 have libraries; item 2 is empty so no list shown even when "expanded".
+    expect(lists).toHaveLength(2);
+  });
+
+  it("alt+click collapses all items when all expandable items are already expanded", () => {
+    const { container } = renderList([
+      { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
+      { id: 2, name: "B", libraries: [{ short_name: "beta" }] },
+    ]);
+    const toggles = container.querySelectorAll(".library-toggle");
+
+    // Expand all first.
+    fireEvent.click(toggles[0], { altKey: true });
+    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+
+    // Alt+click again should collapse all.
+    fireEvent.click(toggles[0], { altKey: true });
+    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(0);
+  });
+
+  // ── Sorted library list ───────────────────────────────────────────────────
+
+  it("renders associated libraries sorted alphabetically by display name", () => {
+    const { container } = renderList([
+      {
+        id: 1,
+        name: "Service A",
+        libraries: [
+          { short_name: "gamma" },
+          { short_name: "alpha" },
+          { short_name: "beta" },
+        ],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toBe("Alpha Library");
+    expect(items[1].textContent).toBe("Beta Library");
+    expect(items[2].textContent).toBe("Gamma Library");
+  });
+
+  it("renders a library with a uuid as a link to its config page", () => {
+    const { container } = renderList([
+      { id: 1, name: "Service A", libraries: [{ short_name: "alpha" }] },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      ".associated-libraries a"
+    );
+    expect(link).not.toBeNull();
+    expect(link.textContent).toBe("Alpha Library");
+    expect(link.href).toContain("/admin/web/config/libraries/edit/uuid-alpha");
+  });
+
+  it("renders a library without a uuid as plain text (no link)", () => {
+    const { container } = renderList([
+      { id: 1, name: "Service A", libraries: [{ short_name: "delta" }] },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    expect(container.querySelector(".associated-libraries a")).toBeNull();
+    expect(
+      container.querySelector(".associated-libraries li").textContent
+    ).toBe("Delta Library");
+  });
+
+  it("falls back to short_name when no display name is available in allLibraries", () => {
+    const { container } = renderList([
+      { id: 1, name: "Service A", libraries: [{ short_name: "unknown" }] },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    expect(
+      container.querySelector(".associated-libraries li").textContent
+    ).toBe("unknown");
+  });
+});

--- a/tests/jest/components/EditableConfigList.test.tsx
+++ b/tests/jest/components/EditableConfigList.test.tsx
@@ -176,13 +176,30 @@ describe("EditableConfigList - library association disclosure", () => {
     const { container } = renderList([
       { id: 1, name: "A", libraries: [{ short_name: "alpha" }] },
     ]);
-    expect(container.querySelector(".expand-collapse-controls")).not.toBeNull();
+    const controlSets = container.querySelectorAll(".expand-collapse-controls");
+    // One set above the list and one below (visual duplicate).
+    expect(controlSets).toHaveLength(2);
+    // Top set: functional, in tab order, not hidden from accessibility tree.
+    const topSet = controlSets[0];
+    expect(topSet.closest("[aria-hidden]")).toBeNull();
     expect(
-      container.querySelector<HTMLButtonElement>(".expand-all").disabled
+      topSet.querySelector<HTMLButtonElement>(".expand-all").tabIndex
+    ).not.toBe(-1);
+    expect(
+      topSet.querySelector<HTMLButtonElement>(".expand-all").disabled
     ).toBe(false);
     expect(
-      container.querySelector<HTMLButtonElement>(".collapse-all").disabled
+      topSet.querySelector<HTMLButtonElement>(".collapse-all").disabled
     ).toBe(true);
+    // Bottom set: hidden from accessibility tree and removed from tab order.
+    const bottomSet = controlSets[1];
+    expect(bottomSet.closest("[aria-hidden='true']")).not.toBeNull();
+    expect(
+      bottomSet.querySelector<HTMLButtonElement>(".expand-all").tabIndex
+    ).toBe(-1);
+    expect(
+      bottomSet.querySelector<HTMLButtonElement>(".collapse-all").tabIndex
+    ).toBe(-1);
   });
 
   it("Expand all expands all items that have libraries", () => {

--- a/tests/jest/components/IndividualAdmins.test.tsx
+++ b/tests/jest/components/IndividualAdmins.test.tsx
@@ -50,7 +50,7 @@ describe("IndividualAdmins - role association disclosure", () => {
 
   it("shows no toggle for an admin with no roles field", () => {
     const { container } = renderAdmins([{ email: "noroles@example.com" }]);
-    expect(container.querySelector(".library-toggle")).toBeNull();
+    expect(container.querySelector(".association-toggle")).toBeNull();
     expect(container.querySelector(".library-count")).toBeNull();
   });
 
@@ -59,7 +59,7 @@ describe("IndividualAdmins - role association disclosure", () => {
       { email: "empty@example.com", roles: [] },
     ]);
     const toggle = container.querySelector<HTMLButtonElement>(
-      ".library-toggle"
+      ".association-toggle"
     );
     expect(toggle).not.toBeNull();
     expect(toggle.disabled).toBe(true);
@@ -93,15 +93,32 @@ describe("IndividualAdmins - role association disclosure", () => {
     );
   });
 
+  it("counts deduplicated display entries, not raw roles, when a library has both manager and librarian roles", () => {
+    // Two raw roles for the same library collapse to one display entry (highest wins).
+    // The count shown to the user should reflect what is displayed, not item.roles.length.
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [
+          { role: "librarian", library: "alpha" },
+          { role: "manager", library: "alpha" },
+        ],
+      },
+    ]);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (1 role)"
+    );
+  });
+
   // ── System admin ──────────────────────────────────────────────────────────
 
   it("shows only 'sysadmin' in the expanded list for a system-role admin", () => {
     const { container } = renderAdmins([
       { email: "sys@example.com", roles: [{ role: "system" }] },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("sysadmin");
   });
@@ -113,9 +130,9 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "system" }, { role: "manager", library: "alpha" }],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("sysadmin");
   });
@@ -129,9 +146,9 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "manager", library: "alpha" }],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("Alpha Library - Manager");
   });
@@ -143,9 +160,9 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "librarian", library: "beta" }],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("Beta Library - Librarian");
   });
@@ -160,9 +177,9 @@ describe("IndividualAdmins - role association disclosure", () => {
         ],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items).toHaveLength(1);
     expect(items[0].textContent).toBe("Alpha Library - Manager");
   });
@@ -173,9 +190,9 @@ describe("IndividualAdmins - role association disclosure", () => {
     const { container } = renderAdmins([
       { email: "mgr@example.com", roles: [{ role: "manager-all" }] },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items[0].textContent).toBe("All libraries - Manager");
   });
 
@@ -183,9 +200,9 @@ describe("IndividualAdmins - role association disclosure", () => {
     const { container } = renderAdmins([
       { email: "lib@example.com", roles: [{ role: "librarian-all" }] },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items[0].textContent).toBe("All libraries - Librarian");
   });
 
@@ -196,13 +213,53 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "librarian-all" }, { role: "manager-all" }],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     // Only the manager-all entry; librarian-all is superseded.
     expect(Array.from(items).map((li) => li.textContent)).toEqual([
       "All libraries - Manager",
     ]);
+  });
+
+  // ── Combined sitewide + library-specific roles ────────────────────────────
+
+  it("shows both 'All libraries' and per-library entries when manager-all and library roles coexist", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [
+          { role: "manager-all" },
+          { role: "manager", library: "alpha" },
+          { role: "librarian", library: "beta" },
+        ],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    const items = container.querySelectorAll(".associated-items li");
+    const texts = Array.from(items).map((li) => li.textContent);
+    expect(texts).toContain("All libraries - Manager");
+    expect(texts).toContain("Alpha Library - Manager");
+    expect(texts).toContain("Beta Library - Librarian");
+  });
+
+  it("shows both 'All libraries' and per-library entries when librarian-all and library roles coexist", () => {
+    const { container } = renderAdmins([
+      {
+        email: "lib@example.com",
+        roles: [
+          { role: "librarian-all" },
+          { role: "librarian", library: "gamma" },
+        ],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".association-toggle"));
+
+    const items = container.querySelectorAll(".associated-items li");
+    const texts = Array.from(items).map((li) => li.textContent);
+    expect(texts).toContain("All libraries - Librarian");
+    expect(texts).toContain("Gamma Library - Librarian");
   });
 
   // ── Sorting ───────────────────────────────────────────────────────────────
@@ -218,9 +275,9 @@ describe("IndividualAdmins - role association disclosure", () => {
         ],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    const items = container.querySelectorAll(".associated-libraries li");
+    const items = container.querySelectorAll(".associated-items li");
     expect(items[0].textContent).toBe("Alpha Library - Manager");
     expect(items[1].textContent).toBe("Beta Library - Librarian");
     expect(items[2].textContent).toBe("Gamma Library - Manager");
@@ -235,10 +292,10 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "manager", library: "alpha" }],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
     const link = container.querySelector<HTMLAnchorElement>(
-      ".associated-libraries a"
+      ".associated-items a"
     );
     expect(link).not.toBeNull();
     expect(link.textContent).toBe("Alpha Library");
@@ -254,12 +311,45 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "librarian", library: "delta" }],
       },
     ]);
-    fireEvent.click(container.querySelector(".library-toggle"));
+    fireEvent.click(container.querySelector(".association-toggle"));
 
-    expect(container.querySelector(".associated-libraries a")).toBeNull();
-    expect(
-      container.querySelector(".associated-libraries li").textContent
-    ).toBe("Delta Library - Librarian");
+    expect(container.querySelector(".associated-items a")).toBeNull();
+    expect(container.querySelector(".associated-items li").textContent).toBe(
+      "Delta Library - Librarian"
+    );
+  });
+
+  // ── Expand all / Collapse all buttons ────────────────────────────────────
+
+  it("Expand all expands all admins that have roles", () => {
+    const { container } = renderAdmins([
+      { email: "sys@example.com", roles: [{ role: "system" }] },
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "manager", library: "alpha" }],
+      },
+      { email: "none@example.com" }, // no roles field → no toggle
+    ]);
+
+    fireEvent.click(container.querySelector(".expand-all"));
+
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+  });
+
+  it("Collapse all collapses all expanded admins", () => {
+    const { container } = renderAdmins([
+      { email: "sys@example.com", roles: [{ role: "system" }] },
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "manager", library: "alpha" }],
+      },
+    ]);
+
+    fireEvent.click(container.querySelector(".expand-all"));
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
+
+    fireEvent.click(container.querySelector(".collapse-all"));
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(0);
   });
 
   // ── Alt+click toggle-all ──────────────────────────────────────────────────
@@ -273,12 +363,12 @@ describe("IndividualAdmins - role association disclosure", () => {
       },
       { email: "none@example.com" }, // no roles field → no toggle
     ]);
-    const toggles = container.querySelectorAll(".library-toggle");
+    const toggles = container.querySelectorAll(".association-toggle");
     expect(toggles).toHaveLength(2);
 
     fireEvent.click(toggles[0], { altKey: true });
 
-    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
   });
 
   it("alt+click collapses all when all are already expanded", () => {
@@ -289,12 +379,12 @@ describe("IndividualAdmins - role association disclosure", () => {
         roles: [{ role: "manager", library: "alpha" }],
       },
     ]);
-    const toggles = container.querySelectorAll(".library-toggle");
+    const toggles = container.querySelectorAll(".association-toggle");
 
     fireEvent.click(toggles[0], { altKey: true });
-    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(2);
 
     fireEvent.click(toggles[0], { altKey: true });
-    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(0);
+    expect(container.querySelectorAll(".associated-items")).toHaveLength(0);
   });
 });

--- a/tests/jest/components/IndividualAdmins.test.tsx
+++ b/tests/jest/components/IndividualAdmins.test.tsx
@@ -1,0 +1,300 @@
+import * as React from "react";
+import { fireEvent } from "@testing-library/react";
+import { IndividualAdmins } from "../../../src/components/IndividualAdmins";
+import renderWithContext from "../testUtils/renderWithContext";
+import {
+  ConfigurationSettings,
+  IndividualAdminsData,
+} from "../../../src/interfaces";
+import { defaultFeatureFlags } from "../../../src/utils/featureFlags";
+
+// NB: This adds tests to the already existing tests in:
+// - `src/components/__tests__/IndividualAdmins-test.tsx`.
+//
+// Those tests should eventually be migrated here and
+// adapted to the Jest/React Testing Library paradigm.
+
+describe("IndividualAdmins - role association disclosure", () => {
+  // ── Shared fixtures ───────────────────────────────────────────────────────
+
+  const allLibraries = [
+    { short_name: "gamma", name: "Gamma Library", uuid: "uuid-gamma" },
+    { short_name: "alpha", name: "Alpha Library", uuid: "uuid-alpha" },
+    { short_name: "beta", name: "Beta Library", uuid: "uuid-beta" },
+    { short_name: "delta", name: "Delta Library" }, // no uuid
+  ];
+
+  const sysAdminConfig: Partial<ConfigurationSettings> = {
+    csrfToken: "",
+    featureFlags: defaultFeatureFlags,
+    roles: [{ role: "system" }],
+  };
+
+  const renderAdmins = (
+    admins: IndividualAdminsData["individualAdmins"],
+    config = sysAdminConfig
+  ) =>
+    renderWithContext(
+      <IndividualAdmins
+        data={{ individualAdmins: admins, allLibraries }}
+        fetchData={jest.fn()}
+        editItem={jest.fn().mockResolvedValue(undefined)}
+        deleteItem={jest.fn().mockResolvedValue(undefined)}
+        csrfToken="token"
+        isFetching={false}
+      />,
+      config
+    );
+
+  // ── Toggle visibility ─────────────────────────────────────────────────────
+
+  it("shows no toggle for an admin with no roles field", () => {
+    const { container } = renderAdmins([{ email: "noroles@example.com" }]);
+    expect(container.querySelector(".library-toggle")).toBeNull();
+    expect(container.querySelector(".library-count")).toBeNull();
+  });
+
+  it("shows 'no roles' and a disabled toggle for an admin with an empty roles array", () => {
+    const { container } = renderAdmins([
+      { email: "empty@example.com", roles: [] },
+    ]);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      ".library-toggle"
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle.disabled).toBe(true);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (no roles)"
+    );
+  });
+
+  it("shows '1 role' for a system admin", () => {
+    const { container } = renderAdmins([
+      { email: "sys@example.com", roles: [{ role: "system" }] },
+    ]);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (1 role)"
+    );
+  });
+
+  it("shows 'N roles' for an admin with multiple role entries", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [
+          { role: "manager", library: "alpha" },
+          { role: "manager", library: "beta" },
+          { role: "librarian", library: "gamma" },
+        ],
+      },
+    ]);
+    expect(container.querySelector(".library-count").textContent).toBe(
+      " (3 roles)"
+    );
+  });
+
+  // ── System admin ──────────────────────────────────────────────────────────
+
+  it("shows only 'sysadmin' in the expanded list for a system-role admin", () => {
+    const { container } = renderAdmins([
+      { email: "sys@example.com", roles: [{ role: "system" }] },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("sysadmin");
+  });
+
+  it("shows only 'sysadmin' even when other roles are also present", () => {
+    const { container } = renderAdmins([
+      {
+        email: "sys@example.com",
+        roles: [{ role: "system" }, { role: "manager", library: "alpha" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("sysadmin");
+  });
+
+  // ── Library-specific roles ────────────────────────────────────────────────
+
+  it("shows '<library> - Manager' for a library manager role", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "manager", library: "alpha" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("Alpha Library - Manager");
+  });
+
+  it("shows '<library> - Librarian' for a librarian role", () => {
+    const { container } = renderAdmins([
+      {
+        email: "lib@example.com",
+        roles: [{ role: "librarian", library: "beta" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("Beta Library - Librarian");
+  });
+
+  it("shows the highest role (Manager) when a library has both manager and librarian roles", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [
+          { role: "librarian", library: "alpha" },
+          { role: "manager", library: "alpha" },
+        ],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("Alpha Library - Manager");
+  });
+
+  // ── Sitewide roles ────────────────────────────────────────────────────────
+
+  it("shows 'All libraries - Manager' for a manager-all role", () => {
+    const { container } = renderAdmins([
+      { email: "mgr@example.com", roles: [{ role: "manager-all" }] },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items[0].textContent).toBe("All libraries - Manager");
+  });
+
+  it("shows 'All libraries - Librarian' for a librarian-all role", () => {
+    const { container } = renderAdmins([
+      { email: "lib@example.com", roles: [{ role: "librarian-all" }] },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items[0].textContent).toBe("All libraries - Librarian");
+  });
+
+  it("shows Manager (not Librarian) when both manager-all and librarian-all are present", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "librarian-all" }, { role: "manager-all" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    // Only the manager-all entry; librarian-all is superseded.
+    expect(Array.from(items).map((li) => li.textContent)).toEqual([
+      "All libraries - Manager",
+    ]);
+  });
+
+  // ── Sorting ───────────────────────────────────────────────────────────────
+
+  it("sorts library role entries alphabetically by library display name", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [
+          { role: "manager", library: "gamma" },
+          { role: "manager", library: "alpha" },
+          { role: "librarian", library: "beta" },
+        ],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const items = container.querySelectorAll(".associated-libraries li");
+    expect(items[0].textContent).toBe("Alpha Library - Manager");
+    expect(items[1].textContent).toBe("Beta Library - Librarian");
+    expect(items[2].textContent).toBe("Gamma Library - Manager");
+  });
+
+  // ── Links ─────────────────────────────────────────────────────────────────
+
+  it("links the library name to its config page when a uuid is available", () => {
+    const { container } = renderAdmins([
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "manager", library: "alpha" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    const link = container.querySelector<HTMLAnchorElement>(
+      ".associated-libraries a"
+    );
+    expect(link).not.toBeNull();
+    expect(link.textContent).toBe("Alpha Library");
+    expect(link.href).toContain("/admin/web/config/libraries/edit/uuid-alpha");
+    // The role suffix should not be part of the link.
+    expect(link.nextSibling.textContent).toBe(" - Manager");
+  });
+
+  it("renders the library name as plain text when no uuid is available", () => {
+    const { container } = renderAdmins([
+      {
+        email: "lib@example.com",
+        roles: [{ role: "librarian", library: "delta" }],
+      },
+    ]);
+    fireEvent.click(container.querySelector(".library-toggle"));
+
+    expect(container.querySelector(".associated-libraries a")).toBeNull();
+    expect(
+      container.querySelector(".associated-libraries li").textContent
+    ).toBe("Delta Library - Librarian");
+  });
+
+  // ── Alt+click toggle-all ──────────────────────────────────────────────────
+
+  it("alt+click expands all admins that have roles", () => {
+    const { container } = renderAdmins([
+      { email: "sys@example.com", roles: [{ role: "system" }] },
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "manager", library: "alpha" }],
+      },
+      { email: "none@example.com" }, // no roles field → no toggle
+    ]);
+    const toggles = container.querySelectorAll(".library-toggle");
+    expect(toggles).toHaveLength(2);
+
+    fireEvent.click(toggles[0], { altKey: true });
+
+    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+  });
+
+  it("alt+click collapses all when all are already expanded", () => {
+    const { container } = renderAdmins([
+      { email: "sys@example.com", roles: [{ role: "system" }] },
+      {
+        email: "mgr@example.com",
+        roles: [{ role: "manager", library: "alpha" }],
+      },
+    ]);
+    const toggles = container.querySelectorAll(".library-toggle");
+
+    fireEvent.click(toggles[0], { altKey: true });
+    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(2);
+
+    fireEvent.click(toggles[0], { altKey: true });
+    expect(container.querySelectorAll(".associated-libraries")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description

Add an expandable disclosure panel to each row on the integration/configuration list pages, showing the libraries / roles associated with that service. Users can expand/collapse individual rows or use Expand all / Collapse all controls. `Alt+Click` on any toggle expands or collapses all rows at once.

This is implemented as a set of overridable template methods on `GenericEditableConfigList`:

- `getAssociatedEntries` — returns entries to display (or `undefined` to suppress the toggle entirely)
- `formatAssociatedCount` — controls the count label (e.g. "3 libraries", "2 roles", "1 registered library")
- `getAllLibraries` — resolves short names to display names and edit links

Each component overrides as needed:
- **Collections / base class** — shows associated libraries
- **DiscoveryServices** — shows successfully registered libraries with their registration stage
- **IndividualAdmins** — shows admin roles; sitewide roles (manager-all, librarian-all) are pinned to the top; system admins show a synthetic "sysadmin" entry
- **Libraries** — suppresses the panel (libraries are not associated with other libraries)

Also includes a few minor fixes picked up along the way:
- `UNSAFE_componentWillMount` update to `componentDidMount`, 
- `(window as any).FormData` updated to `FormData`, 
- `.catch()` added to `save()` to suppress unhandled-rejection warnings, and 
- `CollectionData` now explicitly declares `marked_for_deletion`.

## Motivation and Context

Admins currently have no way to see which libraries are associated with a service without opening each service's edit form individually.

[Jira PP-4022]

## How Has This Been Tested?

- Manual testing in local development environment.
- New tests for added functionality.
- [CI checks](https://github.com/ThePalaceProject/circulation-admin/actions/runs/24351053998) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
