### PR TITLE
Update web-opds-client to v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@nypl/dgx-svg-icons": "0.3.14",
         "@reduxjs/toolkit": "^2.2.5",
         "@tanstack/react-query": "^4.36.1",
-        "@thepalaceproject/web-opds-client": "^1.1.0",
+        "@thepalaceproject/web-opds-client": "^1.2.0",
         "bootstrap": "^3.3.6",
         "classnames": "^2.3.1",
         "draft-convert": "^2.1.5",
@@ -3194,21 +3194,22 @@
       }
     },
     "node_modules/@thepalaceproject/web-opds-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-1.1.0.tgz",
-      "integrity": "sha512-eMMciPWoz8jpGAAvRakByQQkZfJeAp36Qc73gnFXOOeBYlSsHxoJWDA8e307G8HLe0yyN2HxpI32IUFXwFAtFg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-1.2.0.tgz",
+      "integrity": "sha512-FVvG3AmXl6dW6J6Az0qNjxDVPklscYNdGwoIXzdnbtYCYn7i+VmF8qWLGl2cyiR47H4MdodjB9zk2R1dZwEyLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "buffer": "^6.0.3",
-        "dompurify": "3.2.4",
+        "dompurify": "3.4.11",
         "downloadjs": "^1.4.4",
+        "fast-content-type-parse": "^3.0.0",
         "font-awesome": "^4.7.0",
         "isomorphic-fetch": "^3.0.0",
-        "js-cookie": "^2.1.2",
+        "js-cookie": "^3.0.7",
         "jsdom": "^20.0.3",
         "moment": "^2.14.1",
-        "opds-feed-parser": "0.0.17",
+        "opds-feed-parser": "0.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -3223,7 +3224,7 @@
         "throttle-debounce": "1.0.1",
         "timers-browserify": "^2.0.12",
         "url": "^0.11.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.6.2"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -3301,6 +3302,15 @@
         }
       }
     },
+    "node_modules/@thepalaceproject/web-opds-client/node_modules/opds-feed-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opds-feed-parser/-/opds-feed-parser-0.1.0.tgz",
+      "integrity": "sha512-rCZa1erNB0goirLh8f06w7/dsQrgtMN2h9v/GO3kTSQNw2azKJPrwo3ElR/EOF8UU2Yf7poqptk0tPGUsbVpxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xml2js": "0.6.2"
+      }
+    },
     "node_modules/@thepalaceproject/web-opds-client/node_modules/redux": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
@@ -3363,6 +3373,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@thepalaceproject/web-opds-client/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -5088,15 +5111,6 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -7059,21 +7073,6 @@
         }
       }
     },
-    "node_modules/data-urls/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/data-urls/node_modules/tr46": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
@@ -7668,9 +7667,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7903,19 +7902,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -9058,6 +9044,22 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10316,21 +10318,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/html-escaper": {
@@ -13243,9 +13230,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -13460,21 +13448,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7073,6 +7073,21 @@
         }
       }
     },
+    "node_modules/data-urls/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/data-urls/node_modules/tr46": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
@@ -10320,6 +10335,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -13448,6 +13478,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nypl/dgx-svg-icons": "0.3.14",
     "@reduxjs/toolkit": "^2.2.5",
     "@tanstack/react-query": "^4.36.1",
-    "@thepalaceproject/web-opds-client": "^1.1.0",
+    "@thepalaceproject/web-opds-client": "^1.2.0",
     "bootstrap": "^3.3.6",
     "classnames": "^2.3.1",
     "draft-convert": "^2.1.5",


### PR DESCRIPTION
## Description

Bumps `@thepalaceproject/web-opds-client` from `^1.1.0` to `^1.2.0`.

The dependency changes are confined to web-opds-client and its nested tree. Notably, v1.2.0 brings in an updated nested `jsdom`/`data-urls`, where `@exodus/bytes` declares an *optional* peer dependency on `@noble/hashes` (`^1.8.0 || ^2.0.0`).

## Motivation and Context

[web-opds-client v1.2.0](https://github.com/ThePalaceProject/web-opds-client/releases/tag/v1.2.0) fixes [web-opds-client#111](https://github.com/ThePalaceProject/web-opds-client/pull/111): OPDS feeds are now classified using the server's declared `kind` in the response `Content-Type` header rather than guessed from feed structure. This corrects feeds from libraries without patron authentication (which omit borrow links) being misclassified as navigation feeds — so books render as cover images in lanes instead of gray title boxes.

`NavigationFeed` and `AcquisitionFeed` share the same shape, so the fix is internal to web-opds-client with no breaking API changes and no consuming-side code changes required here.

## How Has This Been Tested?

- `npm ci` — succeeds, lockfile in sync (exit 0)
- `npm run lint:js` — clean
- `npm test` — mocha legacy suite + jest: 33 suites, 363 tests passing

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.