### PR TITLE
Revert dependabot's bootstrap v5 update back to v3 (PP-4661)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 4
+    ignore:
+      # We currently support only v3 of Bootstrap. Prevent PRs for v4.0.0 or higher.
+      # See https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates
+      - dependency-name: "bootstrap"
+        versions: [">= 4.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@reduxjs/toolkit": "^2.2.5",
         "@tanstack/react-query": "^4.36.1",
         "@thepalaceproject/web-opds-client": "^1.2.0",
-        "bootstrap": "^5.3.8",
+        "bootstrap": "^3.3.6",
         "classnames": "^2.3.1",
         "draft-convert": "^2.1.5",
         "draft-js": "0.11.7",
@@ -2773,17 +2773,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@react-dnd/asap": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
@@ -5436,22 +5425,11 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/boxen": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@reduxjs/toolkit": "^2.2.5",
     "@tanstack/react-query": "^4.36.1",
     "@thepalaceproject/web-opds-client": "^1.2.0",
-    "bootstrap": "^5.3.8",
+    "bootstrap": "^3.3.6",
     "classnames": "^2.3.1",
     "draft-convert": "^2.1.5",
     "draft-js": "0.11.7",


### PR DESCRIPTION
## Description

- Reverts dependabot's `bootstrap` upgrade (from v3 -> v5) on #298.
- Adds dependabot configuration to pin `bootstrap` to versions less than v4.

## Motivation and Context

Bootstrap v5 is a radical departure from v3, dropping support for many components. This app depends on components and configuration in v3.

The dependabot configuration update is needed to prevent dependabot doing the same thing again.

[Jira PP-4661]

## How Has This Been Tested?

- Manual testing using `npm run dev-server` against Minotaur.
- All tests pass locally and in CI, but they also did with the wrong `bootstrap` version.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
