### PR TITLE
Add a Queue Reap button to the collection editor (PP-4363)

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -461,8 +461,7 @@ export default class ActionCreator extends BaseActionCreator {
 
   reapCollection(collectionId: string | number) {
     const url = `/admin/collection/${collectionId}/reap`;
-    const data = new FormData();
-    return this.postForm(ActionCreator.REAP_COLLECTION, url, data).bind(this);
+    return this.postForm(ActionCreator.REAP_COLLECTION, url, null).bind(this);
   }
 
   fetchIndividualAdmins() {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -66,6 +66,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly EDIT_COLLECTION = "EDIT_COLLECTION";
   static readonly DELETE_COLLECTION = "DELETE_COLLECTION";
   static readonly IMPORT_COLLECTION = "IMPORT_COLLECTION";
+  static readonly REAP_COLLECTION = "REAP_COLLECTION";
   static readonly INDIVIDUAL_ADMINS = "INDIVIDUAL_ADMINS";
   static readonly EDIT_INDIVIDUAL_ADMIN = "EDIT_INDIVIDUAL_ADMIN";
   static readonly DELETE_INDIVIDUAL_ADMIN = "DELETE_INDIVIDUAL_ADMIN";
@@ -456,6 +457,12 @@ export default class ActionCreator extends BaseActionCreator {
     const data = new FormData();
     data.append("force", String(force));
     return this.postForm(ActionCreator.IMPORT_COLLECTION, url, data).bind(this);
+  }
+
+  reapCollection(collectionId: string | number) {
+    const url = `/admin/collection/${collectionId}/reap`;
+    const data = new FormData();
+    return this.postForm(ActionCreator.REAP_COLLECTION, url, data).bind(this);
   }
 
   fetchIndividualAdmins() {

--- a/src/components/CollectionImportButton.tsx
+++ b/src/components/CollectionImportButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { Panel } from "library-simplified-reusable-components";
 import { CollectionData, ProtocolData } from "../interfaces";
 import { protocolSupports, useCollectionTask } from "./collectionTask";
+import CollectionTaskPanel from "./CollectionTaskPanel";
 
 const IMPORT_DEFAULT_LABEL_TEXT = "Queue Import";
 const IMPORT_FORCED_FULL_LABEL_TEXT = "Force full re-import";
@@ -46,43 +46,48 @@ const CollectionImportButton: React.FC<CollectionImportButtonProps> = ({
     return null;
   }
 
-  const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
-
   const buttonLabel = getButtonLabel(force, busy);
 
   const buttonClass = force
     ? "btn btn-default collection-import-button force"
     : "btn btn-default collection-import-button";
 
-  const panelContent = (
-    <div className="collection-import">
-      <div className="collection-import-controls">
-        <button
-          className={buttonClass}
-          disabled={disabled || busy}
-          onClick={handleImport}
-        >
-          {buttonLabel}
-        </button>
-        <label>
-          <input
-            type="checkbox"
-            checked={force}
-            onChange={(e) => setForce(e.target.checked)}
+  return (
+    <CollectionTaskPanel
+      id="collection-import"
+      headerText="Import"
+      collectionId={collection?.id}
+      feedback={feedback}
+      success={success}
+      controls={
+        <div className="collection-import-controls">
+          <button
+            className={buttonClass}
             disabled={disabled || busy}
-          />{" "}
-          {IMPORT_FORCED_FULL_LABEL_TEXT}
-        </label>
-      </div>
-      {feedback && <div className={feedbackClass}>{feedback}</div>}
-      <p className="description">
-        {IMPORT_DEFAULT_LABEL_TEXT} picks up new and changed items. Check{" "}
-        <strong>{IMPORT_FORCED_FULL_LABEL_TEXT}</strong> to re-process
-        everything.
-      </p>
-      <details className="collection-import-details" key={collection?.id}>
-        <summary>More details</summary>
-        <dl className="collection-import-docs">
+            onClick={handleImport}
+          >
+            {buttonLabel}
+          </button>
+          <label>
+            <input
+              type="checkbox"
+              checked={force}
+              onChange={(e) => setForce(e.target.checked)}
+              disabled={disabled || busy}
+            />{" "}
+            {IMPORT_FORCED_FULL_LABEL_TEXT}
+          </label>
+        </div>
+      }
+      description={
+        <>
+          {IMPORT_DEFAULT_LABEL_TEXT} picks up new and changed items. Check{" "}
+          <strong>{IMPORT_FORCED_FULL_LABEL_TEXT}</strong> to re-process
+          everything.
+        </>
+      }
+      docs={
+        <>
           <dt>{IMPORT_DEFAULT_LABEL_TEXT}</dt>
           <dd>
             Schedules a background import job that checks for new or updated
@@ -101,13 +106,9 @@ const CollectionImportButton: React.FC<CollectionImportButtonProps> = ({
             forced re-import will take longer than a regular import because it
             re-processes all items.
           </dd>
-        </dl>
-      </details>
-    </div>
-  );
-
-  return (
-    <Panel id="collection-import" headerText="Import" content={panelContent} />
+        </>
+      }
+    />
   );
 };
 

--- a/src/components/CollectionImportButton.tsx
+++ b/src/components/CollectionImportButton.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Panel } from "library-simplified-reusable-components";
 import { CollectionData, ProtocolData } from "../interfaces";
+import { protocolSupports, useCollectionTask } from "./collectionTask";
 
 const IMPORT_DEFAULT_LABEL_TEXT = "Queue Import";
 const IMPORT_FORCED_FULL_LABEL_TEXT = "Force full re-import";
@@ -26,55 +27,28 @@ const CollectionImportButton: React.FC<CollectionImportButtonProps> = ({
   disabled,
 }) => {
   const [force, setForce] = React.useState(false);
-  const [importing, setImporting] = React.useState(false);
-  const [feedback, setFeedback] = React.useState<string | null>(null);
-  const [success, setSuccess] = React.useState(false);
+  const { busy, feedback, success, run } = useCollectionTask(collection?.id);
 
   React.useEffect(() => {
     setForce(false);
-    setImporting(false);
-    setFeedback(null);
-    setSuccess(false);
   }, [collection?.id]);
 
-  const supportsImport = (): boolean => {
-    if (!collection?.id || !collection?.protocol) {
-      return false;
-    }
-    const protocol = protocols.find((p) => p.name === collection.protocol);
-    return !!protocol?.supports_import;
-  };
+  const handleImport = (): Promise<void> =>
+    run(
+      () => importCollection(collection.id, force),
+      force
+        ? "Full re-import task queued. All items will be re-processed — this may take longer than a regular import. Changes will appear in the catalog once processing completes."
+        : "Import task queued. New and updated items will appear in the catalog once processing completes.",
+      "Failed to queue import task."
+    );
 
-  const handleImport = async (): Promise<void> => {
-    setImporting(true);
-    setFeedback(null);
-    try {
-      await importCollection(collection.id, force);
-      setImporting(false);
-      setFeedback(
-        force
-          ? "Full re-import task queued. All items will be re-processed — this may take longer than a regular import. Changes will appear in the catalog once processing completes."
-          : "Import task queued. New and updated items will appear in the catalog once processing completes."
-      );
-      setSuccess(true);
-    } catch (e) {
-      const message =
-        e && typeof e === "object" && "response" in e
-          ? String((e as { response: string }).response)
-          : "Failed to queue import task.";
-      setImporting(false);
-      setFeedback(message);
-      setSuccess(false);
-    }
-  };
-
-  if (!supportsImport()) {
+  if (!protocolSupports(collection, protocols, "supports_import")) {
     return null;
   }
 
   const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
 
-  const buttonLabel = getButtonLabel(force, importing);
+  const buttonLabel = getButtonLabel(force, busy);
 
   const buttonClass = force
     ? "btn btn-default collection-import-button force"
@@ -85,7 +59,7 @@ const CollectionImportButton: React.FC<CollectionImportButtonProps> = ({
       <div className="collection-import-controls">
         <button
           className={buttonClass}
-          disabled={disabled || importing}
+          disabled={disabled || busy}
           onClick={handleImport}
         >
           {buttonLabel}
@@ -95,7 +69,7 @@ const CollectionImportButton: React.FC<CollectionImportButtonProps> = ({
             type="checkbox"
             checked={force}
             onChange={(e) => setForce(e.target.checked)}
-            disabled={disabled || importing}
+            disabled={disabled || busy}
           />{" "}
           {IMPORT_FORCED_FULL_LABEL_TEXT}
         </label>

--- a/src/components/CollectionImportButton.tsx
+++ b/src/components/CollectionImportButton.tsx
@@ -49,7 +49,7 @@ const CollectionImportButton: React.FC<CollectionImportButtonProps> = ({
   const buttonLabel = getButtonLabel(force, busy);
 
   const buttonClass = force
-    ? "btn btn-default collection-import-button force"
+    ? "btn btn-default collection-import-button force collection-task-caution"
     : "btn btn-default collection-import-button";
 
   return (

--- a/src/components/CollectionReapButton.tsx
+++ b/src/components/CollectionReapButton.tsx
@@ -55,18 +55,22 @@ const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
       description={
         <>
           {REAP_LABEL_TEXT} removes titles that are no longer in the
-          collection's feed from the catalog.
+          collection's feed from the catalog — a slow, processing-intensive
+          task.
         </>
       }
       docs={
         <>
           <dt>{REAP_LABEL_TEXT}</dt>
           <dd>
-            Schedules a background job that re-reads the collection's feed and
-            marks any titles that are no longer present in it as unavailable,
-            removing them from the catalog. Use this when items have been
-            accidentally added to the catalog and need to be removed without
-            waiting for the collection's scheduled reap.
+            Schedules a background job that re-reads the collection's entire
+            feed and marks any titles that are no longer present in it as
+            unavailable, removing them from the catalog. Because it re-reads
+            every title rather than just recent changes, reaping is slow and
+            processing-intensive, so queue it only when you need to clear out
+            titles that should no longer appear — for example, when items have
+            been accidentally added to the catalog and need to be removed
+            without waiting for the collection's scheduled reap.
           </dd>
         </>
       }

--- a/src/components/CollectionReapButton.tsx
+++ b/src/components/CollectionReapButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { Panel } from "library-simplified-reusable-components";
 import { CollectionData, ProtocolData } from "../interfaces";
 import { protocolSupports, useCollectionTask } from "./collectionTask";
+import CollectionTaskPanel from "./CollectionTaskPanel";
 
 const REAP_LABEL_TEXT = "Queue Reap";
 
@@ -36,25 +36,30 @@ const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
       "Failed to queue reap task."
     );
 
-  const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
-
-  const panelContent = (
-    <div className="collection-reap">
-      <button
-        className="btn btn-default collection-reap-button"
-        disabled={disabled || busy}
-        onClick={handleReap}
-      >
-        {busy ? "Queuing..." : REAP_LABEL_TEXT}
-      </button>
-      {feedback && <div className={feedbackClass}>{feedback}</div>}
-      <p className="description">
-        {REAP_LABEL_TEXT} removes titles that are no longer in the collection's
-        feed from the catalog.
-      </p>
-      <details className="collection-reap-details" key={collection?.id}>
-        <summary>More details</summary>
-        <dl className="collection-reap-docs">
+  return (
+    <CollectionTaskPanel
+      id="collection-reap"
+      headerText="Reap"
+      collectionId={collection?.id}
+      feedback={feedback}
+      success={success}
+      controls={
+        <button
+          className="btn btn-default collection-reap-button"
+          disabled={disabled || busy}
+          onClick={handleReap}
+        >
+          {busy ? "Queuing..." : REAP_LABEL_TEXT}
+        </button>
+      }
+      description={
+        <>
+          {REAP_LABEL_TEXT} removes titles that are no longer in the
+          collection's feed from the catalog.
+        </>
+      }
+      docs={
+        <>
           <dt>{REAP_LABEL_TEXT}</dt>
           <dd>
             Schedules a background job that re-reads the collection's feed and
@@ -63,13 +68,9 @@ const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
             accidentally added to the catalog and need to be removed without
             waiting for the collection's scheduled reap.
           </dd>
-        </dl>
-      </details>
-    </div>
-  );
-
-  return (
-    <Panel id="collection-reap" headerText="Reap" content={panelContent} />
+        </>
+      }
+    />
   );
 };
 

--- a/src/components/CollectionReapButton.tsx
+++ b/src/components/CollectionReapButton.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Panel } from "library-simplified-reusable-components";
 import { CollectionData, ProtocolData } from "../interfaces";
+import { protocolSupports, useCollectionTask } from "./collectionTask";
 
 const REAP_LABEL_TEXT = "Queue Reap";
 
@@ -22,54 +23,30 @@ const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
   reapCollection,
   disabled,
 }) => {
-  const [reaping, setReaping] = React.useState(false);
-  const [feedback, setFeedback] = React.useState<string | null>(null);
-  const [success, setSuccess] = React.useState(false);
+  const { busy, feedback, success, run } = useCollectionTask(collection?.id);
 
-  React.useEffect(() => {
-    setReaping(false);
-    setFeedback(null);
-    setSuccess(false);
-  }, [collection?.id]);
-
-  const handleReap = async (): Promise<void> => {
-    setReaping(true);
-    setFeedback(null);
-    try {
-      await reapCollection(collection.id);
-      setReaping(false);
-      setFeedback(
-        "Reap task queued. Titles that are no longer in the collection's feed will be removed from the catalog once processing completes."
-      );
-      setSuccess(true);
-    } catch (e) {
-      const message =
-        e && typeof e === "object" && "response" in e
-          ? String((e as { response: string }).response)
-          : "Failed to queue reap task.";
-      setReaping(false);
-      setFeedback(message);
-      setSuccess(false);
-    }
-  };
-
-  if (!supportsReap(collection, protocols)) {
+  if (!protocolSupports(collection, protocols, "supports_reap")) {
     return null;
   }
+
+  const handleReap = (): Promise<void> =>
+    run(
+      () => reapCollection(collection.id),
+      "Reap task queued. Titles that are no longer in the collection's feed will be removed from the catalog once processing completes.",
+      "Failed to queue reap task."
+    );
 
   const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
 
   const panelContent = (
     <div className="collection-reap">
-      <div className="collection-reap-controls">
-        <button
-          className="btn btn-default collection-reap-button"
-          disabled={disabled || reaping}
-          onClick={handleReap}
-        >
-          {reaping ? "Queuing..." : REAP_LABEL_TEXT}
-        </button>
-      </div>
+      <button
+        className="btn btn-default collection-reap-button"
+        disabled={disabled || busy}
+        onClick={handleReap}
+      >
+        {busy ? "Queuing..." : REAP_LABEL_TEXT}
+      </button>
       {feedback && <div className={feedbackClass}>{feedback}</div>}
       <p className="description">
         {REAP_LABEL_TEXT} removes titles that are no longer in the collection's
@@ -95,16 +72,5 @@ const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
     <Panel id="collection-reap" headerText="Reap" content={panelContent} />
   );
 };
-
-function supportsReap(
-  collection: CollectionData,
-  protocols: ProtocolData[]
-): boolean {
-  if (!collection?.id || !collection?.protocol) {
-    return false;
-  }
-  const protocol = protocols.find((p) => p.name === collection.protocol);
-  return !!protocol?.supports_reap;
-}
 
 export default CollectionReapButton;

--- a/src/components/CollectionReapButton.tsx
+++ b/src/components/CollectionReapButton.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import { Panel } from "library-simplified-reusable-components";
+import { CollectionData, ProtocolData } from "../interfaces";
+
+const REAP_LABEL_TEXT = "Queue Reap";
+
+export interface CollectionReapButtonProps {
+  collection: CollectionData;
+  protocols: ProtocolData[];
+  reapCollection: (collectionId: string | number) => Promise<void>;
+  disabled?: boolean;
+}
+
+/**
+ * Renders a reap button for collections whose protocol supports reaping.
+ * Renders nothing otherwise. Reaping re-reads the collection's feed and
+ * removes any titles that are no longer present in it from the catalog.
+ */
+const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
+  collection,
+  protocols,
+  reapCollection,
+  disabled,
+}) => {
+  const [reaping, setReaping] = React.useState(false);
+  const [feedback, setFeedback] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  React.useEffect(() => {
+    setReaping(false);
+    setFeedback(null);
+    setSuccess(false);
+  }, [collection?.id]);
+
+  const handleReap = async (): Promise<void> => {
+    setReaping(true);
+    setFeedback(null);
+    try {
+      await reapCollection(collection.id);
+      setReaping(false);
+      setFeedback(
+        "Reap task queued. Titles that are no longer in the collection's feed will be removed from the catalog once processing completes."
+      );
+      setSuccess(true);
+    } catch (e) {
+      const message =
+        e && typeof e === "object" && "response" in e
+          ? String((e as { response: string }).response)
+          : "Failed to queue reap task.";
+      setReaping(false);
+      setFeedback(message);
+      setSuccess(false);
+    }
+  };
+
+  if (!supportsReap(collection, protocols)) {
+    return null;
+  }
+
+  const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
+
+  const panelContent = (
+    <div className="collection-reap">
+      <div className="collection-reap-controls">
+        <button
+          className="btn btn-default collection-reap-button"
+          disabled={disabled || reaping}
+          onClick={handleReap}
+        >
+          {reaping ? "Queuing..." : REAP_LABEL_TEXT}
+        </button>
+      </div>
+      {feedback && <div className={feedbackClass}>{feedback}</div>}
+      <p className="description">
+        {REAP_LABEL_TEXT} removes titles that are no longer in the collection's
+        feed from the catalog.
+      </p>
+      <details className="collection-reap-details" key={collection?.id}>
+        <summary>More details</summary>
+        <dl className="collection-reap-docs">
+          <dt>{REAP_LABEL_TEXT}</dt>
+          <dd>
+            Schedules a background job that re-reads the collection's feed and
+            marks any titles that are no longer present in it as unavailable,
+            removing them from the catalog. Use this when items have been
+            accidentally added to the catalog and need to be removed without
+            waiting for the collection's scheduled reap.
+          </dd>
+        </dl>
+      </details>
+    </div>
+  );
+
+  return (
+    <Panel id="collection-reap" headerText="Reap" content={panelContent} />
+  );
+};
+
+function supportsReap(
+  collection: CollectionData,
+  protocols: ProtocolData[]
+): boolean {
+  if (!collection?.id || !collection?.protocol) {
+    return false;
+  }
+  const protocol = protocols.find((p) => p.name === collection.protocol);
+  return !!protocol?.supports_reap;
+}
+
+export default CollectionReapButton;

--- a/src/components/CollectionReapButton.tsx
+++ b/src/components/CollectionReapButton.tsx
@@ -45,7 +45,7 @@ const CollectionReapButton: React.FC<CollectionReapButtonProps> = ({
       success={success}
       controls={
         <button
-          className="btn btn-default collection-reap-button"
+          className="btn btn-default collection-reap-button collection-task-caution"
           disabled={disabled || busy}
           onClick={handleReap}
         >

--- a/src/components/CollectionTaskPanel.tsx
+++ b/src/components/CollectionTaskPanel.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Panel } from "library-simplified-reusable-components";
+
+export interface CollectionTaskPanelProps {
+  /** DOM id for the underlying Panel. */
+  id: string;
+  /** Collapsible panel header text. */
+  headerText: string;
+  /**
+   * The edited collection's id. Used as the `<details>` key so the
+   * "More details" disclosure collapses when the collection changes.
+   */
+  collectionId?: string | number;
+  /** The success or error message to display, or null when idle. */
+  feedback: string | null;
+  /** True when `feedback` describes a success rather than a failure. */
+  success: boolean;
+  /** The action button(s) and any related controls. */
+  controls: React.ReactNode;
+  /** Short inline description shown under the controls. */
+  description: React.ReactNode;
+  /** Long-form documentation revealed under "More details". */
+  docs: React.ReactNode;
+}
+
+/**
+ * Shared panel layout for collection task buttons (import, reap, ...).
+ * Renders the supplied controls, feedback, a short description, and a
+ * collapsible "More details" docs section inside a Panel.
+ */
+const CollectionTaskPanel: React.FC<CollectionTaskPanelProps> = ({
+  id,
+  headerText,
+  collectionId,
+  feedback,
+  success,
+  controls,
+  description,
+  docs,
+}) => {
+  const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
+
+  const content = (
+    <div className="collection-task">
+      {controls}
+      {feedback && <div className={feedbackClass}>{feedback}</div>}
+      <p className="description">{description}</p>
+      <details className="collection-task-details" key={collectionId}>
+        <summary>More details</summary>
+        <dl className="collection-task-docs">{docs}</dl>
+      </details>
+    </div>
+  );
+
+  return <Panel id={id} headerText={headerText} content={content} />;
+};
+
+export default CollectionTaskPanel;

--- a/src/components/CollectionTaskPanel.tsx
+++ b/src/components/CollectionTaskPanel.tsx
@@ -39,11 +39,16 @@ const CollectionTaskPanel: React.FC<CollectionTaskPanelProps> = ({
   docs,
 }) => {
   const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
+  const feedbackAriaLive = success ? "polite" : "assertive";
 
   const content = (
     <div className="collection-task">
       {controls}
-      {feedback && <div className={feedbackClass}>{feedback}</div>}
+      {feedback && (
+        <div className={feedbackClass} aria-live={feedbackAriaLive}>
+          {feedback}
+        </div>
+      )}
       <p className="description">{description}</p>
       <details className="collection-task-details" key={collectionId}>
         <summary>More details</summary>

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -17,6 +17,7 @@ import {
   LibraryRegistrationsData,
 } from "../interfaces";
 import CollectionImportButton from "./CollectionImportButton";
+import CollectionReapButton from "./CollectionReapButton";
 import ServiceWithRegistrationsEditForm from "./ServiceWithRegistrationsEditForm";
 import TrashIcon from "./icons/TrashIcon";
 
@@ -33,6 +34,7 @@ export interface CollectionsDispatchProps
     collectionId: string | number,
     force: boolean
   ) => Promise<void>;
+  reapCollection: (collectionId: string | number) => Promise<void>;
 }
 
 export interface CollectionsProps
@@ -48,11 +50,13 @@ export class CollectionEditForm extends ServiceWithRegistrationsEditForm<
       collectionId: string | number,
       force: boolean
     ) => Promise<void>;
+    reapCollection: (collectionId: string | number) => Promise<void>;
   };
 
   static contextTypes = {
     ...ServiceWithRegistrationsEditForm.contextTypes,
     importCollection: PropTypes.func,
+    reapCollection: PropTypes.func,
   };
 
   /**
@@ -80,6 +84,13 @@ export class CollectionEditForm extends ServiceWithRegistrationsEditForm<
         collection={this.props.item as CollectionData}
         protocols={this.props.data?.protocols || []}
         importCollection={this.context.importCollection}
+        disabled={this.props.disabled}
+      />,
+      <CollectionReapButton
+        key="reap"
+        collection={this.props.item as CollectionData}
+        protocols={this.props.data?.protocols || []}
+        reapCollection={this.context.reapCollection}
         disabled={this.props.disabled}
       />,
     ];
@@ -112,6 +123,7 @@ export class Collections extends GenericEditableConfigList<
   static childContextTypes: React.ValidationMap<any> = {
     registerLibrary: PropTypes.func,
     importCollection: PropTypes.func,
+    reapCollection: PropTypes.func,
   };
 
   getChildContext() {
@@ -129,6 +141,7 @@ export class Collections extends GenericEditableConfigList<
         }
       },
       importCollection: this.props.importCollection,
+      reapCollection: this.props.reapCollection,
     };
   }
 
@@ -221,13 +234,15 @@ function mapDispatchToProps(dispatch, ownProps) {
       dispatch(actions.deleteCollection(identifier)),
     importCollection: (collectionId: string | number, force: boolean) =>
       dispatch(actions.importCollection(collectionId, force)),
+    reapCollection: (collectionId: string | number) =>
+      dispatch(actions.reapCollection(collectionId)),
   };
 }
 
 const ConnectedCollections = connect<
   EditableConfigListStateProps<CollectionsData>,
   EditableConfigListDispatchProps<CollectionsData> &
-    Pick<CollectionsDispatchProps, "importCollection">,
+    Pick<CollectionsDispatchProps, "importCollection" | "reapCollection">,
   EditableConfigListOwnProps
 >(
   mapStateToProps,

--- a/src/components/__tests__/Collections-test.tsx
+++ b/src/components/__tests__/Collections-test.tsx
@@ -49,6 +49,7 @@ describe("Collections", () => {
           registerLibrary={registerLibrary}
           fetchLibraryRegistrations={fetchLibraryRegistrations}
           importCollection={stub().resolves()}
+          reapCollection={stub().resolves()}
         />,
         { context: { admin: systemAdmin } }
       );
@@ -88,6 +89,7 @@ describe("Collections", () => {
           registerLibrary={registerLibrary}
           fetchLibraryRegistrations={fetchLibraryRegistrations}
           importCollection={stub().resolves()}
+          reapCollection={stub().resolves()}
         />,
         { context: { admin: systemAdmin } }
       );

--- a/src/components/collectionTask.ts
+++ b/src/components/collectionTask.ts
@@ -1,0 +1,92 @@
+import * as React from "react";
+import { CollectionData, ProtocolData } from "../interfaces";
+
+/** Protocol capability flags that gate a collection task button. */
+type CollectionTaskFlag = "supports_import" | "supports_reap";
+
+/**
+ * Returns true when the collection is saved (has an id) and its protocol
+ * advertises the given capability. Older backends that predate a capability
+ * simply omit the flag, so a missing flag is treated as unsupported and the
+ * associated control renders nothing — the admin and circulation manager can
+ * deploy out of sync without breaking.
+ */
+export function protocolSupports(
+  collection: CollectionData,
+  protocols: ProtocolData[],
+  flag: CollectionTaskFlag
+): boolean {
+  if (!collection?.id || !collection?.protocol) {
+    return false;
+  }
+  const protocol = protocols.find((p) => p.name === collection.protocol);
+  return !!protocol?.[flag];
+}
+
+/**
+ * Extracts a human-readable message from a rejected request, falling back to
+ * the supplied default when the error doesn't carry a `response` string.
+ */
+export function extractErrorMessage(error: unknown, fallback: string): string {
+  return error && typeof error === "object" && "response" in error
+    ? String((error as { response: string }).response)
+    : fallback;
+}
+
+export interface CollectionTask {
+  /** True while the queued action is in flight. */
+  busy: boolean;
+  /** The success or error message to display, or null when idle. */
+  feedback: string | null;
+  /** True when `feedback` describes a success rather than a failure. */
+  success: boolean;
+  /** Runs the action, managing busy/feedback/success state and errors. */
+  run: (
+    action: () => Promise<void>,
+    successMessage: string,
+    errorFallback: string
+  ) => Promise<void>;
+}
+
+/**
+ * Shared state machine for collection task buttons (import, reap, ...).
+ * Tracks in-flight/feedback/success state and resets it whenever the edited
+ * collection changes.
+ */
+export function useCollectionTask(
+  collectionId?: string | number
+): CollectionTask {
+  const [busy, setBusy] = React.useState(false);
+  const [feedback, setFeedback] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  React.useEffect(() => {
+    setBusy(false);
+    setFeedback(null);
+    setSuccess(false);
+  }, [collectionId]);
+
+  const run = React.useCallback(
+    async (
+      action: () => Promise<void>,
+      successMessage: string,
+      errorFallback: string
+    ): Promise<void> => {
+      setBusy(true);
+      setFeedback(null);
+      try {
+        await action();
+        setBusy(false);
+        setFeedback(successMessage);
+        setSuccess(true);
+      } catch (e) {
+        setBusy(false);
+        setFeedback(extractErrorMessage(e, errorFallback));
+        setSuccess(false);
+      }
+    },
+    []
+  );
+
+  return { busy, feedback, success, run };
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -337,6 +337,7 @@ export interface ProtocolData {
   supports_registration?: boolean;
   supports_staging?: boolean;
   supports_import?: boolean;
+  supports_reap?: boolean;
   settings: SettingData[];
   child_settings?: SettingData[];
   library_settings?: SettingData[];

--- a/src/stylesheets/collection.scss
+++ b/src/stylesheets/collection.scss
@@ -117,16 +117,6 @@
       color: $dark-gray;
     }
   }
-
-  .collection-reap-controls {
-    display: flex;
-    align-items: center;
-    gap: 1em;
-  }
-
-  label {
-    margin: 0;
-  }
 }
 
 .tab-container {

--- a/src/stylesheets/collection.scss
+++ b/src/stylesheets/collection.scss
@@ -52,6 +52,16 @@
       color: $dark-gray;
     }
   }
+
+  .collection-import-controls {
+    display: flex;
+    align-items: center;
+    gap: 1em;
+
+    label {
+      margin: 0;
+    }
+  }
 }
 
 // Cautionary treatment for heavyweight tasks (forced re-import, reap).
@@ -68,16 +78,6 @@
     background: $yellow;
     border-color: darken($yellow, 25%);
     color: $dark-gray;
-  }
-}
-
-.collection-import-controls {
-  display: flex;
-  align-items: center;
-  gap: 1em;
-
-  label {
-    margin: 0;
   }
 }
 

--- a/src/stylesheets/collection.scss
+++ b/src/stylesheets/collection.scss
@@ -10,21 +10,9 @@
   }
 }
 
-.collection-import {
-  .collection-import-button.force {
-    background: darken($yellow, 8%);
-    border-color: darken($yellow, 20%);
-    color: $dark-gray;
-
-    &:hover,
-    &:focus-visible {
-      background: $yellow;
-      border-color: darken($yellow, 25%);
-      color: $dark-gray;
-    }
-  }
-
-  details.collection-import-details {
+// Shared layout for collection task panels (import, reap, ...).
+.collection-task {
+  details.collection-task-details {
     margin-bottom: 1em;
 
     summary {
@@ -46,7 +34,7 @@
     }
   }
 
-  .collection-import-docs {
+  .collection-task-docs {
     font-size: 0.8rem;
     margin-bottom: 1em;
 
@@ -63,59 +51,29 @@
       margin-left: 0;
       color: $dark-gray;
     }
-  }
-
-  .collection-import-controls {
-    display: flex;
-    align-items: center;
-    gap: 1em;
-  }
-
-  label {
-    margin: 0;
   }
 }
 
-.collection-reap {
-  details.collection-reap-details {
-    margin-bottom: 1em;
+.collection-import-button.force {
+  background: darken($yellow, 8%);
+  border-color: darken($yellow, 20%);
+  color: $dark-gray;
 
-    summary {
-      list-style: none;
-      color: $dark-gray;
-      cursor: pointer;
-      font-size: 0.8rem;
-      text-decoration: underline;
-
-      &::-webkit-details-marker {
-        display: none;
-      }
-
-      &:hover,
-      &:focus-visible {
-        color: $blue-dark;
-        text-decoration: underline;
-      }
-    }
+  &:hover,
+  &:focus-visible {
+    background: $yellow;
+    border-color: darken($yellow, 25%);
+    color: $dark-gray;
   }
+}
 
-  .collection-reap-docs {
-    font-size: 0.8rem;
-    margin-bottom: 1em;
+.collection-import-controls {
+  display: flex;
+  align-items: center;
+  gap: 1em;
 
-    dt {
-      font-weight: bold;
-      margin-top: 0.75em;
-
-      &:first-child {
-        margin-top: 0;
-      }
-    }
-
-    dd {
-      margin-left: 0;
-      color: $dark-gray;
-    }
+  label {
+    margin: 0;
   }
 }
 

--- a/src/stylesheets/collection.scss
+++ b/src/stylesheets/collection.scss
@@ -54,7 +54,9 @@
   }
 }
 
-.collection-import-button.force {
+// Cautionary treatment for heavyweight tasks (forced re-import, reap).
+.collection-import-button.force,
+.btn-default.collection-reap-button {
   background: darken($yellow, 8%);
   border-color: darken($yellow, 20%);
   color: $dark-gray;

--- a/src/stylesheets/collection.scss
+++ b/src/stylesheets/collection.scss
@@ -76,6 +76,59 @@
   }
 }
 
+.collection-reap {
+  details.collection-reap-details {
+    margin-bottom: 1em;
+
+    summary {
+      list-style: none;
+      color: $dark-gray;
+      cursor: pointer;
+      font-size: 0.8rem;
+      text-decoration: underline;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      &:hover,
+      &:focus-visible {
+        color: $blue-dark;
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .collection-reap-docs {
+    font-size: 0.8rem;
+    margin-bottom: 1em;
+
+    dt {
+      font-weight: bold;
+      margin-top: 0.75em;
+
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+
+    dd {
+      margin-left: 0;
+      color: $dark-gray;
+    }
+  }
+
+  .collection-reap-controls {
+    display: flex;
+    align-items: center;
+    gap: 1em;
+  }
+
+  label {
+    margin: 0;
+  }
+}
+
 .tab-container {
   li.deleted-collection {
     background: $red-error;

--- a/src/stylesheets/collection.scss
+++ b/src/stylesheets/collection.scss
@@ -55,8 +55,10 @@
 }
 
 // Cautionary treatment for heavyweight tasks (forced re-import, reap).
-.collection-import-button.force,
-.btn-default.collection-reap-button {
+// Scoped under .collection-task and qualified with .btn-default so the rule
+// keeps enough specificity (0,3,0) to win over Bootstrap's own .btn-default
+// interactive states (:focus/:active, 0,2,0), which also set a background.
+.collection-task .btn-default.collection-task-caution {
   background: darken($yellow, 8%);
   border-color: darken($yellow, 20%);
   color: $dark-gray;

--- a/tests/jest/components/CollectionReapButton.test.tsx
+++ b/tests/jest/components/CollectionReapButton.test.tsx
@@ -66,6 +66,19 @@ describe("CollectionReapButton", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("does not render when the backend omits supports_reap (older CM)", () => {
+    // A circulation manager that predates reaping won't include the
+    // supports_reap flag at all. The admin must degrade gracefully and hide
+    // the panel rather than offering a button that would 404.
+    const legacyProtocol: ProtocolData = {
+      name: "OPDS 2.0",
+      label: "OPDS 2.0",
+      settings: [],
+    };
+    const { container } = renderButton({ protocols: [legacyProtocol] });
+    expect(container.innerHTML).toBe("");
+  });
+
   it("renders panel header when supported", () => {
     renderButton();
     expect(screen.getByText("Reap")).toBeInTheDocument();

--- a/tests/jest/components/CollectionReapButton.test.tsx
+++ b/tests/jest/components/CollectionReapButton.test.tsx
@@ -1,0 +1,202 @@
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CollectionReapButton, {
+  CollectionReapButtonProps,
+} from "../../../src/components/CollectionReapButton";
+import { CollectionData, ProtocolData } from "../../../src/interfaces";
+
+const protocolWithReap: ProtocolData = {
+  name: "OPDS 2.0",
+  label: "OPDS 2.0",
+  supports_reap: true,
+  settings: [],
+};
+
+const protocolWithoutReap: ProtocolData = {
+  name: "Boundless",
+  label: "Boundless",
+  supports_reap: false,
+  settings: [],
+};
+
+const savedCollection: CollectionData = {
+  id: 42,
+  protocol: "OPDS 2.0",
+  name: "Test Collection",
+};
+
+const unsavedCollection: CollectionData = {
+  protocol: "OPDS 2.0",
+  name: "Unsaved Collection",
+};
+
+function renderButton(overrides: Partial<CollectionReapButtonProps> = {}) {
+  const defaultProps: CollectionReapButtonProps = {
+    collection: savedCollection,
+    protocols: [protocolWithReap, protocolWithoutReap],
+    reapCollection: jest.fn().mockResolvedValue(undefined),
+    disabled: false,
+    ...overrides,
+  };
+  return {
+    ...render(<CollectionReapButton {...defaultProps} />),
+    reapCollection: defaultProps.reapCollection as jest.Mock,
+  };
+}
+
+/** Expand the collapsed Reap panel by clicking its header. */
+async function expandPanel(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText("Reap"));
+}
+
+describe("CollectionReapButton", () => {
+  it("does not render when protocol lacks supports_reap", () => {
+    const collection: CollectionData = {
+      id: 1,
+      protocol: "Boundless",
+      name: "Boundless Collection",
+    };
+    const { container } = renderButton({ collection });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("does not render for unsaved collection (no id)", () => {
+    const { container } = renderButton({ collection: unsavedCollection });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders panel header when supported", () => {
+    renderButton();
+    expect(screen.getByText("Reap")).toBeInTheDocument();
+  });
+
+  it("renders button when panel is expanded and has no force checkbox", async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await expandPanel(user);
+    expect(
+      screen.getByRole("button", { name: "Queue Reap" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("shows compact summary by default; detailed docs are hidden", async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await expandPanel(user);
+    expect(
+      screen.getByText(/queue reap removes titles that are no longer/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/schedules a background job that re-reads/i)
+    ).not.toBeVisible();
+  });
+
+  it("clicking 'More details' reveals the detailed docs", async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await expandPanel(user);
+
+    const details = screen.getByText("More details").closest("details");
+    expect(details).not.toHaveAttribute("open");
+
+    await user.click(screen.getByText("More details"));
+
+    expect(details).toHaveAttribute("open");
+    expect(
+      screen.getByText(/schedules a background job that re-reads/i)
+    ).toBeVisible();
+  });
+
+  it("button triggers reap with the collection id", async () => {
+    const user = userEvent.setup();
+    const { reapCollection } = renderButton();
+    await expandPanel(user);
+    await user.click(screen.getByRole("button", { name: "Queue Reap" }));
+    expect(reapCollection).toHaveBeenCalledWith(42);
+  });
+
+  it("shows success feedback after queuing", async () => {
+    const user = userEvent.setup();
+    renderButton();
+    await expandPanel(user);
+    await user.click(screen.getByRole("button", { name: "Queue Reap" }));
+    await waitFor(() => {
+      const feedback = screen.getByText(/reap task queued\./i);
+      expect(feedback).toBeInTheDocument();
+      expect(feedback).toHaveClass("alert", "alert-success");
+    });
+  });
+
+  it("shows error feedback with alert-danger styling on failure", async () => {
+    const user = userEvent.setup();
+    const mockReap = jest
+      .fn()
+      .mockRejectedValue({ response: "Something went wrong" });
+    renderButton({ reapCollection: mockReap });
+    await expandPanel(user);
+    await user.click(screen.getByRole("button", { name: "Queue Reap" }));
+    await waitFor(() => {
+      const feedback = screen.getByText("Something went wrong");
+      expect(feedback).toBeInTheDocument();
+      expect(feedback).toHaveClass("alert", "alert-danger");
+    });
+  });
+
+  it("resets feedback when switching collections", async () => {
+    const user = userEvent.setup();
+    const { rerender, reapCollection } = renderButton();
+    await expandPanel(user);
+
+    await user.click(screen.getByRole("button", { name: "Queue Reap" }));
+    await waitFor(() => {
+      expect(screen.getByText(/reap task queued\./i)).toBeInTheDocument();
+    });
+
+    const nextCollection: CollectionData = {
+      id: 99,
+      protocol: "OPDS 2.0",
+      name: "Another Collection",
+    };
+    rerender(
+      <CollectionReapButton
+        collection={nextCollection}
+        protocols={[protocolWithReap, protocolWithoutReap]}
+        reapCollection={reapCollection}
+        disabled={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/reap task queued\./i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("disables button when disabled prop is true", async () => {
+    const user = userEvent.setup();
+    renderButton({ disabled: true });
+    await expandPanel(user);
+    expect(screen.getByRole("button", { name: "Queue Reap" })).toBeDisabled();
+  });
+
+  it("shows 'Queuing...' text while reaping", async () => {
+    const user = userEvent.setup();
+    let resolveReap: () => void;
+    const pendingReap = new Promise<void>((resolve) => {
+      resolveReap = resolve;
+    });
+    const mockReap = jest.fn().mockReturnValue(pendingReap);
+    renderButton({ reapCollection: mockReap });
+    await expandPanel(user);
+
+    await user.click(screen.getByRole("button", { name: "Queue Reap" }));
+
+    expect(screen.getByRole("button", { name: "Queuing..." })).toBeDisabled();
+
+    resolveReap();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Queue Reap" })).toBeEnabled();
+    });
+  });
+});

--- a/tests/jest/components/Collections.test.tsx
+++ b/tests/jest/components/Collections.test.tsx
@@ -46,6 +46,7 @@ describe("Collections - associated library disclosure", () => {
         deleteItem={jest.fn().mockResolvedValue(undefined)}
         registerLibrary={jest.fn().mockResolvedValue(undefined)}
         importCollection={jest.fn().mockResolvedValue(undefined)}
+        reapCollection={jest.fn().mockResolvedValue(undefined)}
         csrfToken="token"
         isFetching={false}
       />,


### PR DESCRIPTION
## Description

Adds a "Queue Reap" button to the collection editor. Specifically:

- Adds a `REAP_COLLECTION` action that posts to `/admin/collection/<id>/reap`, a `CollectionReapButton` gated on the protocol's `supports_reap` flag, and wires `reapCollection` through the `Collections` context and dispatch.
- Extracts the import button's in-flight/feedback state into a shared `useCollectionTask` hook and its markup into a shared `CollectionTaskPanel`, so import and reap stay in sync.
- Styles the reap button and the forced full re-import button as heavyweight tasks via a shared `collection-task-caution` class (yellow, cautionary copy).

## Motivation and Context

Reaping for collections only happens on a cron schedule. When items are accidentally added to a collection's feed and show up in the catalog, there is currently no way to remove them without filing a request for a manual reap. This gives admins a self-service control to trigger a reap immediately.

This is the frontend half of the change. It depends on the backend endpoint and `supports_reap` protocol flag added in ThePalaceProject/circulation#3454, and the two must be deployed together.

## How Has This Been Tested?

- Added `CollectionReapButton.test.tsx` (renders only when `supports_reap` is set, hidden for unsaved collections and older CMs that omit the flag, triggers reap with the collection id, success/error feedback, disabled/loading states) and updated the existing Collections tests for the new prop.
- Ran the affected Jest suites (passing) and lint (`eslint --max-warnings 0` + sass-lint, clean).

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.