### PR TITLE
Align direct opds-feed-parser dependency to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@nypl/dgx-svg-icons": "0.3.14",
         "@reduxjs/toolkit": "^2.2.5",
         "@tanstack/react-query": "^4.36.1",
-        "@thepalaceproject/web-opds-client": "^1.1.0",
+        "@thepalaceproject/web-opds-client": "^1.2.0",
         "bootstrap": "^3.3.6",
         "classnames": "^2.3.1",
         "draft-convert": "^2.1.5",
@@ -3194,21 +3194,22 @@
       }
     },
     "node_modules/@thepalaceproject/web-opds-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-1.1.0.tgz",
-      "integrity": "sha512-eMMciPWoz8jpGAAvRakByQQkZfJeAp36Qc73gnFXOOeBYlSsHxoJWDA8e307G8HLe0yyN2HxpI32IUFXwFAtFg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@thepalaceproject/web-opds-client/-/web-opds-client-1.2.0.tgz",
+      "integrity": "sha512-FVvG3AmXl6dW6J6Az0qNjxDVPklscYNdGwoIXzdnbtYCYn7i+VmF8qWLGl2cyiR47H4MdodjB9zk2R1dZwEyLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nypl/dgx-svg-icons": "^0.3.4",
         "buffer": "^6.0.3",
-        "dompurify": "3.2.4",
+        "dompurify": "3.4.11",
         "downloadjs": "^1.4.4",
+        "fast-content-type-parse": "^3.0.0",
         "font-awesome": "^4.7.0",
         "isomorphic-fetch": "^3.0.0",
-        "js-cookie": "^2.1.2",
+        "js-cookie": "^3.0.7",
         "jsdom": "^20.0.3",
         "moment": "^2.14.1",
-        "opds-feed-parser": "0.0.17",
+        "opds-feed-parser": "0.1.0",
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -3223,7 +3224,7 @@
         "throttle-debounce": "1.0.1",
         "timers-browserify": "^2.0.12",
         "url": "^0.11.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.6.2"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -3301,6 +3302,15 @@
         }
       }
     },
+    "node_modules/@thepalaceproject/web-opds-client/node_modules/opds-feed-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opds-feed-parser/-/opds-feed-parser-0.1.0.tgz",
+      "integrity": "sha512-rCZa1erNB0goirLh8f06w7/dsQrgtMN2h9v/GO3kTSQNw2azKJPrwo3ElR/EOF8UU2Yf7poqptk0tPGUsbVpxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xml2js": "0.6.2"
+      }
+    },
     "node_modules/@thepalaceproject/web-opds-client/node_modules/redux": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
@@ -3363,6 +3373,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@thepalaceproject/web-opds-client/node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -5088,15 +5111,6 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -7059,21 +7073,6 @@
         }
       }
     },
-    "node_modules/data-urls/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/data-urls/node_modules/tr46": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
@@ -7668,9 +7667,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7903,19 +7902,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -9058,6 +9044,22 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10316,21 +10318,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/html-escaper": {
@@ -13243,9 +13230,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -13460,21 +13448,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "isomorphic-fetch": "^3.0.0",
         "library-simplified-reusable-components": "1.3.18",
         "numeral": "^2.0.6",
-        "opds-feed-parser": "0.0.17",
+        "opds-feed-parser": "0.1.0",
         "prop-types": "^15.7.2",
         "qs": "^6.15.2",
         "react": "^16.8.6",
@@ -3302,15 +3302,6 @@
         }
       }
     },
-    "node_modules/@thepalaceproject/web-opds-client/node_modules/opds-feed-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/opds-feed-parser/-/opds-feed-parser-0.1.0.tgz",
-      "integrity": "sha512-rCZa1erNB0goirLh8f06w7/dsQrgtMN2h9v/GO3kTSQNw2azKJPrwo3ElR/EOF8UU2Yf7poqptk0tPGUsbVpxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xml2js": "0.6.2"
-      }
-    },
     "node_modules/@thepalaceproject/web-opds-client/node_modules/redux": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
@@ -3373,19 +3364,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@thepalaceproject/web-opds-client/node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -15953,21 +15931,13 @@
       }
     },
     "node_modules/opds-feed-parser": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/opds-feed-parser/-/opds-feed-parser-0.0.17.tgz",
-      "integrity": "sha512-qLHrvQKnvyh6ZCvuYlbQkJTyQQ1EdeXp5yXPSoOypn07HMDbKG27r0aMxVSYeZArpaPffMdrElTSvuB/ADc2fA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/opds-feed-parser/-/opds-feed-parser-0.1.0.tgz",
+      "integrity": "sha512-rCZa1erNB0goirLh8f06w7/dsQrgtMN2h9v/GO3kTSQNw2azKJPrwo3ElR/EOF8UU2Yf7poqptk0tPGUsbVpxg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "core-js": "^2.6.9",
-        "requirejs": "^2.1.22",
-        "xml2js": "^0.4.16"
+        "xml2js": "0.6.2"
       }
