### PR TITLE
Support monospace font in designated settings fields (PP-4734)

### DIFF
--- a/src/components/JsonField.tsx
+++ b/src/components/JsonField.tsx
@@ -9,6 +9,7 @@ import {
 import CopyIcon from "./icons/CopyIcon";
 import XCloseIcon from "./icons/XCloseIcon";
 import { SettingData } from "../interfaces";
+import { MONOSPACE_FONT_STACK } from "../fonts";
 
 export interface JsonFieldProps {
   setting: SettingData;
@@ -188,6 +189,11 @@ const JsonField = forwardRef<JsonFieldHandle, JsonFieldProps>(
             readOnly={readOnly}
             aria-invalid={jsonError ? true : undefined}
             aria-describedby={describedBy}
+            style={
+              setting.use_monospace_font
+                ? { fontFamily: MONOSPACE_FONT_STACK }
+                : undefined
+            }
           />
           <div className="json-field-actions">
             <span className="json-field-copied-feedback" aria-live="polite">

--- a/src/components/ProtocolFormField.tsx
+++ b/src/components/ProtocolFormField.tsx
@@ -5,6 +5,7 @@ import JsonField, { JsonFieldHandle } from "./JsonField";
 import { Button } from "library-simplified-reusable-components";
 import InputList from "./InputList";
 import { SettingData, CustomListsSetting } from "../interfaces";
+import { MONOSPACE_FONT_STACK } from "../fonts";
 import { FetchErrorData } from "@thepalaceproject/web-opds-client/lib/interfaces";
 
 export interface ProtocolFormFieldProps {
@@ -64,12 +65,12 @@ export default class ProtocolFormField extends React.Component<
       setting.type === "select"
         ? this.renderSelectSetting(setting)
         : setting.type === "list" || setting.type === "menu"
-        ? this.renderListSetting(setting)
-        : setting.type === "color-picker"
-        ? this.renderColorPickerSetting(setting)
-        : setting.type === "json"
-        ? this.renderJsonSetting(setting)
-        : this.renderSetting(setting);
+          ? this.renderListSetting(setting)
+          : setting.type === "color-picker"
+            ? this.renderColorPickerSetting(setting)
+            : setting.type === "json"
+              ? this.renderJsonSetting(setting)
+              : this.renderSetting(setting);
     // Special handling for hidden settings.
     return setting.hidden ? this.renderHiddenElement(element) : element;
   }
@@ -149,6 +150,9 @@ export default class ProtocolFormField extends React.Component<
       ref: this.elementRef,
       onChange: this.props.onChange,
       readOnly: this.props.readOnly,
+      ...(setting.use_monospace_font && {
+        style: { fontFamily: MONOSPACE_FONT_STACK },
+      }),
     };
     let props = extraProps[setting.type]
       ? { ...basicProps, ...extraProps[setting.type] }

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,0 +1,5 @@
+// GitHub's system monospace stack: ui-monospace (modern catch-all), SF Mono (macOS),
+// Menlo (macOS legacy), Consolas (Windows), Liberation Mono (Linux).
+// See: https://primer.style/product/primitives/typography/
+export const MONOSPACE_FONT_STACK =
+  "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -324,6 +324,7 @@ export interface SettingData {
   paired?: string;
   readOnly?: boolean;
   capitalize?: boolean;
+  use_monospace_font?: boolean;
   skip?: boolean;
   level?: number;
 }

--- a/tests/jest/components/JsonField.test.tsx
+++ b/tests/jest/components/JsonField.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import JsonField, { JsonFieldHandle } from "../../../src/components/JsonField";
+import { MONOSPACE_FONT_STACK } from "../../../src/fonts";
 
 const setting = {
   key: "my_json",
@@ -469,6 +470,25 @@ describe("JsonField", () => {
 
       fireEvent.keyDown(ta, { key: "z", ctrlKey: true });
       expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("use_monospace_font", () => {
+    (
+      [
+        { id: "set", use_monospace_font: true, hasStyle: true },
+        { id: "absent", hasStyle: false },
+      ] as { id: string; use_monospace_font?: boolean; hasStyle: boolean }[]
+    ).forEach(({ id, use_monospace_font, hasStyle }) => {
+      it(id, () => {
+        render(<JsonField setting={{ ...setting, use_monospace_font }} />);
+        const ta = screen.getByLabelText("JSON Setting");
+        if (hasStyle) {
+          expect(ta).toHaveStyle({ fontFamily: MONOSPACE_FONT_STACK });
+        } else {
+          expect(ta).not.toHaveStyle({ fontFamily: MONOSPACE_FONT_STACK });
+        }
+      });
     });
   });
 

--- a/tests/jest/components/ProtocolFormField.test.tsx
+++ b/tests/jest/components/ProtocolFormField.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ProtocolFormField from "../../../src/components/ProtocolFormField";
+import { MONOSPACE_FONT_STACK } from "../../../src/fonts";
 
 // NB: This file adds / duplicates existing tests from:
 // - `src/components/__tests__/ProtocolFormField-test.tsx`.
@@ -61,6 +62,41 @@ describe("ProtocolFormField — json type", () => {
       ref.current!.clear();
     });
     expect(ta.value).toBe("");
+  });
+});
+
+describe("ProtocolFormField — use_monospace_font", () => {
+  (
+    [
+      { id: "text-input", use_monospace_font: true, hasStyle: true },
+      {
+        id: "textarea",
+        type: "textarea",
+        use_monospace_font: true,
+        hasStyle: true,
+      },
+      { id: "absent", hasStyle: false },
+    ] as {
+      id: string;
+      type?: string;
+      use_monospace_font?: boolean;
+      hasStyle: boolean;
+    }[]
+  ).forEach(({ id, type, use_monospace_font, hasStyle }) => {
+    it(id, () => {
+      render(
+        <ProtocolFormField
+          setting={{ key: "f", label: "My Field", type, use_monospace_font }}
+          disabled={false}
+        />
+      );
+      const el = screen.getByLabelText("My Field");
+      if (hasStyle) {
+        expect(el).toHaveStyle({ fontFamily: MONOSPACE_FONT_STACK });
+      } else {
+        expect(el).not.toHaveStyle({ fontFamily: MONOSPACE_FONT_STACK });
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Adds a `use_monospace_font` flag to the `SettingData` interface. When set to `true` on a setting from the server, the admin UI renders that field's input using a system monospace font. The flag is respected by both the general-purpose field renderer and the JSON field component.

The monospace font stack is [the one currently specified as GitHub's design system monospace stack](https://primer.style/foundations/typography#monospace): SF Mono for macOS, Consolas for Windows, Liberation Mono for Linux.

## Motivation and Context

Some configuration values (e.g., structured data, filter expressions) are easier to read and edit in a monospace font where character alignment is consistent. This change adds the client-side plumbing for that hint. To be used in practice, the corresponding support added on ThePalaceProject/circulation#3539 must be merged to enable the use of `use_monospace_font: true` on settings. That said, it is safe to merge these two PRs in any order.

[Jira PP-4734]

## How Has This Been Tested?

- Manual testing in local dev environment.
- New tests cover text input, textarea, and JSON field types, both with the flag set and absent.
- Tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation-admin/actions/runs/28826832936) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
