### PR TITLE
Adds JSON form field support (PP-4438)

### DIFF
--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import { SettingData } from "../interfaces";
+
+export interface JsonFieldProps {
+  setting: SettingData;
+  value?: any;
+  disabled?: boolean;
+  readOnly?: boolean;
+  onChange?: (value: any) => void;
+}
+
+export interface JsonFieldState {
+  text: string;
+  jsonError: string | null;
+}
+
+function valueToText(value: any): string {
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value, null, 2);
+}
+
+export default class JsonField extends React.Component<
+  JsonFieldProps,
+  JsonFieldState
+> {
+  static displayName = "JsonField";
+
+  constructor(props: JsonFieldProps) {
+    super(props);
+    this.state = {
+      text: valueToText(props.value),
+      jsonError: null,
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  UNSAFE_componentWillReceiveProps(nextProps: JsonFieldProps) {
+    if (nextProps.value !== this.props.value) {
+      this.setState({ text: valueToText(nextProps.value), jsonError: null });
+    }
+  }
+
+  handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const text = e.target.value;
+    let jsonError: string | null = null;
+    let parsed: any = null;
+    if (text.trim()) {
+      try {
+        parsed = JSON.parse(text);
+      } catch (err) {
+        jsonError = err.message;
+      }
+    }
+    this.setState({ text, jsonError });
+    if (!jsonError && this.props.onChange) {
+      this.props.onChange(text.trim() ? parsed : null);
+    }
+  }
+
+  getValue(): any {
+    const { text } = this.state;
+    if (!text.trim()) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return undefined;
+    }
+  }
+
+  clear() {
+    this.setState({ text: "", jsonError: null });
+  }
+
+  render(): JSX.Element {
+    const { setting, disabled, readOnly } = this.props;
+    const { text, jsonError } = this.state;
+    const descId = setting.description ? `json-desc-${setting.key}` : undefined;
+
+    return (
+      <div className={`form-group${jsonError ? " field-error" : ""}`}>
+        <label className="control-label">
+          {setting.label}
+          {setting.required && <span className="required-field">Required</span>}
+          <textarea
+            className="form-control"
+            name={setting.key}
+            value={text}
+            onChange={this.handleChange}
+            disabled={disabled}
+            readOnly={readOnly}
+            aria-describedby={descId}
+          />
+        </label>
+        {setting.description && (
+          <p
+            id={descId}
+            className="description"
+            dangerouslySetInnerHTML={{ __html: setting.description }}
+          />
+        )}
+        {jsonError && <p className="description">{jsonError}</p>}
+      </div>
+    );
+  }
+}

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -1,4 +1,11 @@
 import * as React from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useImperativeHandle,
+  forwardRef,
+} from "react";
 import CopyIcon from "./icons/CopyIcon";
 import XCloseIcon from "./icons/XCloseIcon";
 import { SettingData } from "../interfaces";
@@ -11,13 +18,9 @@ export interface JsonFieldProps {
   onChange?: (value: any) => void;
 }
 
