### PR TITLE
Make lane count optional and stop displaying it (PP-4506)

### DIFF
--- a/src/components/Lane.tsx
+++ b/src/components/Lane.tsx
@@ -72,7 +72,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
                 aria-label={`Button to expand or collapse a lane`}
                 content={<PyramidIcon />}
               />
-              {lane.display_name + " (" + lane.count + ")"}
+              {lane.display_name}
             </span>
             {this.renderVisibilityToggle()}
           </div>

--- a/src/components/__tests__/Lanes-test.tsx
+++ b/src/components/__tests__/Lanes-test.tsx
@@ -408,9 +408,7 @@ describe("Lanes", () => {
     const lane4 = topLevelLanes.at(0);
     const lane1 = topLevelLanes.at(1);
     expect(lane1.text()).to.contain("lane 1");
-    expect(lane1.text()).to.contain("(5)");
     expect(lane4.text()).to.contain("lane 4");
-    expect(lane4.text()).to.contain("(1)");
   });
 
   it("drags a sublane", () => {

--- a/src/components/__tests__/LanesSidebar-test.tsx
+++ b/src/components/__tests__/LanesSidebar-test.tsx
@@ -246,9 +246,7 @@ describe("LanesSidebar", () => {
     let topLane1 = topLevelLanes.at(0).find("div").at(0);
     const topLane2 = topLevelLanes.at(1).find("div").at(0);
     expect(topLane1.text()).to.contain("Top Lane 1");
-    expect(topLane1.text()).to.contain("(5)");
     expect(topLane2.text()).to.contain("Top Lane 2");
-    expect(topLane2.text()).to.contain("(1)");
 
     // both top-level lanes are expanded to start.
     expectExpanded(topLane1);
@@ -257,7 +255,6 @@ describe("LanesSidebar", () => {
     // top lane 1 has one sublane which is collapsed
     let subLane1 = topLane1.find("li > div");
     expect(subLane1.text()).to.contain("Sublane 1");
-    expect(subLane1.text()).to.contain("(3)");
     expect(subLane1.length).to.equal(1);
     const subLane1Expand = expectCollapsed(subLane1);
 
@@ -281,7 +278,6 @@ describe("LanesSidebar", () => {
     const subLane1Collapse = expectExpanded(subLane1);
     subSubLane = subLane1.find("li > div");
     expect(subSubLane.text()).to.contain("SubSublane 1");
-    expect(subSubLane.text()).to.contain("(2)");
     expectCollapsed(subSubLane);
 
     // if we collapse sublane 1, its sublane is hidden again.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -511,7 +511,10 @@ export interface LaneData {
   id: string | number;
   display_name: string;
   visible: boolean;
-  count: number;
+  // Deprecated: the backend no longer returns a lane count (lane sizes were
+  // removed). Kept optional for backward compatibility with older servers; the
+  // UI no longer displays it.
+  count?: number;
   sublanes: LaneData[];
   custom_list_ids: number[];
   inherit_parent_restrictions: boolean;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -514,6 +514,9 @@ export interface LaneData {
   // Deprecated: the backend no longer returns a lane count (lane sizes were
   // removed). Kept optional for backward compatibility with older servers; the
   // UI no longer displays it.
+  // TODO: Remove this field and the deprecation note above once the backend
+  // changes in ThePalaceProject/circulation#3424 have been released to
+  // production.
   count?: number;
   sublanes: LaneData[];
   custom_list_ids: number[];


### PR DESCRIPTION
## Description

The Palace Manager backend is removing lane-size maintenance (see ThePalaceProject/circulation#3424), so the admin `GET .../lanes` response no longer includes a per-lane `count`.

- `interfaces.ts`: make `LaneData.count` optional (`count?: number`) for backward compatibility with older servers.
- `Lane.tsx`: stop rendering the `" (count)"` suffix next to the lane name.

`count` was display-only — no logic depended on it — so this degrades gracefully and is safe to ship independently of the backend change.

## Motivation and Context

JIRA: PP-4506

Companion to ThePalaceProject/circulation#3424, which removes the lane `size`/`count` from the backend.

## How Has This Been Tested?

- `tsc` type-check passes.
- `tests/jest/components/Lane.test.tsx` passes (2/2); Prettier clean.
