### PR TITLE
Use central github-actions repo for jira-release-sync

### DIFF
--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -6,11 +6,8 @@ jobs:
   sync-to-jira:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Sync release to Jira
-        uses: ThePalaceProject/circulation/.github/actions/jira-release-sync@main
+        uses: ThePalaceProject/github-actions/jira-release-sync@v1
         with:
           jira-base-url: ${{ secrets.JIRA_BASE_URL }}
           jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}


### PR DESCRIPTION
## Description

Update the Jira release sync workflow to use the centralized `jira-release-sync` action from the new `ThePalaceProject/github-actions` repository, pinned to the `v1` tag, instead of the inline action under `ThePalaceProject/circulation/.github/actions/jira-release-sync@main`. Also drops the `actions/checkout` step since the action does not require the repository to be checked out.

## Motivation and Context

The `jira-release-sync` action has been moved to a central `github-actions` repository so it can be shared and versioned across Palace repos. This switches us over to the new location and pins to `v1`.

## How Has This Been Tested?

No code changes — only workflow updates. Will be exercised the next time a release is published.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.