-    },
-    "node_modules/opds-feed-parser/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
     },
     "node_modules/open": {
       "version": "8.4.2",
@@ -17731,18 +17701,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/requirejs": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
-      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
-      "bin": {
-        "r_js": "bin/r.js",
-        "r.js": "bin/r.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/requires-port": {
@@ -22262,9 +22220,10 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7073,6 +7073,21 @@
         }
       }
     },
+    "node_modules/data-urls/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/data-urls/node_modules/tr46": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
@@ -10320,6 +10335,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -13448,6 +13478,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "isomorphic-fetch": "^3.0.0",
     "library-simplified-reusable-components": "1.3.18",
     "numeral": "^2.0.6",
-    "opds-feed-parser": "0.0.17",
+    "opds-feed-parser": "0.1.0",
     "prop-types": "^15.7.2",
     "qs": "^6.15.2",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nypl/dgx-svg-icons": "0.3.14",
     "@reduxjs/toolkit": "^2.2.5",
     "@tanstack/react-query": "^4.36.1",
-    "@thepalaceproject/web-opds-client": "^1.1.0",
+    "@thepalaceproject/web-opds-client": "^1.2.0",
     "bootstrap": "^3.3.6",
     "classnames": "^2.3.1",
     "draft-convert": "^2.1.5",

--- a/src/__tests__/editorAdapter-test.ts
+++ b/src/__tests__/editorAdapter-test.ts
@@ -158,8 +158,10 @@ describe("editorAdapter", () => {
       id: "id",
       updated: "updated",
       title: "title",
+      subtitle: "subtitle",
       authors: [],
       contributors: [],
+      series: new Series({ name: "series", position: 2 }),
       categories: [
         new Category({ term: "term", scheme: "scheme", label: "label" }),
         new Category({
@@ -188,8 +190,10 @@ describe("editorAdapter", () => {
       id: "id",
       updated: "updated",
       title: "title",
+      subtitle: "subtitle",
       authors: [],
       contributors: [],
+      series: new Series({ name: "series", position: 2 }),
       categories: [
         new Category({
           term: "policy-filtered",


### PR DESCRIPTION
> **Stacked on #279.** Its base is the `chore/update-web-opds-client-1.2.0` branch and the diff shown here is just the `opds-feed-parser` change. GitHub will auto-retarget this to `main` once #279 merges. It should merge after #279.

## Description

Bumps the direct `opds-feed-parser` dependency from `0.0.17` to `0.1.0` to match the version web-opds-client 1.2.0 uses internally, and updates the two `editorAdapter` mocha fixtures for 0.1.0's stricter `OPDSEntryArgs`.

Lockfile effect (net −41 lines): the tree collapses to a single `opds-feed-parser@0.1.0` / `xml2js@0.6.2` copy instead of two, and the deprecated `core-js@2.6.12` and `requirejs` transitive deps (pulled by 0.0.17) are dropped.

## Motivation and Context

web-opds-client 1.2.0's `DataFetcher` parses feeds with `opds-feed-parser@0.1.0` and hands the resulting `OPDSEntry` to `editorAdapter` (`new DataFetcher({ adapter: editorAdapter })`). Until now `editorAdapter`'s types — and the legacy mocha fixtures in `editorAdapter-test.ts` that call `new OPDSEntry(...)` — came from the directly-declared `0.0.17`, so in production the entries were produced by `0.1.0` while the types came from `0.0.17`. The build still compiled (structural typing) and the `data.unparsed[...]` reads are try/catch-guarded, so this was not a proven break, but bumping the direct dependency keeps the type definitions and fixtures aligned with the parser that actually produces the entries and avoids carrying two copies of `opds-feed-parser`.

`opds-feed-parser@0.1.0` redefines `OPDSEntryArgs extends OPDSEntry`, making every `OPDSEntry` field required — `subtitle` and `series` were optional in `0.0.17`. The two visibility-status fixtures omitted them, so they now provide both (matching the existing "valid OPDS entry" fixture). `editorAdapter.ts` itself needed no changes.

## How Has This Been Tested?

Validated on the same toolchain CI uses — **Node 20 / npm 10.8.2**:

- `npm ci` — lockfile in sync (exit 0)
- `npx tsc --noEmit` — typechecks clean against 0.1.0
- `npm run lint:js` — clean
- `npm run test-file-ts src/__tests__/editorAdapter-test.ts` — 4 passing against 0.1.0
- `npm test` — full mocha + jest suite: 33 suites, 363 tests passing

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.