-export interface JsonFieldState {
-  text: string;
-  jsonError: string | null;
-  copied: boolean;
-  previousText: string | null;
-  clearFeedback: boolean;
-  focused: boolean;
+export interface JsonFieldHandle {
+  getValue(): any;
+  clear(): void;
 }
 
 function valueToText(value: any): string {
@@ -25,176 +28,151 @@ function valueToText(value: any): string {
   return JSON.stringify(value, null, 2);
 }
 
-export default class JsonField extends React.Component<
-  JsonFieldProps,
-  JsonFieldState
-> {
-  static displayName = "JsonField";
-  private copyTimeoutId: ReturnType<typeof setTimeout> | null = null;
-  private clearFeedbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
-  constructor(props: JsonFieldProps) {
-    super(props);
-    this.state = {
-      text: valueToText(props.value),
-      jsonError: null,
-      copied: false,
-      previousText: null,
-      clearFeedback: false,
-      focused: false,
-    };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleFocus = this.handleFocus.bind(this);
-    this.handleBlur = this.handleBlur.bind(this);
-    this.handleCopy = this.handleCopy.bind(this);
-    this.handleClearClick = this.handleClearClick.bind(this);
-    this.preventButtonBlur = this.preventButtonBlur.bind(this);
+function parseJson(s: string): { parsed: any; error: string | null } {
+  if (!s.trim()) return { parsed: null, error: null };
+  try {
+    return { parsed: JSON.parse(s), error: null };
+  } catch (err) {
+    return { parsed: null, error: (err as Error).message };
   }
+}
 
-  componentWillUnmount() {
-    if (this.copyTimeoutId) clearTimeout(this.copyTimeoutId);
-    if (this.clearFeedbackTimeoutId) clearTimeout(this.clearFeedbackTimeoutId);
-  }
+const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
+  function JsonField({ setting, value, disabled, readOnly, onChange }, ref) {
+    const [text, setText] = useState(() => valueToText(value));
+    const [jsonError, setJsonError] = useState<string | null>(null);
+    const [copied, setCopied] = useState(false);
+    const [copyFailed, setCopyFailed] = useState(false);
+    const [previousText, setPreviousText] = useState<string | null>(null);
+    const [clearFeedback, setClearFeedback] = useState(false);
+    const [focused, setFocused] = useState(false);
 
-  UNSAFE_componentWillReceiveProps(nextProps: JsonFieldProps) {
-    if (nextProps.value !== this.props.value) {
-      this.setState({
-        text: valueToText(nextProps.value),
-        jsonError: null,
-        previousText: null,
-        clearFeedback: false,
-      });
+    const copyTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const clearFeedbackTimeoutId = useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
+
+    // Sync external value changes to internal text (replaces UNSAFE_componentWillReceiveProps).
+    const [prevValue, setPrevValue] = useState(value);
+    if (prevValue !== value) {
+      setPrevValue(value);
+      setText(valueToText(value));
+      setJsonError(null);
+      setPreviousText(null);
+      setClearFeedback(false);
     }
-  }
 
-  handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    const text = e.target.value;
-    let jsonError: string | null = null;
-    let parsed: any = null;
-    if (text.trim()) {
-      try {
-        parsed = JSON.parse(text);
-      } catch (err) {
-        jsonError = err.message;
-      }
-    }
-    // Typing discards undo state and dismisses the cleared message.
-    this.setState({
-      text,
-      jsonError,
-      previousText: null,
-      clearFeedback: false,
-    });
-    if (!jsonError && this.props.onChange) {
-      this.props.onChange(text.trim() ? parsed : null);
-    }
-  }
+    useEffect(() => {
+      return () => {
+        if (copyTimeoutId.current) clearTimeout(copyTimeoutId.current);
+        if (clearFeedbackTimeoutId.current)
+          clearTimeout(clearFeedbackTimeoutId.current);
+      };
+    }, []);
 
-  handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if ((e.ctrlKey || e.metaKey) && e.key === "z") {
-      const { previousText } = this.state;
-      if (previousText !== null) {
-        e.preventDefault();
-        if (this.clearFeedbackTimeoutId)
-          clearTimeout(this.clearFeedbackTimeoutId);
-        let jsonError: string | null = null;
-        let parsed: any = null;
-        if (previousText.trim()) {
-          try {
-            parsed = JSON.parse(previousText);
-          } catch (err) {
-            jsonError = err.message;
+    useImperativeHandle(
+      ref,
+      () => ({
+        getValue() {
+          const { parsed, error } = parseJson(text);
+          return error ? undefined : parsed;
+        },
+        clear() {
+          if (clearFeedbackTimeoutId.current) {
+            clearTimeout(clearFeedbackTimeoutId.current);
+            clearFeedbackTimeoutId.current = null;
           }
-        }
-        this.setState({
-          text: previousText,
-          jsonError,
-          previousText: null,
-          clearFeedback: false,
-        });
-        if (!jsonError && this.props.onChange) {
-          this.props.onChange(previousText.trim() ? parsed : null);
+          if (copyTimeoutId.current) {
+            clearTimeout(copyTimeoutId.current);
+            copyTimeoutId.current = null;
+          }
+          setText("");
+          setJsonError(null);
+          setCopied(false);
+          setCopyFailed(false);
+          setPreviousText(null);
+          setClearFeedback(false);
+          if (onChange) onChange(null);
+        },
+      }),
+      [text, onChange]
+    );
+
+    function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+      const newText = e.target.value;
+      const { parsed, error } = parseJson(newText);
+      if (clearFeedbackTimeoutId.current) {
+        clearTimeout(clearFeedbackTimeoutId.current);
+        clearFeedbackTimeoutId.current = null;
+      }
+      setText(newText);
+      setJsonError(error);
+      setPreviousText(null);
+      setClearFeedback(false);
+      if (!error && onChange) {
+        onChange(newText.trim() ? parsed : null);
+      }
+    }
+
+    function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "z" && previousText !== null) {
+        e.preventDefault();
+        if (clearFeedbackTimeoutId.current)
+          clearTimeout(clearFeedbackTimeoutId.current);
+        const { parsed, error } = parseJson(previousText);
+        setText(previousText);
+        setJsonError(error);
+        setPreviousText(null);
+        setClearFeedback(false);
+        if (!error && onChange) {
+          onChange(previousText.trim() ? parsed : null);
         }
       }
     }
-  }
 
-  handleFocus() {
-    this.setState({ focused: true });
-  }
-
-  handleBlur() {
-    this.setState({ focused: false });
-  }
-
-  getValue(): any {
-    const { text } = this.state;
-    if (!text.trim()) return null;
-    try {
-      return JSON.parse(text);
-    } catch {
-      return undefined;
+    function handleCopy() {
+      if (copyTimeoutId.current) clearTimeout(copyTimeoutId.current);
+      navigator.clipboard.writeText(text).then(
+        () => {
+          setCopied(true);
+          setCopyFailed(false);
+          copyTimeoutId.current = setTimeout(() => {
+            setCopied(false);
+            copyTimeoutId.current = null;
+          }, 2000);
+        },
+        () => {
+          setCopyFailed(true);
+          setCopied(false);
+          copyTimeoutId.current = setTimeout(() => {
+            setCopyFailed(false);
+            copyTimeoutId.current = null;
+          }, 2000);
+        }
+      );
     }
-  }
 
-  handleCopy() {
-    if (this.copyTimeoutId) clearTimeout(this.copyTimeoutId);
-    this.setState({ copied: true });
-    this.copyTimeoutId = setTimeout(() => {
-      this.setState({ copied: false });
-      this.copyTimeoutId = null;
-    }, 2000);
-    navigator.clipboard.writeText(this.state.text).catch(() => {
-      if (this.copyTimeoutId) {
-        clearTimeout(this.copyTimeoutId);
-        this.copyTimeoutId = null;
-      }
-      this.setState({ copied: false });
-    });
-  }
-
-  handleClearClick() {
-    const previousText = this.state.text;
-    if (this.clearFeedbackTimeoutId) clearTimeout(this.clearFeedbackTimeoutId);
-    this.setState({
-      text: "",
-      jsonError: null,
-      copied: false,
-      previousText,
-      clearFeedback: true,
-    });
-    this.clearFeedbackTimeoutId = setTimeout(() => {
-      this.setState({ clearFeedback: false });
-      this.clearFeedbackTimeoutId = null;
-    }, 5000);
-    if (this.props.onChange) {
-      this.props.onChange(null);
+    function handleClearClick() {
+      if (clearFeedbackTimeoutId.current)
+        clearTimeout(clearFeedbackTimeoutId.current);
+      setClearFeedback(true);
+      clearFeedbackTimeoutId.current = setTimeout(() => {
+        setClearFeedback(false);
+        clearFeedbackTimeoutId.current = null;
+      }, 5000);
+      setText("");
+      setJsonError(null);
+      setCopied(false);
+      setCopyFailed(false);
+      setPreviousText(text);
+      if (onChange) onChange(null);
     }
-  }
 
-  // Prevents buttons from stealing focus from the textarea.
-  preventButtonBlur(e: React.MouseEvent) {
-    e.preventDefault();
-  }
-
-  clear() {
-    if (this.clearFeedbackTimeoutId) clearTimeout(this.clearFeedbackTimeoutId);
-    this.setState({
-      text: "",
-      jsonError: null,
-      copied: false,
-      previousText: null,
-      clearFeedback: false,
-    });
-    if (this.props.onChange) {
-      this.props.onChange(null);
+    // Prevents buttons from stealing focus from the textarea.
+    function preventButtonBlur(e: React.MouseEvent) {
+      e.preventDefault();
     }
-  }
 
-  render(): JSX.Element {
-    const { setting, disabled, readOnly } = this.props;
-    const { text, jsonError, copied, clearFeedback, focused } = this.state;
     const textareaId = `json-field-${setting.key}`;
     const descId = setting.description ? `json-desc-${setting.key}` : undefined;
     const errorId = `json-error-${setting.key}`;
@@ -220,18 +198,21 @@ export default class JsonField extends React.Component<
             className="form-control"
             name={setting.key}
             value={text}
-            onChange={this.handleChange}
-            onKeyDown={this.handleKeyDown}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
             disabled={disabled}
             readOnly={readOnly}
-            aria-invalid={!!jsonError}
+            aria-invalid={jsonError ? true : undefined}
             aria-describedby={describedBy}
           />
           <div className="json-field-actions">
             <span className="json-field-copied-feedback" aria-live="polite">
               {copied ? "Copied!" : ""}
+            </span>
+            <span className="json-field-copy-failed-feedback" role="alert">
+              {copyFailed ? "Copy failed." : ""}
             </span>
             <span className="json-field-cleared-feedback" aria-live="polite">
               {clearFeedback ? "Cleared! Ctrl-Z / Cmd-Z to recover." : ""}
@@ -239,8 +220,8 @@ export default class JsonField extends React.Component<
             <button
               type="button"
               aria-label="Copy to clipboard"
-              onClick={this.handleCopy}
-              onMouseDown={this.preventButtonBlur}
+              onClick={handleCopy}
+              onMouseDown={preventButtonBlur}
               disabled={isEmpty}
             >
               <CopyIcon />
@@ -248,8 +229,8 @@ export default class JsonField extends React.Component<
             <button
               type="button"
               aria-label="Clear field"
-              onClick={this.handleClearClick}
-              onMouseDown={this.preventButtonBlur}
+              onClick={handleClearClick}
+              onMouseDown={preventButtonBlur}
               disabled={disabled || readOnly || isEmpty}
             >
               <XCloseIcon />
@@ -271,4 +252,8 @@ export default class JsonField extends React.Component<
       </div>
     );
   }
-}
+);
+
+JsonField.displayName = "JsonField";
+
+export default JsonField;

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -48,21 +48,14 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
       setClearFeedback(false);
       setCopied(false);
       setCopyFailed(false);
-      if (clearFeedbackTimeoutId.current) {
-        clearTimeout(clearFeedbackTimeoutId.current);
-        clearFeedbackTimeoutId.current = null;
-      }
-      if (copyTimeoutId.current) {
-        clearTimeout(copyTimeoutId.current);
-        copyTimeoutId.current = null;
-      }
+      cancelTimer(clearFeedbackTimeoutId);
+      cancelTimer(copyTimeoutId);
     }
 
     useEffect(() => {
       return () => {
-        if (copyTimeoutId.current) clearTimeout(copyTimeoutId.current);
-        if (clearFeedbackTimeoutId.current)
-          clearTimeout(clearFeedbackTimeoutId.current);
+        cancelTimer(copyTimeoutId);
+        cancelTimer(clearFeedbackTimeoutId);
       };
     }, []);
 
@@ -74,14 +67,8 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
           return error ? undefined : parsed;
         },
         clear() {
-          if (clearFeedbackTimeoutId.current) {
-            clearTimeout(clearFeedbackTimeoutId.current);
-            clearFeedbackTimeoutId.current = null;
-          }
-          if (copyTimeoutId.current) {
-            clearTimeout(copyTimeoutId.current);
-            copyTimeoutId.current = null;
-          }
+          cancelTimer(clearFeedbackTimeoutId);
+          cancelTimer(copyTimeoutId);
           setText("");
           setJsonError(null);
           setCopied(false);
@@ -97,14 +84,8 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
       const newText = e.target.value;
       const { parsed, error } = parseJson(newText);
-      if (clearFeedbackTimeoutId.current) {
-        clearTimeout(clearFeedbackTimeoutId.current);
-        clearFeedbackTimeoutId.current = null;
-      }
-      if (copyTimeoutId.current) {
-        clearTimeout(copyTimeoutId.current);
-        copyTimeoutId.current = null;
-      }
+      cancelTimer(clearFeedbackTimeoutId);
+      cancelTimer(copyTimeoutId);
       setText(newText);
       setJsonError(error);
       setPreviousText(null);
@@ -119,10 +100,7 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
       if ((e.ctrlKey || e.metaKey) && e.key === "z" && previousText !== null) {
         e.preventDefault();
-        if (clearFeedbackTimeoutId.current) {
-          clearTimeout(clearFeedbackTimeoutId.current);
-          clearFeedbackTimeoutId.current = null;
-        }
+        cancelTimer(clearFeedbackTimeoutId);
         const { parsed, error } = parseJson(previousText);
         setText(previousText);
         setJsonError(error);
@@ -135,7 +113,7 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     }
 
     function handleCopy() {
-      if (copyTimeoutId.current) clearTimeout(copyTimeoutId.current);
+      cancelTimer(copyTimeoutId);
 
       function applyCopyResult(success: boolean) {
         setCopied(success);
@@ -158,12 +136,8 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     }
 
     function handleClearClick() {
-      if (clearFeedbackTimeoutId.current)
-        clearTimeout(clearFeedbackTimeoutId.current);
-      if (copyTimeoutId.current) {
-        clearTimeout(copyTimeoutId.current);
-        copyTimeoutId.current = null;
-      }
+      cancelTimer(clearFeedbackTimeoutId);
+      cancelTimer(copyTimeoutId);
       setClearFeedback(true);
       clearFeedbackTimeoutId.current = setTimeout(() => {
         setClearFeedback(false);
@@ -267,6 +241,15 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
 );
 
 JsonField.displayName = "JsonField";
+
+function cancelTimer(
+  ref: React.MutableRefObject<ReturnType<typeof setTimeout> | null>
+) {
+  if (ref.current) {
+    clearTimeout(ref.current);
+    ref.current = null;
+  }
+}
 
 function valueToText(value: any): string {
   if (value === null || value === undefined) return "";

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+import CopyIcon from "./icons/CopyIcon";
+import XCloseIcon from "./icons/XCloseIcon";
 import { SettingData } from "../interfaces";
 
 export interface JsonFieldProps {
@@ -12,6 +14,9 @@ export interface JsonFieldProps {
 export interface JsonFieldState {
   text: string;
   jsonError: string | null;
+  copied: boolean;
+  previousText: string | null;
+  clearFeedback: boolean;
 }
 
 function valueToText(value: any): string {
@@ -24,19 +29,38 @@ export default class JsonField extends React.Component<
   JsonFieldState
 > {
   static displayName = "JsonField";
+  private copyTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private clearFeedbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   constructor(props: JsonFieldProps) {
     super(props);
     this.state = {
       text: valueToText(props.value),
       jsonError: null,
+      copied: false,
+      previousText: null,
+      clearFeedback: false,
     };
     this.handleChange = this.handleChange.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleCopy = this.handleCopy.bind(this);
+    this.handleClearClick = this.handleClearClick.bind(this);
+    this.preventButtonBlur = this.preventButtonBlur.bind(this);
+  }
+
+  componentWillUnmount() {
+    if (this.copyTimeoutId) clearTimeout(this.copyTimeoutId);
+    if (this.clearFeedbackTimeoutId) clearTimeout(this.clearFeedbackTimeoutId);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: JsonFieldProps) {
     if (nextProps.value !== this.props.value) {
-      this.setState({ text: valueToText(nextProps.value), jsonError: null });
+      this.setState({
+        text: valueToText(nextProps.value),
+        jsonError: null,
+        previousText: null,
+        clearFeedback: false,
+      });
     }
   }
 
@@ -51,9 +75,44 @@ export default class JsonField extends React.Component<
         jsonError = err.message;
       }
     }
-    this.setState({ text, jsonError });
+    // Typing discards undo state and dismisses the cleared message.
+    this.setState({
+      text,
+      jsonError,
+      previousText: null,
+      clearFeedback: false,
+    });
     if (!jsonError && this.props.onChange) {
       this.props.onChange(text.trim() ? parsed : null);
+    }
+  }
+
+  handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+      const { previousText } = this.state;
+      if (previousText !== null) {
+        e.preventDefault();
+        if (this.clearFeedbackTimeoutId)
+          clearTimeout(this.clearFeedbackTimeoutId);
+        let jsonError: string | null = null;
+        let parsed: any = null;
+        if (previousText.trim()) {
+          try {
+            parsed = JSON.parse(previousText);
+          } catch (err) {
+            jsonError = err.message;
+          }
+        }
+        this.setState({
+          text: previousText,
+          jsonError,
+          previousText: null,
+          clearFeedback: false,
+        });
+        if (!jsonError && this.props.onChange) {
+          this.props.onChange(previousText.trim() ? parsed : null);
+        }
+      }
     }
   }
 
@@ -67,30 +126,112 @@ export default class JsonField extends React.Component<
     }
   }
 
+  handleCopy() {
+    if (this.copyTimeoutId) clearTimeout(this.copyTimeoutId);
+    this.setState({ copied: true });
+    this.copyTimeoutId = setTimeout(() => {
+      this.setState({ copied: false });
+      this.copyTimeoutId = null;
+    }, 2000);
+    navigator.clipboard.writeText(this.state.text).catch(() => {
+      if (this.copyTimeoutId) {
+        clearTimeout(this.copyTimeoutId);
+        this.copyTimeoutId = null;
+      }
+      this.setState({ copied: false });
+    });
+  }
+
+  handleClearClick() {
+    const previousText = this.state.text;
+    if (this.clearFeedbackTimeoutId) clearTimeout(this.clearFeedbackTimeoutId);
+    this.setState({
+      text: "",
+      jsonError: null,
+      copied: false,
+      previousText,
+      clearFeedback: true,
+    });
+    this.clearFeedbackTimeoutId = setTimeout(() => {
+      this.setState({ clearFeedback: false });
+      this.clearFeedbackTimeoutId = null;
+    }, 5000);
+    if (this.props.onChange) {
+      this.props.onChange(null);
+    }
+  }
+
+  // Prevents buttons from stealing focus from the textarea.
+  preventButtonBlur(e: React.MouseEvent) {
+    e.preventDefault();
+  }
+
   clear() {
-    this.setState({ text: "", jsonError: null });
+    if (this.clearFeedbackTimeoutId) clearTimeout(this.clearFeedbackTimeoutId);
+    this.setState({
+      text: "",
+      jsonError: null,
+      copied: false,
+      previousText: null,
+      clearFeedback: false,
+    });
+    if (this.props.onChange) {
+      this.props.onChange(null);
+    }
   }
 
   render(): JSX.Element {
     const { setting, disabled, readOnly } = this.props;
-    const { text, jsonError } = this.state;
+    const { text, jsonError, copied, clearFeedback } = this.state;
+    const textareaId = `json-field-${setting.key}`;
     const descId = setting.description ? `json-desc-${setting.key}` : undefined;
+    const isEmpty = !text;
 
     return (
       <div className={`form-group${jsonError ? " field-error" : ""}`}>
-        <label className="control-label">
+        <label className="control-label" htmlFor={textareaId}>
           {setting.label}
           {setting.required && <span className="required-field">Required</span>}
+        </label>
+        <div className="json-field-textarea-wrap">
           <textarea
+            id={textareaId}
             className="form-control"
             name={setting.key}
             value={text}
             onChange={this.handleChange}
+            onKeyDown={this.handleKeyDown}
             disabled={disabled}
             readOnly={readOnly}
             aria-describedby={descId}
           />
-        </label>
+          <div className="json-field-actions">
+            <span className="json-field-copied-feedback" aria-live="polite">
+              {copied ? "Copied!" : ""}
+            </span>
+            <span className="json-field-cleared-feedback" aria-live="polite">
+              {clearFeedback ? "Cleared! Ctrl-Z / Cmd-Z to recover." : ""}
+            </span>
+            <button
+              type="button"
+              aria-label="Copy to clipboard"
+              onClick={this.handleCopy}
+              onMouseDown={this.preventButtonBlur}
+              disabled={isEmpty}
+            >
+              <CopyIcon />
+            </button>
+            <button
+              type="button"
+              aria-label="Clear field"
+              onClick={this.handleClearClick}
+              onMouseDown={this.preventButtonBlur}
+              disabled={disabled || readOnly || isEmpty}
+            >
+              <XCloseIcon />
+            </button>
+          </div>
+        </div>
         {setting.description && (
           <p
             id={descId}

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -48,16 +48,12 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
       setClearFeedback(false);
       setCopied(false);
       setCopyFailed(false);
-      cancelTimer(clearFeedbackTimeoutId);
-      cancelTimer(copyTimeoutId);
     }
 
-    useEffect(() => {
-      return () => {
-        cancelTimer(copyTimeoutId);
-        cancelTimer(clearFeedbackTimeoutId);
-      };
-    }, []);
+    useTimeoutCleanup({
+      refs: [copyTimeoutId, clearFeedbackTimeoutId],
+      deps: [value],
+    });
 
     useImperativeHandle(
       ref,
@@ -241,6 +237,25 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
 );
 
 JsonField.displayName = "JsonField";
+
+/**
+ * Hook to set up timer cleanup when the specified dependency array changes.
+ *
+ * Note that there's no body in the contained `useEffect`. It just returns a
+ * cleanup function that will be invoked before the next run or unmount.
+ *
+ * @param refs - Refs holding active timeout IDs to cancel on cleanup.
+ * @param deps - Dependency array that triggers the cleanup; defaults to `[]` (unmount only).
+ */
+function useTimeoutCleanup({
+  refs,
+  deps = [],
+}: {
+  refs: React.MutableRefObject<ReturnType<typeof setTimeout> | null>[];
+  deps?: React.DependencyList;
+}) {
+  useEffect(() => () => refs.forEach(cancelTimer), deps);
+}
 
 function cancelTimer(
   ref: React.MutableRefObject<ReturnType<typeof setTimeout> | null>

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -46,6 +46,12 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
       setJsonError(null);
       setPreviousText(null);
       setClearFeedback(false);
+      setCopied(false);
+      setCopyFailed(false);
+      if (copyTimeoutId.current) {
+        clearTimeout(copyTimeoutId.current);
+        copyTimeoutId.current = null;
+      }
     }
 
     useEffect(() => {

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -17,6 +17,7 @@ export interface JsonFieldState {
   copied: boolean;
   previousText: string | null;
   clearFeedback: boolean;
+  focused: boolean;
 }
 
 function valueToText(value: any): string {
@@ -40,9 +41,12 @@ export default class JsonField extends React.Component<
       copied: false,
       previousText: null,
       clearFeedback: false,
+      focused: false,
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
     this.handleCopy = this.handleCopy.bind(this);
     this.handleClearClick = this.handleClearClick.bind(this);
     this.preventButtonBlur = this.preventButtonBlur.bind(this);
@@ -116,6 +120,14 @@ export default class JsonField extends React.Component<
     }
   }
 
+  handleFocus() {
+    this.setState({ focused: true });
+  }
+
+  handleBlur() {
+    this.setState({ focused: false });
+  }
+
   getValue(): any {
     const { text } = this.state;
     if (!text.trim()) return null;
@@ -182,13 +194,22 @@ export default class JsonField extends React.Component<
 
   render(): JSX.Element {
     const { setting, disabled, readOnly } = this.props;
-    const { text, jsonError, copied, clearFeedback } = this.state;
+    const { text, jsonError, copied, clearFeedback, focused } = this.state;
     const textareaId = `json-field-${setting.key}`;
     const descId = setting.description ? `json-desc-${setting.key}` : undefined;
+    const errorId = `json-error-${setting.key}`;
+    const showErrorMsg = focused || !!jsonError;
+    const describedBy =
+      [descId, jsonError ? errorId : undefined].filter(Boolean).join(" ") ||
+      undefined;
     const isEmpty = !text;
 
     return (
-      <div className={`form-group${jsonError ? " field-error" : ""}`}>
+      <div
+        className={`form-group json-field-group${
+          jsonError ? " field-error" : ""
+        }`}
+      >
         <label className="control-label" htmlFor={textareaId}>
           {setting.label}
           {setting.required && <span className="required-field">Required</span>}
@@ -201,9 +222,12 @@ export default class JsonField extends React.Component<
             value={text}
             onChange={this.handleChange}
             onKeyDown={this.handleKeyDown}
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
             disabled={disabled}
             readOnly={readOnly}
-            aria-describedby={descId}
+            aria-invalid={!!jsonError}
+            aria-describedby={describedBy}
           />
           <div className="json-field-actions">
             <span className="json-field-copied-feedback" aria-live="polite">
@@ -239,7 +263,11 @@ export default class JsonField extends React.Component<
             dangerouslySetInnerHTML={{ __html: setting.description }}
           />
         )}
-        {jsonError && <p className="description">{jsonError}</p>}
+        {showErrorMsg && (
+          <p id={errorId} className="json-field-error-msg">
+            {jsonError ?? ""}
+          </p>
+        )}
       </div>
     );
   }

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -132,23 +132,24 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
 
     function handleCopy() {
       if (copyTimeoutId.current) clearTimeout(copyTimeoutId.current);
-      navigator.clipboard.writeText(text).then(
-        () => {
-          setCopied(true);
-          setCopyFailed(false);
-          copyTimeoutId.current = setTimeout(() => {
-            setCopied(false);
-            copyTimeoutId.current = null;
-          }, 2000);
-        },
-        () => {
-          setCopyFailed(true);
+
+      function applyCopyResult(success: boolean) {
+        setCopied(success);
+        setCopyFailed(!success);
+        copyTimeoutId.current = setTimeout(() => {
           setCopied(false);
-          copyTimeoutId.current = setTimeout(() => {
-            setCopyFailed(false);
-            copyTimeoutId.current = null;
-          }, 2000);
-        }
+          setCopyFailed(false);
+          copyTimeoutId.current = null;
+        }, 2000);
+      }
+
+      if (!navigator.clipboard) {
+        applyCopyResult(false);
+        return;
+      }
+      navigator.clipboard.writeText(text).then(
+        () => applyCopyResult(true),
+        () => applyCopyResult(false)
       );
     }
 

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -23,20 +23,6 @@ export interface JsonFieldHandle {
   clear(): void;
 }
 
-function valueToText(value: any): string {
-  if (value === null || value === undefined) return "";
-  return JSON.stringify(value, null, 2);
-}
-
-function parseJson(s: string): { parsed: any; error: string | null } {
-  if (!s.trim()) return { parsed: null, error: null };
-  try {
-    return { parsed: JSON.parse(s), error: null };
-  } catch (err) {
-    return { parsed: null, error: (err as Error).message };
-  }
-}
-
 const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
   function JsonField({ setting, value, disabled, readOnly, onChange }, ref) {
     const [text, setText] = useState(() => valueToText(value));
@@ -117,8 +103,10 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
       if ((e.ctrlKey || e.metaKey) && e.key === "z" && previousText !== null) {
         e.preventDefault();
-        if (clearFeedbackTimeoutId.current)
+        if (clearFeedbackTimeoutId.current) {
           clearTimeout(clearFeedbackTimeoutId.current);
+          clearFeedbackTimeoutId.current = null;
+        }
         const { parsed, error } = parseJson(previousText);
         setText(previousText);
         setJsonError(error);
@@ -259,5 +247,19 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
 );
 
 JsonField.displayName = "JsonField";
+
+function valueToText(value: any): string {
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value, null, 2);
+}
+
+function parseJson(s: string): { parsed: any; error: string | null } {
+  if (!s.trim()) return { parsed: null, error: null };
+  try {
+    return { parsed: JSON.parse(s), error: null };
+  } catch (err) {
+    return { parsed: null, error: (err as Error).message };
+  }
+}
 
 export default JsonField;

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -91,10 +91,16 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
         clearTimeout(clearFeedbackTimeoutId.current);
         clearFeedbackTimeoutId.current = null;
       }
+      if (copyTimeoutId.current) {
+        clearTimeout(copyTimeoutId.current);
+        copyTimeoutId.current = null;
+      }
       setText(newText);
       setJsonError(error);
       setPreviousText(null);
       setClearFeedback(false);
+      setCopied(false);
+      setCopyFailed(false);
       if (!error && onChange) {
         onChange(newText.trim() ? parsed : null);
       }
@@ -144,6 +150,10 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     function handleClearClick() {
       if (clearFeedbackTimeoutId.current)
         clearTimeout(clearFeedbackTimeoutId.current);
+      if (copyTimeoutId.current) {
+        clearTimeout(copyTimeoutId.current);
+        copyTimeoutId.current = null;
+      }
       setClearFeedback(true);
       clearFeedbackTimeoutId.current = setTimeout(() => {
         setClearFeedback(false);

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -211,7 +211,10 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
             <span className="json-field-copied-feedback" aria-live="polite">
               {copied ? "Copied!" : ""}
             </span>
-            <span className="json-field-copy-failed-feedback" role="alert">
+            <span
+              className="json-field-copy-failed-feedback"
+              aria-live="assertive"
+            >
               {copyFailed ? "Copy failed." : ""}
             </span>
             <span className="json-field-cleared-feedback" aria-live="polite">

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -39,6 +39,9 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
     );
 
     // Sync external value changes to internal text (replaces UNSAFE_componentWillReceiveProps).
+    // Uses reference equality: callers must not pass a new object literal on every render
+    // (e.g. value={{ key: "val" }}), or in-progress edits will be wiped. Values sourced
+    // from Redux state are stable references and satisfy this requirement.
     const [prevValue, setPrevValue] = useState(value);
     if (prevValue !== value) {
       setPrevValue(value);

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -48,6 +48,10 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
       setClearFeedback(false);
       setCopied(false);
       setCopyFailed(false);
+      if (clearFeedbackTimeoutId.current) {
+        clearTimeout(clearFeedbackTimeoutId.current);
+        clearFeedbackTimeoutId.current = null;
+      }
       if (copyTimeoutId.current) {
         clearTimeout(copyTimeoutId.current);
         copyTimeoutId.current = null;

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
 import ColorPicker from "./ColorPicker";
-import JsonField from "./JsonField";
+import JsonField, { JsonFieldHandle } from "./JsonField";
 import { Button } from "library-simplified-reusable-components";
 import InputList from "./InputList";
 import { SettingData, CustomListsSetting } from "../interfaces";
@@ -46,7 +46,7 @@ export default class ProtocolFormField extends React.Component<
   private inputListRef = React.createRef<InputList>();
   private colorPickerRef = React.createRef<ColorPicker>();
   private elementRef = React.createRef<EditableInput>();
-  private jsonFieldRef = React.createRef<JsonField>();
+  private jsonFieldRef = React.createRef<JsonFieldHandle>();
   static defaultProps = {
     readOnly: false,
   };
@@ -255,6 +255,9 @@ export default class ProtocolFormField extends React.Component<
   }
 
   getValue() {
+    if (this.jsonFieldRef.current) {
+      return this.jsonFieldRef.current.getValue();
+    }
     return this.findRef().getValue();
   }
 
@@ -268,14 +271,18 @@ export default class ProtocolFormField extends React.Component<
     element?.setState({ value: random });
   }
 
+  // Excludes jsonFieldRef: JsonFieldHandle lacks setState, which randomize() calls.
   findRef() {
     return (this.inputListRef?.current ||
       this.elementRef?.current ||
-      this.colorPickerRef?.current ||
-      this.jsonFieldRef?.current) as any;
+      this.colorPickerRef?.current) as any;
   }
 
   clear() {
+    if (this.jsonFieldRef.current) {
+      this.jsonFieldRef.current.clear();
+      return;
+    }
     const element = this.findRef();
     if (element && element.clear) {
       element.clear();

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import EditableInput from "./EditableInput";
 import ColorPicker from "./ColorPicker";
+import JsonField from "./JsonField";
 import { Button } from "library-simplified-reusable-components";
 import InputList from "./InputList";
 import { SettingData, CustomListsSetting } from "../interfaces";
@@ -13,6 +14,8 @@ export interface ProtocolFormFieldProps {
     | string
     | string[]
     | object[]
+    | object
+    | null
     | Array<string | object | JSX.Element>
     | JSX.Element;
   altValue?: string;
@@ -43,6 +46,7 @@ export default class ProtocolFormField extends React.Component<
   private inputListRef = React.createRef<InputList>();
   private colorPickerRef = React.createRef<ColorPicker>();
   private elementRef = React.createRef<EditableInput>();
+  private jsonFieldRef = React.createRef<JsonField>();
   static defaultProps = {
     readOnly: false,
   };
@@ -63,6 +67,8 @@ export default class ProtocolFormField extends React.Component<
         ? this.renderListSetting(setting)
         : setting.type === "color-picker"
         ? this.renderColorPickerSetting(setting)
+        : setting.type === "json"
+        ? this.renderJsonSetting(setting)
         : this.renderSetting(setting);
     // Special handling for hidden settings.
     return setting.hidden ? this.renderHiddenElement(element) : element;
@@ -208,6 +214,19 @@ export default class ProtocolFormField extends React.Component<
     );
   }
 
+  renderJsonSetting(setting: SettingData): JSX.Element {
+    return (
+      <JsonField
+        ref={this.jsonFieldRef}
+        setting={setting}
+        value={this.props.value}
+        disabled={this.props.disabled}
+        readOnly={this.props.readOnly}
+        onChange={this.props.onChange}
+      />
+    );
+  }
+
   labelAndDescription(setting: SettingData): JSX.Element[] {
     const label = <label key={setting.label}>{setting.label}</label>;
     const description = setting.description && (
@@ -252,7 +271,8 @@ export default class ProtocolFormField extends React.Component<
   findRef() {
     return (this.inputListRef?.current ||
       this.elementRef?.current ||
-      this.colorPickerRef?.current) as any;
+      this.colorPickerRef?.current ||
+      this.jsonFieldRef?.current) as any;
   }
 
   clear() {

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -219,7 +219,7 @@ export default class ProtocolFormField extends React.Component<
       <JsonField
         ref={this.jsonFieldRef}
         setting={setting}
-        value={this.props.value}
+        value={defaultValueIfMissing(this.props.value, setting.default)}
         disabled={this.props.disabled}
         readOnly={this.props.readOnly}
         onChange={this.props.onChange}

--- a/src/components/icons/CopyIcon.tsx
+++ b/src/components/icons/CopyIcon.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+const CopyIcon = (): JSX.Element => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <title>Copy Icon</title>
+    <path d="M16 1H4C2.9 1 2 1.9 2 3v14h2V3h12V1zm3 4H8C6.9 5 6 5.9 6 7v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+  </svg>
+);
+
+export default CopyIcon;

--- a/src/components/icons/CopyIcon.tsx
+++ b/src/components/icons/CopyIcon.tsx
@@ -6,7 +6,6 @@ const CopyIcon = (): JSX.Element => (
     viewBox="0 0 24 24"
     aria-hidden="true"
   >
-    <title>Copy Icon</title>
     <path d="M16 1H4C2.9 1 2 1.9 2 3v14h2V3h12V1zm3 4H8C6.9 5 6 5.9 6 7v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
   </svg>
 );

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -299,6 +299,7 @@ export type SpecificSettingType =
   | "date"
   | "date-picker"
   | "image"
+  | "json"
   | "list"
   | "menu"
   | "select"

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -42,6 +42,7 @@ $fontfamily: 'Open Sans', sans-serif;
 @import "header";
 @import "icon";
 @import "individual_admin_edit_form";
+@import "json_field";
 @import "input_list";
 @import "lane_editor";
 @import "lanes";

--- a/src/stylesheets/colors.scss
+++ b/src/stylesheets/colors.scss
@@ -10,6 +10,7 @@ $red-tint: tint($red, 30%);
 $light-gray: #D7D4D0;
 $medium-gray: #DDD;
 $medium-dark-gray: #AAA;
+$gray-accessible: #767676;
 $dark-gray: #080807;
 $gray-tint: #F5F5F4;
 $gray-border: #CCCCCC;

--- a/src/stylesheets/json_field.scss
+++ b/src/stylesheets/json_field.scss
@@ -1,3 +1,19 @@
+.json-field-group {
+  // The global .field-error .description rule would color the setting
+  // description red; only the dedicated error element should be red.
+  &.field-error .description {
+    color: inherit;
+  }
+
+  .json-field-error-msg {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: $red;
+    margin-top: 5px;
+    min-height: 1.5em;
+  }
+}
+
 .json-field-textarea-wrap {
   position: relative;
 

--- a/src/stylesheets/json_field.scss
+++ b/src/stylesheets/json_field.scss
@@ -1,0 +1,63 @@
+.json-field-textarea-wrap {
+  position: relative;
+
+  textarea {
+    padding-right: 3.5em;
+  }
+
+  .json-field-actions {
+    display: flex;
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    align-items: center;
+    gap: 2px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.1s ease;
+
+    .json-field-copied-feedback,
+    .json-field-cleared-feedback {
+      font-size: 0.75em;
+      color: $blue-dark;
+      white-space: nowrap;
+      padding-right: 2px;
+    }
+
+    button {
+      background: transparent;
+      border: none;
+      padding: 3px;
+      cursor: pointer;
+      color: $gray-accessible;
+      line-height: 1;
+
+      svg {
+        display: block;
+        height: 1em;
+        width: 1em;
+        fill: currentColor;
+      }
+
+      &:hover:not(:disabled) {
+        color: $dark-gray;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $blue-dark;
+        outline-offset: 2px;
+        border-radius: 2px;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        color: $medium-dark-gray;
+      }
+    }
+  }
+
+  &:focus-within .json-field-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}

--- a/src/stylesheets/json_field.scss
+++ b/src/stylesheets/json_field.scss
@@ -33,11 +33,20 @@
     transition: opacity 0.1s ease;
 
     .json-field-copied-feedback,
+    .json-field-copy-failed-feedback,
     .json-field-cleared-feedback {
       font-size: 0.75em;
-      color: $blue-dark;
       white-space: nowrap;
       padding-right: 2px;
+    }
+
+    .json-field-copied-feedback,
+    .json-field-cleared-feedback {
+      color: $blue-dark;
+    }
+
+    .json-field-copy-failed-feedback {
+      color: $red;
     }
 
     button {
@@ -72,8 +81,11 @@
     }
   }
 
-  &:focus-within .json-field-actions {
-    opacity: 1;
-    pointer-events: auto;
+  &:focus-within,
+  &:hover {
+    .json-field-actions {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 }

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import JsonField from "../../../src/components/JsonField";
+
+const setting = {
+  key: "my_json",
+  label: "JSON Setting",
+  description: "<p>A JSON field</p>",
+};
+
+const requiredSetting = { ...setting, required: true };
+
+describe("JsonField", () => {
+  it("renders textarea with label and description", () => {
+    render(<JsonField setting={setting} />);
+    expect(screen.getByLabelText("JSON Setting")).toBeInstanceOf(
+      HTMLTextAreaElement
+    );
+    expect(screen.getByText("A JSON field")).toBeInTheDocument();
+  });
+
+  it("shows empty textarea for null value", () => {
+    render(<JsonField setting={setting} value={null} />);
+    const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+    expect(ta.value).toBe("");
+  });
+
+  it("shows empty textarea when no value prop provided", () => {
+    render(<JsonField setting={setting} />);
+    const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+    expect(ta.value).toBe("");
+  });
+
+  it("displays pretty-printed JSON for an object value", () => {
+    const obj = { foo: "bar", baz: 42 };
+    render(<JsonField setting={setting} value={obj} />);
+    const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+    expect(ta.value).toBe(JSON.stringify(obj, null, 2));
+  });
+
+  it("displays pretty-printed JSON for an array value", () => {
+    const arr = [1, "two", { three: 3 }];
+    render(<JsonField setting={setting} value={arr} />);
+    const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+    expect(ta.value).toBe(JSON.stringify(arr, null, 2));
+  });
+
+  it("shows inline error for invalid JSON input", () => {
+    render(<JsonField setting={setting} />);
+    const ta = screen.getByLabelText("JSON Setting");
+    fireEvent.change(ta, { target: { value: "not valid json" } });
+    expect(screen.getByText(/unexpected token|expected/i)).toBeInTheDocument();
+  });
+
+  it("clears the error when input becomes valid JSON", () => {
+    render(<JsonField setting={setting} />);
+    const ta = screen.getByLabelText("JSON Setting");
+
+    fireEvent.change(ta, { target: { value: "{invalid" } });
+    expect(screen.getByText(/unexpected token|expected/i)).toBeInTheDocument();
+
+    fireEvent.change(ta, { target: { value: '{"key":"value"}' } });
+    expect(
+      screen.queryByText(/unexpected token|expected/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the error when textarea is emptied", () => {
+    render(<JsonField setting={setting} />);
+    const ta = screen.getByLabelText("JSON Setting");
+
+    fireEvent.change(ta, { target: { value: "bad" } });
+    expect(screen.getByText(/unexpected token|expected/i)).toBeInTheDocument();
+
+    fireEvent.change(ta, { target: { value: "" } });
+    expect(
+      screen.queryByText(/unexpected token|expected/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Required badge for required settings", () => {
+    render(<JsonField setting={requiredSetting} />);
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("calls onChange with parsed value on valid input", () => {
+    const onChange = jest.fn();
+    render(<JsonField setting={setting} onChange={onChange} />);
+    const ta = screen.getByLabelText("JSON Setting");
+
+    fireEvent.change(ta, { target: { value: '{"x":1}' } });
+    expect(onChange).toHaveBeenCalledWith({ x: 1 });
+  });
+
+  it("does not call onChange when JSON is invalid", () => {
+    const onChange = jest.fn();
+    render(<JsonField setting={setting} onChange={onChange} />);
+    const ta = screen.getByLabelText("JSON Setting");
+
+    fireEvent.change(ta, { target: { value: "{bad" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe("getValue()", () => {
+    it("returns null for empty textarea", () => {
+      const ref = React.createRef<JsonField>();
+      render(<JsonField setting={setting} ref={ref} />);
+      expect(ref.current!.getValue()).toBeNull();
+    });
+
+    it("returns parsed object for valid JSON", () => {
+      const ref = React.createRef<JsonField>();
+      render(<JsonField setting={setting} ref={ref} />);
+      const ta = screen.getByLabelText("JSON Setting");
+
+      fireEvent.change(ta, { target: { value: '{"a":1}' } });
+      expect(ref.current!.getValue()).toEqual({ a: 1 });
+    });
+
+    it("returns undefined for invalid JSON", () => {
+      const ref = React.createRef<JsonField>();
+      render(<JsonField setting={setting} ref={ref} />);
+      const ta = screen.getByLabelText("JSON Setting");
+
+      fireEvent.change(ta, { target: { value: "not json" } });
+      expect(ref.current!.getValue()).toBeUndefined();
+    });
+  });
+
+  describe("clear()", () => {
+    it("resets text and clears parse error", () => {
+      const ref = React.createRef<JsonField>();
+      render(<JsonField setting={setting} ref={ref} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+
+      expect(ta.value).toBe(JSON.stringify({ a: 1 }, null, 2));
+
+      fireEvent.change(ta, { target: { value: "bad json" } });
+      expect(
+        screen.queryByText(/unexpected token|expected/i)
+      ).toBeInTheDocument();
+
+      act(() => {
+        ref.current!.clear();
+      });
+
+      expect(ta.value).toBe("");
+      expect(
+        screen.queryByText(/unexpected token|expected/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -274,7 +274,7 @@ describe("JsonField", () => {
       });
       const msg = screen.getByText("Copy failed.");
       expect(msg).toBeInTheDocument();
-      expect(msg).toHaveAttribute("role", "alert");
+      expect(msg).toHaveAttribute("aria-live", "assertive");
       expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
     });
   });

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -258,6 +258,20 @@ describe("JsonField", () => {
       jest.useRealTimers();
     });
 
+    it("shows 'Copy failed.' when navigator.clipboard is unavailable", () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" })
+      );
+      expect(screen.getByText("Copy failed.")).toBeInTheDocument();
+      expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+    });
+
     it("shows 'Copy failed.' when clipboard write fails", async () => {
       Object.defineProperty(navigator, "clipboard", {
         value: {

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -128,6 +128,233 @@ describe("JsonField", () => {
     });
   });
 
+  describe("Copy button", () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: jest.fn().mockResolvedValue(undefined) },
+        writable: true,
+      });
+    });
+
+    it("is disabled when textarea is empty", () => {
+      render(<JsonField setting={setting} />);
+      expect(
+        screen.getByRole("button", { name: "Copy to clipboard" })
+      ).toBeDisabled();
+    });
+
+    it("is enabled when textarea has content", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      expect(
+        screen.getByRole("button", { name: "Copy to clipboard" })
+      ).not.toBeDisabled();
+    });
+
+    it("copies textarea text to clipboard", () => {
+      const obj = { a: 1 };
+      render(<JsonField setting={setting} value={obj} />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" })
+      );
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        JSON.stringify(obj, null, 2)
+      );
+    });
+
+    it("shows Copied! text briefly after click then hides it", () => {
+      jest.useFakeTimers();
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" })
+      );
+      expect(screen.getByText("Copied!")).toBeInTheDocument();
+      act(() => jest.advanceTimersByTime(2000));
+      expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+      jest.useRealTimers();
+    });
+  });
+
+  describe("Clear button", () => {
+    it("is disabled when textarea is empty", () => {
+      render(<JsonField setting={setting} />);
+      expect(
+        screen.getByRole("button", { name: "Clear field" })
+      ).toBeDisabled();
+    });
+
+    it("is disabled when field is disabled", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} disabled={true} />);
+      expect(
+        screen.getByRole("button", { name: "Clear field" })
+      ).toBeDisabled();
+    });
+
+    it("is disabled when field is readOnly", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} readOnly={true} />);
+      expect(
+        screen.getByRole("button", { name: "Clear field" })
+      ).toBeDisabled();
+    });
+
+    it("clears the textarea when clicked", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+      expect(ta.value).not.toBe("");
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(ta.value).toBe("");
+    });
+
+    it("calls onChange with null when clicked", () => {
+      const onChange = jest.fn();
+      render(
+        <JsonField setting={setting} value={{ a: 1 }} onChange={onChange} />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it("clears inline JSON error when clicked", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      fireEvent.change(ta, { target: { value: "bad json" } });
+      expect(
+        screen.queryByText(/unexpected token|expected/i)
+      ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(
+        screen.queryByText(/unexpected token|expected/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows 'Cleared! Ctrl-Z / Cmd-Z to recover.' message after clicking", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      expect(screen.queryByText(/Cleared!/i)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(
+        screen.getByText("Cleared! Ctrl-Z / Cmd-Z to recover.")
+      ).toBeInTheDocument();
+    });
+
+    it("hides 'Cleared!' message after timeout", () => {
+      jest.useFakeTimers();
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(
+        screen.getByText("Cleared! Ctrl-Z / Cmd-Z to recover.")
+      ).toBeInTheDocument();
+      act(() => jest.advanceTimersByTime(5000));
+      expect(screen.queryByText(/Cleared!/i)).not.toBeInTheDocument();
+      jest.useRealTimers();
+    });
+
+    it("hides 'Cleared!' message when user starts typing", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(
+        screen.getByText("Cleared! Ctrl-Z / Cmd-Z to recover.")
+      ).toBeInTheDocument();
+      fireEvent.change(ta, { target: { value: "42" } });
+      expect(screen.queryByText(/Cleared!/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("undo after clear (Ctrl+Z)", () => {
+    it("restores content after clicking Clear then pressing Ctrl+Z", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+      const original = ta.value;
+
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(ta.value).toBe("");
+
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      expect(ta.value).toBe(original);
+    });
+
+    it("hides 'Cleared!' message on undo", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(
+        screen.getByText("Cleared! Ctrl-Z / Cmd-Z to recover.")
+      ).toBeInTheDocument();
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      expect(screen.queryByText(/Cleared!/i)).not.toBeInTheDocument();
+    });
+
+    it("restores content using Cmd+Z (macOS)", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+      const original = ta.value;
+
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      fireEvent.keyDown(ta, { key: "z", metaKey: true });
+      expect(ta.value).toBe(original);
+    });
+
+    it("calls onChange with restored value on undo", () => {
+      const onChange = jest.fn();
+      const obj = { a: 1 };
+      render(<JsonField setting={setting} value={obj} onChange={onChange} />);
+      const ta = screen.getByLabelText("JSON Setting");
+
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      onChange.mockClear();
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      expect(onChange).toHaveBeenCalledWith(obj);
+    });
+
+    it("does not undo when no clear has occurred", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+      const original = ta.value;
+
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      expect(ta.value).toBe(original);
+    });
+
+    it("discards undo state once the user starts typing after a clear", () => {
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      fireEvent.change(ta, { target: { value: "42" } });
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      // Should stay at "42", not jump back to original
+      expect(ta.value).toBe("42");
+    });
+
+    it("restores partial/invalid JSON text on undo without throwing", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+
+      fireEvent.change(ta, { target: { value: '{"partial":' } });
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      expect(ta.value).toBe("");
+
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      expect(ta.value).toBe('{"partial":');
+      expect(
+        screen.queryByText(/unexpected token|expected/i)
+      ).toBeInTheDocument();
+    });
+
+    it("does not call onChange when restored text is invalid JSON", () => {
+      const onChange = jest.fn();
+      render(<JsonField setting={setting} onChange={onChange} />);
+      const ta = screen.getByLabelText("JSON Setting");
+
+      fireEvent.change(ta, { target: { value: '{"partial":' } });
+      fireEvent.click(screen.getByRole("button", { name: "Clear field" }));
+      onChange.mockClear();
+
+      fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe("clear()", () => {
     it("resets text and clears parse error", () => {
       const ref = React.createRef<JsonField>();
@@ -149,6 +376,25 @@ describe("JsonField", () => {
       expect(
         screen.queryByText(/unexpected token|expected/i)
       ).not.toBeInTheDocument();
+    });
+
+    it("calls onChange with null when cleared programmatically", () => {
+      const onChange = jest.fn();
+      const ref = React.createRef<JsonField>();
+      render(
+        <JsonField
+          setting={setting}
+          ref={ref}
+          value={{ a: 1 }}
+          onChange={onChange}
+        />
+      );
+
+      act(() => {
+        ref.current!.clear();
+      });
+
+      expect(onChange).toHaveBeenCalledWith(null);
     });
   });
 });

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -102,6 +102,65 @@ describe("JsonField", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  describe("error message visibility", () => {
+    it("is absent before the field is focused and there is no error", () => {
+      render(<JsonField setting={setting} />);
+      expect(
+        document.querySelector(".json-field-error-msg")
+      ).not.toBeInTheDocument();
+    });
+
+    it("appears (empty) when the field is focused with no error", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      fireEvent.focus(ta);
+      const el = document.querySelector(".json-field-error-msg");
+      expect(el).toBeInTheDocument();
+      expect(el!.textContent).toBe("");
+    });
+
+    it("disappears on blur when there is no error", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      fireEvent.focus(ta);
+      fireEvent.blur(ta);
+      expect(
+        document.querySelector(".json-field-error-msg")
+      ).not.toBeInTheDocument();
+    });
+
+    it("stays visible after blur when there is an error", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      fireEvent.focus(ta);
+      fireEvent.change(ta, { target: { value: "bad json" } });
+      fireEvent.blur(ta);
+      expect(
+        screen.getByText(/unexpected token|expected/i)
+      ).toBeInTheDocument();
+    });
+
+    it("sets aria-invalid on the textarea when JSON is invalid", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      expect(ta).not.toHaveAttribute("aria-invalid", "true");
+      fireEvent.change(ta, { target: { value: "bad json" } });
+      expect(ta).toHaveAttribute("aria-invalid", "true");
+      fireEvent.change(ta, { target: { value: '{"x":1}' } });
+      expect(ta).not.toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("adds the error element id to aria-describedby when invalid", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      expect(ta.getAttribute("aria-describedby") ?? "").not.toContain(
+        "json-error-"
+      );
+      fireEvent.change(ta, { target: { value: "bad" } });
+      expect(ta.getAttribute("aria-describedby")).toContain("json-error-");
+    });
+  });
+
   describe("getValue()", () => {
     it("returns null for empty textarea", () => {
       const ref = React.createRef<JsonField>();

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import JsonField from "../../../src/components/JsonField";
+import JsonField, { JsonFieldHandle } from "../../../src/components/JsonField";
 
 const setting = {
   key: "my_json",
@@ -46,6 +46,17 @@ describe("JsonField", () => {
     expect(ta.value).toBe(JSON.stringify(arr, null, 2));
   });
 
+  it("resets textarea when value prop changes externally", () => {
+    const { rerender } = render(
+      <JsonField setting={setting} value={{ a: 1 }} />
+    );
+    const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
+    expect(ta.value).toBe(JSON.stringify({ a: 1 }, null, 2));
+
+    rerender(<JsonField setting={setting} value={{ b: 2 }} />);
+    expect(ta.value).toBe(JSON.stringify({ b: 2 }, null, 2));
+  });
+
   it("shows inline error for invalid JSON input", () => {
     render(<JsonField setting={setting} />);
     const ta = screen.getByLabelText("JSON Setting");
@@ -82,6 +93,11 @@ describe("JsonField", () => {
   it("shows the Required badge for required settings", () => {
     render(<JsonField setting={requiredSetting} />);
     expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("disables the textarea when disabled prop is true", () => {
+    render(<JsonField setting={setting} disabled={true} />);
+    expect(screen.getByLabelText("JSON Setting")).toBeDisabled();
   });
 
   it("calls onChange with parsed value on valid input", () => {
@@ -159,17 +175,23 @@ describe("JsonField", () => {
       fireEvent.change(ta, { target: { value: "bad" } });
       expect(ta.getAttribute("aria-describedby")).toContain("json-error-");
     });
+
+    it("includes the description element id in aria-describedby when description is present", () => {
+      render(<JsonField setting={setting} />);
+      const ta = screen.getByLabelText("JSON Setting");
+      expect(ta.getAttribute("aria-describedby")).toContain("json-desc-");
+    });
   });
 
   describe("getValue()", () => {
     it("returns null for empty textarea", () => {
-      const ref = React.createRef<JsonField>();
+      const ref = React.createRef<JsonFieldHandle>();
       render(<JsonField setting={setting} ref={ref} />);
       expect(ref.current!.getValue()).toBeNull();
     });
 
     it("returns parsed object for valid JSON", () => {
-      const ref = React.createRef<JsonField>();
+      const ref = React.createRef<JsonFieldHandle>();
       render(<JsonField setting={setting} ref={ref} />);
       const ta = screen.getByLabelText("JSON Setting");
 
@@ -178,7 +200,7 @@ describe("JsonField", () => {
     });
 
     it("returns undefined for invalid JSON", () => {
-      const ref = React.createRef<JsonField>();
+      const ref = React.createRef<JsonFieldHandle>();
       render(<JsonField setting={setting} ref={ref} />);
       const ta = screen.getByLabelText("JSON Setting");
 
@@ -192,6 +214,7 @@ describe("JsonField", () => {
       Object.defineProperty(navigator, "clipboard", {
         value: { writeText: jest.fn().mockResolvedValue(undefined) },
         writable: true,
+        configurable: true,
       });
     });
 
@@ -220,17 +243,39 @@ describe("JsonField", () => {
       );
     });
 
-    it("shows Copied! text briefly after click then hides it", () => {
+    it("shows Copied! text briefly after click then hides it", async () => {
       jest.useFakeTimers();
       render(<JsonField setting={setting} value={{ a: 1 }} />);
       expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
-      fireEvent.click(
-        screen.getByRole("button", { name: "Copy to clipboard" })
-      );
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Copy to clipboard" })
+        );
+      });
       expect(screen.getByText("Copied!")).toBeInTheDocument();
       act(() => jest.advanceTimersByTime(2000));
       expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
       jest.useRealTimers();
+    });
+
+    it("shows 'Copy failed.' when clipboard write fails", async () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: {
+          writeText: jest.fn().mockRejectedValue(new Error("denied")),
+        },
+        writable: true,
+        configurable: true,
+      });
+      render(<JsonField setting={setting} value={{ a: 1 }} />);
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole("button", { name: "Copy to clipboard" })
+        );
+      });
+      const msg = screen.getByText("Copy failed.");
+      expect(msg).toBeInTheDocument();
+      expect(msg).toHaveAttribute("role", "alert");
+      expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
     });
   });
 
@@ -416,7 +461,7 @@ describe("JsonField", () => {
 
   describe("clear()", () => {
     it("resets text and clears parse error", () => {
-      const ref = React.createRef<JsonField>();
+      const ref = React.createRef<JsonFieldHandle>();
       render(<JsonField setting={setting} ref={ref} value={{ a: 1 }} />);
       const ta = screen.getByLabelText("JSON Setting") as HTMLTextAreaElement;
 
@@ -439,7 +484,7 @@ describe("JsonField", () => {
 
     it("calls onChange with null when cleared programmatically", () => {
       const onChange = jest.fn();
-      const ref = React.createRef<JsonField>();
+      const ref = React.createRef<JsonFieldHandle>();
       render(
         <JsonField
           setting={setting}

--- a/tests/jest/components/ProtocolFormField.test.tsx
+++ b/tests/jest/components/ProtocolFormField.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProtocolFormField from "../../../src/components/ProtocolFormField";
 
@@ -8,6 +8,43 @@ import ProtocolFormField from "../../../src/components/ProtocolFormField";
 //
 // Those tests should eventually be migrated here and
 // adapted to the Jest/React Testing Library paradigm.
+
+describe("ProtocolFormField — json type", () => {
+  const jsonSetting = {
+    key: "config",
+    label: "Config JSON",
+    description: "<p>JSON configuration</p>",
+    type: "json",
+  };
+
+  it("renders a textarea (not an input) for json type", () => {
+    const value = { enabled: true, count: 3 };
+    render(
+      <ProtocolFormField setting={jsonSetting} disabled={false} value={value} />
+    );
+    const ta = screen.getByLabelText("Config JSON") as HTMLTextAreaElement;
+    expect(ta.tagName).toBe("TEXTAREA");
+    expect(ta.value).toBe(JSON.stringify(value, null, 2));
+  });
+
+  it("renders empty textarea for null value", () => {
+    render(
+      <ProtocolFormField setting={jsonSetting} disabled={false} value={null} />
+    );
+    const ta = screen.getByLabelText("Config JSON") as HTMLTextAreaElement;
+    expect(ta.value).toBe("");
+  });
+
+  it("getValue() returns parsed object", () => {
+    const ref = React.createRef<ProtocolFormField>();
+    render(
+      <ProtocolFormField setting={jsonSetting} disabled={false} ref={ref} />
+    );
+    const ta = screen.getByLabelText("Config JSON");
+    fireEvent.change(ta, { target: { value: '{"x":42}' } });
+    expect(ref.current!.getValue()).toEqual({ x: 42 });
+  });
+});
 
 describe("ProtocolFormField", () => {
   it("renders date-picker setting", async () => {

--- a/tests/jest/components/ProtocolFormField.test.tsx
+++ b/tests/jest/components/ProtocolFormField.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProtocolFormField from "../../../src/components/ProtocolFormField";
 
@@ -43,6 +43,24 @@ describe("ProtocolFormField — json type", () => {
     const ta = screen.getByLabelText("Config JSON");
     fireEvent.change(ta, { target: { value: '{"x":42}' } });
     expect(ref.current!.getValue()).toEqual({ x: 42 });
+  });
+
+  it("clear() resets the textarea", () => {
+    const ref = React.createRef<ProtocolFormField>();
+    render(
+      <ProtocolFormField
+        setting={jsonSetting}
+        disabled={false}
+        ref={ref}
+        value={{ x: 42 }}
+      />
+    );
+    const ta = screen.getByLabelText("Config JSON") as HTMLTextAreaElement;
+    expect(ta.value).not.toBe("");
+    act(() => {
+      ref.current!.clear();
+    });
+    expect(ta.value).toBe("");
   });
 });
 


### PR DESCRIPTION
## Description

Adds a new `JsonField` form component for editing JSON-typed protocol settings. The field renders as a `textarea` with:
- Live JSON validation with an inline error message;
- Copy-to-clipboard and clear buttons that appear on hover/focus;
- One-shot undo (Ctrl-Z / Cmd-Z) after a clear;
- Accessible ARIA markup.

**Note**: This field is activated by the new `FormFieldType.JSON` settings field type introduced on [circulation PR #3386](https://github.com/ThePalaceProject/circulation/pull/3386).

## Motivation and Context

Allows admins to actively validate JSON in place without submitting the form.

[Jira PP-4438]

## How Has This Been Tested?

- Manual testing in local development environment.
- Additional tests to cover the new functionality.
- All checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/circulation-admin/actions/runs/26348949842) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.

