### PR TITLE
Fix latent code issues surfaced by ESLint

### DIFF
--- a/src/components/AdvancedSearchBooleanFilter.tsx
+++ b/src/components/AdvancedSearchBooleanFilter.tsx
@@ -33,10 +33,6 @@ export default function AdvancedSearchBooleanFilter({
 }: AdvancedSearchBooleanFilterProps) {
   const children = query && (query.and || query.or);
 
-  if (!children) {
-    return null;
-  }
-
   const handleBooleanChange = (
     event: React.SyntheticEvent<HTMLSelectElement>
   ) => {
@@ -93,6 +89,11 @@ export default function AdvancedSearchBooleanFilter({
     },
     [query.id, onMove]
   );
+
+  // Hooks must run unconditionally, so this guard comes after useDrop above.
+  if (!children) {
+    return null;
+  }
 
   const isSelected = !readOnly && selectedQueryId === query.id;
 

--- a/src/components/AdvancedSearchValueFilter.tsx
+++ b/src/components/AdvancedSearchValueFilter.tsx
@@ -43,7 +43,7 @@ const AdvancedSearchValueFilter = ({
     event.stopPropagation();
     event.preventDefault();
 
-    onSelect?.(query.id);
+    onSelect?.(query?.id);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -51,7 +51,7 @@ const AdvancedSearchValueFilter = ({
     event.preventDefault();
 
     if (event.key === " ") {
-      onSelect?.(query.id);
+      onSelect?.(query?.id);
     }
   };
 
@@ -59,7 +59,7 @@ const AdvancedSearchValueFilter = ({
     event.stopPropagation();
     event.preventDefault();
 
-    onRemove?.(query.id);
+    onRemove?.(query?.id);
   };
 
   const [, drag]: [{}, ConnectDragSource, ConnectDragPreview] = useDrag(

--- a/src/components/AdvancedSearchValueFilter.tsx
+++ b/src/components/AdvancedSearchValueFilter.tsx
@@ -31,7 +31,7 @@ function getOpSymbol(value) {
   return op?.symbol || value;
 }
 
-export default ({
+const AdvancedSearchValueFilter = ({
   query,
   readOnly,
   selected,
@@ -39,10 +39,6 @@ export default ({
   onRemove,
   onSelect,
 }: AdvancedSearchValueFilterProps) => {
-  if (!query) {
-    return null;
-  }
-
   const handleClick = (event: React.SyntheticEvent) => {
     event.stopPropagation();
     event.preventDefault();
@@ -70,10 +66,10 @@ export default ({
     {
       type: "filter",
       item: {
-        id: query.id,
+        id: query?.id,
       },
     },
-    [query.id]
+    [query?.id]
   );
 
   const [dropProps, drop]: [
@@ -82,13 +78,13 @@ export default ({
   ] = useDrop(
     {
       accept: "filter",
-      canDrop: (item: any) => item.id !== query.id,
+      canDrop: (item: any) => item.id !== query?.id,
       drop: (item: any, monitor) => {
         if (!monitor.didDrop()) {
-          onMove?.(item.id, query.id);
+          onMove?.(item.id, query?.id);
 
           return {
-            id: query.id,
+            id: query?.id,
           };
         }
       },
@@ -97,8 +93,13 @@ export default ({
         isOver: !!monitor.isOver(),
       }),
     },
-    [query.id, onMove]
+    [query?.id, onMove]
   );
+
+  // Hooks must run unconditionally, so this guard comes after the hooks above.
+  if (!query) {
+    return null;
+  }
 
   const isSelected = !readOnly && selected;
   const { key, op, value } = query;
@@ -127,3 +128,5 @@ export default ({
     </div>
   );
 };
+
+export default AdvancedSearchValueFilter;

--- a/src/components/CustomListEditor.tsx
+++ b/src/components/CustomListEditor.tsx
@@ -113,10 +113,11 @@ export default function CustomListEditor({
   const { name } = properties;
 
   // Automatically execute the search when the list being edited changes, or finishes loading
-  // (which means a stored query may have been loaded).
-
+  // (which means a stored query may have been loaded). Intentionally keyed only on
+  // listId/isLoaded; `search` is a stable callback we don't want to re-trigger the effect.
   React.useEffect(() => {
     search?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listId, isLoaded]);
 
   const readOnly = !isOwner;

--- a/src/components/CustomListSearch.tsx
+++ b/src/components/CustomListSearch.tsx
@@ -60,6 +60,7 @@ const CustomListSearch = ({
   removeAdvSearchQuery,
   selectAdvSearchQuery,
 }: CustomListSearchProps) => {
+  // Seed the advanced-search query from startingTitle once, on mount only.
   React.useEffect(() => {
     if (startingTitle) {
       addAdvSearchQuery?.("include", {
@@ -70,6 +71,7 @@ const CustomListSearch = ({
 
       search?.();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const readOnly = !isOwner;

--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -257,6 +257,9 @@ function useTimeoutCleanup({
   refs: React.MutableRefObject<ReturnType<typeof setTimeout> | null>[];
   deps?: React.DependencyList;
 }) {
+  // `deps` is supplied by callers and `refs` is intentionally stable for the
+  // lifetime of the hook; both are excluded from static dependency checking.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => () => refs.forEach(cancelTimer), deps);
 }
 


### PR DESCRIPTION
## Description

Stacked on #254 (base branch `eslint-9-migration`). Fixes the real code issues that the ESLint 9 migration surfaced once `eslint .` lints the whole tree (the pre-commit hook only lints *staged* files, so these latent issues had accumulated unseen).

- **`AdvancedSearchBooleanFilter.tsx`** — `react-hooks/rules-of-hooks`: `useDrop` was called after an early `return null`. Moved the `!children` guard to *after* the hook so hooks always run in the same order. `query` is non-null in that guard, so behavior is unchanged.
- **`AdvancedSearchValueFilter.tsx`** — `react/display-name`: it was an anonymous `export default ({...}) => {...}`. Named the component. Because naming it makes `react-hooks` analyze it, that surfaced the *same* latent rules-of-hooks pattern (an early `!query` return before `useDrag`/`useDrop`), so the guard was moved below the hooks and the hooks' `query` access made null-safe (`query?.id`) to preserve the defensive behavior.
- **`CustomListEditor.tsx`, `CustomListSearch.tsx`, `JsonField.tsx`** — `react-hooks/exhaustive-deps`: suppressed on three intentional effects (a load-triggered search, a mount-only query seed, and a reusable timeout-cleanup hook), each with a comment explaining why adding the missing deps would be incorrect (re-trigger loops / duplicate searches).

## Motivation and Context

#254 deliberately left these latent findings out of scope to keep the dependency migration clean. This PR resolves them so the tree can reach a zero-error baseline ahead of enabling a full ESLint gate in CI (next stacked PR).

## How Has This Been Tested?

- `eslint .` reports **0 errors and 0 `exhaustive-deps` warnings** after the change (only the pre-existing `no-unused-vars` warnings remain, handled in the follow-up).
- Full `npm test` passes: mocha **1062 passing**, jest **349 passed / 32 suites**. The four affected components have existing test coverage under `src/components/__tests__/`.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.