### PR TITLE
Keep collection-task feedback live region permanently mounted

### DIFF
--- a/src/components/CollectionTaskPanel.tsx
+++ b/src/components/CollectionTaskPanel.tsx
@@ -44,11 +44,13 @@ const CollectionTaskPanel: React.FC<CollectionTaskPanelProps> = ({
   const content = (
     <div className="collection-task">
       {controls}
-      {feedback && (
-        <div className={feedbackClass} aria-live={feedbackAriaLive}>
-          {feedback}
-        </div>
-      )}
+      {/* Keep the live region mounted at all times and toggle only its inner
+          content. Several screen readers won't announce a region inserted into
+          the DOM together with its text; the region must already exist when its
+          content mutates. */}
+      <div className="collection-task-feedback" aria-live={feedbackAriaLive}>
+        {feedback && <div className={feedbackClass}>{feedback}</div>}
+      </div>
       <p className="description">{description}</p>
       <details className="collection-task-details" key={collectionId}>
         <summary>More details</summary>

--- a/src/components/CollectionTaskPanel.tsx
+++ b/src/components/CollectionTaskPanel.tsx
@@ -39,17 +39,27 @@ const CollectionTaskPanel: React.FC<CollectionTaskPanelProps> = ({
   docs,
 }) => {
   const feedbackClass = success ? "alert alert-success" : "alert alert-danger";
-  const feedbackAriaLive = success ? "polite" : "assertive";
 
   const content = (
     <div className="collection-task">
       {controls}
-      {/* Keep the live region mounted at all times and toggle only its inner
-          content. Several screen readers won't announce a region inserted into
-          the DOM together with its text; the region must already exist when its
-          content mutates. */}
-      <div className="collection-task-feedback" aria-live={feedbackAriaLive}>
-        {feedback && <div className={feedbackClass}>{feedback}</div>}
+      {/* Keep both live regions mounted at all times, each at a fixed
+          politeness, and toggle only their inner content. Several screen
+          readers won't announce a region inserted into the DOM alongside its
+          text, nor a politeness change on an already-mounted node — so success
+          feedback routes to the permanently-polite region and errors to the
+          permanently-assertive one. */}
+      <div className="collection-task-feedback">
+        <div aria-live="polite">
+          {feedback && success && (
+            <div className={feedbackClass}>{feedback}</div>
+          )}
+        </div>
+        <div aria-live="assertive">
+          {feedback && !success && (
+            <div className={feedbackClass}>{feedback}</div>
+          )}
+        </div>
       </div>
       <p className="description">{description}</p>
       <details className="collection-task-details" key={collectionId}>

--- a/tests/jest/components/CollectionReapButton.test.tsx
+++ b/tests/jest/components/CollectionReapButton.test.tsx
@@ -130,16 +130,19 @@ describe("CollectionReapButton", () => {
     expect(reapCollection).toHaveBeenCalledWith(42);
   });
 
-  it("keeps the feedback live region mounted before any feedback appears", async () => {
+  it("keeps both feedback live regions mounted before any feedback appears", async () => {
     const user = userEvent.setup();
     const { container } = renderButton();
     await expandPanel(user);
-    // The live region must already exist when its content mutates; several
-    // screen readers won't announce a region inserted alongside its text.
-    const liveRegion = container.querySelector(".collection-task-feedback");
-    expect(liveRegion).toBeInTheDocument();
-    expect(liveRegion).toBeEmptyDOMElement();
-    expect(liveRegion).toHaveAttribute("aria-live");
+    // Both regions must already exist at a fixed politeness when their content
+    // mutates; several screen readers won't announce a region inserted
+    // alongside its text, nor a politeness change on an already-mounted node.
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+    const assertiveRegion = container.querySelector('[aria-live="assertive"]');
+    expect(politeRegion).toBeInTheDocument();
+    expect(politeRegion).toBeEmptyDOMElement();
+    expect(assertiveRegion).toBeInTheDocument();
+    expect(assertiveRegion).toBeEmptyDOMElement();
   });
 
   it("shows success feedback after queuing", async () => {
@@ -151,6 +154,11 @@ describe("CollectionReapButton", () => {
       const feedback = screen.getByText(/reap task queued\./i);
       expect(feedback).toBeInTheDocument();
       expect(feedback).toHaveClass("alert", "alert-success");
+      // Success routes to the permanently-polite region.
+      expect(feedback.closest("[aria-live]")).toHaveAttribute(
+        "aria-live",
+        "polite"
+      );
     });
   });
 
@@ -166,6 +174,11 @@ describe("CollectionReapButton", () => {
       const feedback = screen.getByText("Something went wrong");
       expect(feedback).toBeInTheDocument();
       expect(feedback).toHaveClass("alert", "alert-danger");
+      // Errors route to the permanently-assertive region.
+      expect(feedback.closest("[aria-live]")).toHaveAttribute(
+        "aria-live",
+        "assertive"
+      );
     });
   });
 

--- a/tests/jest/components/CollectionReapButton.test.tsx
+++ b/tests/jest/components/CollectionReapButton.test.tsx
@@ -130,6 +130,18 @@ describe("CollectionReapButton", () => {
     expect(reapCollection).toHaveBeenCalledWith(42);
   });
 
+  it("keeps the feedback live region mounted before any feedback appears", async () => {
+    const user = userEvent.setup();
+    const { container } = renderButton();
+    await expandPanel(user);
+    // The live region must already exist when its content mutates; several
+    // screen readers won't announce a region inserted alongside its text.
+    const liveRegion = container.querySelector(".collection-task-feedback");
+    expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion).toBeEmptyDOMElement();
+    expect(liveRegion).toHaveAttribute("aria-live");
+  });
+
   it("shows success feedback after queuing", async () => {
     const user = userEvent.setup();
     renderButton();


### PR DESCRIPTION
## Description

Follow-up to #273 addressing post-merge accessibility review feedback on `CollectionTaskPanel`. After I merged, Claude did its review, and it seemed like it had reasonable feedback, so I made this small follow up.

## Motivation and Context

Makes screen-reader announcements of import/reap task feedback reliable. Without a stable live region, the success/error messages queued from the collection task buttons may not be announced at all.

## How Has This Been Tested?

- `npm run test-jest-file tests/jest/components/CollectionReapButton.test.tsx` — 14 passing, including a new regression test asserting the live region is present and empty before any feedback appears.
- `npm run test-jest-file tests/jest/components/CollectionImportButton.test.tsx` — 19 passing.
- ESLint clean on the changed files.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.