### PR TITLE
Add Dependabot auto-approve/merge workflow and config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 4
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot Auto-Approve and Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+
+      - name: Auto-approve
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge
+        run: gh pr merge --auto --squash --body "" "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@
 # We need to handle both of these cases from a single workflow because we want to
 # use NPM's OIDC Trusted Publisher support for publishing. That feature supports
 # only a single workflow filename and, thus, a single workflow.
+#
+# The nightly schedule runs the same "next" publish path as a push. It exists
+# because merges performed by the Dependabot auto-merge workflow use GITHUB_TOKEN,
+# and GitHub deliberately does not trigger downstream workflows for GITHUB_TOKEN
+# pushes. Without the schedule, Dependabot bumps would never produce a "next"
+# build. The scheduled run skips publishing when the computed version is already
+# on npm (i.e. no new commits landed since the last next build).
 
 name: Test & Publish
 
@@ -14,6 +21,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Daily at 06:00 UTC — catches commits merged by GITHUB_TOKEN (e.g. Dependabot
+    # auto-merge) that did not trigger the push-based next publish.
+    - cron: "0 6 * * *"
 
 permissions:
   id-token: write
@@ -69,22 +80,39 @@ jobs:
       if: github.event_name == 'release'
       run: npm publish --access public
 
-    # For push events, version using dunamai and publish to "next" npm tag.
-    # dunamai requires Python.
+    # For push and scheduled events, version using dunamai and publish to the
+    # "next" npm tag. dunamai requires Python.
     - name: Set up Python 🐍
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 
     - name: Set up Dunamai 🪄
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       run: pip install -r requirements-ci.txt
 
     - name: Version (Next) ✅
-      if: github.event_name == 'push'
-      run: npm version --no-git-tag-version $(dunamai from git --style semver)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      id: version-next
+      run: |
+        VERSION=$(dunamai from git --style semver)
+        npm version --no-git-tag-version "$VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    # On the schedule, the most recent commit may already have a published next
+    # build (no new commits since the last run). Detect that so we can skip the
+    # publish instead of failing on a duplicate-version error.
+    - name: Check existing next version 🔍
+      if: github.event_name == 'schedule'
+      id: existing-next
+      run: |
+        if npm view "@thepalaceproject/circulation-admin@${{ steps.version-next.outputs.version }}" version > /dev/null 2>&1; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Publish (Next) 📚
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || (github.event_name == 'schedule' && steps.existing-next.outputs.exists == 'false')
       run: npm publish --tag next --access public


### PR DESCRIPTION
## Description

Adds Dependabot automation to this repo, ported from the circulation repo, plus a fix for the publish gap it creates:

- **`.github/workflows/dependabot-auto-merge.yml`** — auto-approves and auto-merges (squash) PRs opened by `dependabot[bot]`.
- **`.github/dependabot.yml`** — configures daily `npm` and `github-actions` updates with a **4-day `cooldown`**.
- **`.github/workflows/publish.yml`** — adds a nightly `schedule` trigger that runs the existing `next`-publish path.

The `cooldown` is the key safety control: Dependabot won't open a PR until a release has been public for at least 4 days, which prevents the auto-merge workflow from approving a freshly-published (potentially malicious) version the moment it lands.

The nightly `schedule` runs the next-publish path to catch merges that happen automatically, since they don't trigger additional workflows. It guards against duplicate-version errors by checking npm for the computed dunamai version and skipping the publish when it already exists (no new commits since the last next build).

## Motivation and Context

We already receive Dependabot PRs in this repo but have no auto-merge automation, so they pile up and require manual review/merge. This mirrors the setup in the circulation repo so dependency updates flow through automatically while keeping the cooldown safeguard, and ensures the resulting commits still get a `next` publish despite the GITHUB_TOKEN trigger limitation.

Ports the setup from circulation:
- ThePalaceProject/circulation#3103 — Add Dependabot auto-approve and auto-merge workflow

This has been working fairly well in circulation, so I'd like to give it a try here.

## How Has This Been Tested?

Not yet exercised against a live Dependabot PR. The workflow and config are copied from the circulation repo where they are in active use; the `publish.yml` YAML was validated locally. I believe the repo has all the config needed to make it work, but we'll have to try it out once this gets merged.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.