### PR TITLE
Rewrite actions-test as a jest test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "fetch-mock": "^10.0.7",
         "fetch-mock-jest": "^1.5.1",
         "fetch-ponyfill": "^7.1.0",
         "file-loader": "^6.2.0",
@@ -7280,15 +7279,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8919,27 +8909,6 @@
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
-    "node_modules/fetch-mock": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-10.1.1.tgz",
-      "integrity": "sha512-R6MwxuGwlUe0K6GzdLY1Wa9voX/GbUBDZjNHBsvlBhrpXurCYpQN4EW0iFCmtWddDTuS0ubR93OtFSgy9E/L2A==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "dequal": "^2.0.3",
-        "globrex": "^0.1.2",
-        "is-subset": "^0.1.1",
-        "regexparam": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-fetch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fetch-mock-jest": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
@@ -9654,12 +9623,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
     },
     "node_modules/globule": {
       "version": "1.3.4",
@@ -17043,15 +17006,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexparam": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
-      "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/remove-accents": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "fetch-mock": "^10.0.7",
     "fetch-mock-jest": "^1.5.1",
     "fetch-ponyfill": "^7.1.0",
     "file-loader": "^6.2.0",

--- a/tests/jest/actions.test.ts
+++ b/tests/jest/actions.test.ts
@@ -1,8 +1,6 @@
-import { expect } from "chai";
-import { stub } from "sinon";
-const fetchMock = require("fetch-mock");
+import * as fetchMock from "fetch-mock-jest";
 
-import ActionCreator from "../actions";
+import ActionCreator from "../../src/actions";
 
 class MockDataFetcher {
   resolve: boolean = true;
@@ -50,35 +48,35 @@ describe("actions", () => {
     formData.append("test", "test");
 
     it("dispatches request, success, and load", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const responseText = "response";
       fetchMock.post(url, responseText);
 
       await actions.postForm(type, url, formData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${type}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${type}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${type}_${ActionCreator.LOAD}`
       );
-      expect(dispatch.args[2][0].data).to.equal(responseText);
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(url);
-      expect(fetchArgs[0][1].method).to.equal("POST");
+      expect(dispatch.mock.calls[2][0].data).toBe(responseText);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(url);
+      expect(fetchArgs[0][1].method).toBe("POST");
       const expectedHeaders = new Headers();
       expectedHeaders.append("X-CSRF-Token", "token");
-      expect(fetchArgs[0][1].headers).to.deep.equal(expectedHeaders);
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchArgs[0][1].headers).toStrictEqual(expectedHeaders);
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
 
     it("postForm with JSON response dispatches request, success, and load", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       // prettier-ignore
       const responseText = "{\"id\": \"test\", \"name\": \"test\"}";
       fetchMock.mock(url, responseText);
@@ -86,62 +84,64 @@ describe("actions", () => {
       await actions.postForm(type, url, formData, "POST", "", "JSON")(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${type}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${type}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${type}_${ActionCreator.LOAD}`
       );
-      expect(dispatch.args[2][0].data).to.deep.equal(JSON.parse(responseText));
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(url);
-      expect(fetchArgs[0][1].method).to.equal("POST");
+      expect(dispatch.mock.calls[2][0].data).toStrictEqual(
+        JSON.parse(responseText)
+      );
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(url);
+      expect(fetchArgs[0][1].method).toBe("POST");
       const expectedHeaders = new Headers();
       expectedHeaders.append("X-CSRF-Token", "token");
-      expect(fetchArgs[0][1].headers).to.deep.equal(expectedHeaders);
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchArgs[0][1].headers).toStrictEqual(expectedHeaders);
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
 
     it("dispatches a DELETE request", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const responseText = "response";
       fetchMock.mock(url, responseText);
 
       await actions.postForm(type, url, formData, "DELETE")(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(url);
-      expect(fetchArgs[0][1].method).to.equal("DELETE");
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(url);
+      expect(fetchArgs[0][1].method).toBe("DELETE");
       const expectedHeaders = new Headers();
       expectedHeaders.append("X-CSRF-Token", "token");
-      expect(fetchArgs[0][1].headers).to.deep.equal(expectedHeaders);
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchArgs[0][1].headers).toStrictEqual(expectedHeaders);
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
 
     it("dispatches failure on bad response", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       fetchMock.mock(url, { status: 500, body: { detail: "problem detail" } });
 
       try {
         await actions.postForm(type, url, formData)(dispatch);
         // shouldn't get here
-        expect(false).to.equal(true);
+        expect(false).toBe(true);
       } catch (err) {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(
+        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls[0][0].type).toBe(
           `${type}_${ActionCreator.REQUEST}`
         );
-        expect(dispatch.args[1][0].type).to.equal(
+        expect(dispatch.mock.calls[1][0].type).toBe(
           `${type}_${ActionCreator.FAILURE}`
         );
-        expect(fetchMock.called()).to.equal(true);
-        expect(err).to.deep.equal({
+        expect(fetchMock.called()).toBe(true);
+        expect(err).toStrictEqual({
           status: 500,
           response: "problem detail",
           url: url,
@@ -150,7 +150,7 @@ describe("actions", () => {
     });
 
     it("dispatches failure on non-JSON response", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       fetchMock.mock(url, { status: 500, body: "Not JSON" });
 
       try {
@@ -162,17 +162,17 @@ describe("actions", () => {
           "Default error"
         )(dispatch);
         // shouldn't get here
-        expect(false).to.equal(true);
+        expect(false).toBe(true);
       } catch (err) {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(
+        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls[0][0].type).toBe(
           `${type}_${ActionCreator.REQUEST}`
         );
-        expect(dispatch.args[1][0].type).to.equal(
+        expect(dispatch.mock.calls[1][0].type).toBe(
           `${type}_${ActionCreator.FAILURE}`
         );
-        expect(fetchMock.called()).to.equal(true);
-        expect(err).to.deep.equal({
+        expect(fetchMock.called()).toBe(true);
+        expect(err).toStrictEqual({
           status: 500,
           response: "Default error",
           url: url,
@@ -181,7 +181,7 @@ describe("actions", () => {
     });
 
     it("dispatches failure on no response", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       fetchMock.mock(url, () => {
         throw { message: "test error" };
       });
@@ -189,17 +189,17 @@ describe("actions", () => {
       try {
         await actions.postForm(type, url, formData)(dispatch);
         // shouldn't get here
-        expect(false).to.equal(true);
+        expect(false).toBe(true);
       } catch (err) {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(
+        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls[0][0].type).toBe(
           `${type}_${ActionCreator.REQUEST}`
         );
-        expect(dispatch.args[1][0].type).to.equal(
+        expect(dispatch.mock.calls[1][0].type).toBe(
           `${type}_${ActionCreator.FAILURE}`
         );
-        expect(fetchMock.called()).to.equal(true);
-        expect(err).to.deep.equal({
+        expect(fetchMock.called()).toBe(true);
+        expect(err).toStrictEqual({
           status: null,
           response: "test error",
           url: url,
@@ -214,48 +214,48 @@ describe("actions", () => {
     const jsonData = { test: 1 };
 
     it("dispatches request and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       fetchMock.mock(url, 200);
 
       await actions.postJSON<{ test: number }>(type, url, jsonData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(2);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${type}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${type}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(url);
-      expect(fetchArgs[0][1].method).to.equal("POST");
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(url);
+      expect(fetchArgs[0][1].method).toBe("POST");
       const expectedHeaders = new Headers();
       expectedHeaders.append("Accept", "application/json");
       expectedHeaders.append("Content-Type", "application/json");
       expectedHeaders.append("X-CSRF-Token", "token");
-      expect(fetchArgs[0][1].headers).to.deep.equal(expectedHeaders);
-      expect(fetchArgs[0][1].body).to.equal(JSON.stringify(jsonData));
+      expect(fetchArgs[0][1].headers).toStrictEqual(expectedHeaders);
+      expect(fetchArgs[0][1].body).toBe(JSON.stringify(jsonData));
     });
 
     it("dispatches failure on bad response", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       fetchMock.mock(url, { status: 500, body: { detail: "problem detail" } });
 
       try {
         await actions.postJSON<{ test: number }>(type, url, jsonData)(dispatch);
         // shouldn't get here
-        expect(false).to.equal(true);
+        expect(false).toBe(true);
       } catch (err) {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(
+        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls[0][0].type).toBe(
           `${type}_${ActionCreator.REQUEST}`
         );
-        expect(dispatch.args[1][0].type).to.equal(
+        expect(dispatch.mock.calls[1][0].type).toBe(
           `${type}_${ActionCreator.FAILURE}`
         );
-        expect(fetchMock.called()).to.equal(true);
-        expect(err).to.deep.equal({
+        expect(fetchMock.called()).toBe(true);
+        expect(err).toStrictEqual({
           status: 500,
           response: "problem detail",
           url: url,
@@ -264,7 +264,7 @@ describe("actions", () => {
     });
 
     it("dispatches failure on no response", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       fetchMock.mock(url, () => {
         throw { message: "test error" };
       });
@@ -272,17 +272,17 @@ describe("actions", () => {
       try {
         await actions.postJSON<{ test: number }>(type, url, jsonData)(dispatch);
         // shouldn't get here
-        expect(false).to.equal(true);
+        expect(false).toBe(true);
       } catch (err) {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(
+        expect(dispatch.mock.calls.length).toBe(2);
+        expect(dispatch.mock.calls[0][0].type).toBe(
           `${type}_${ActionCreator.REQUEST}`
         );
-        expect(dispatch.args[1][0].type).to.equal(
+        expect(dispatch.mock.calls[1][0].type).toBe(
           `${type}_${ActionCreator.FAILURE}`
         );
-        expect(fetchMock.called()).to.equal(true);
-        expect(err).to.deep.equal({
+        expect(fetchMock.called()).toBe(true);
+        expect(err).toStrictEqual({
           status: null,
           response: "test error",
           url: url,
@@ -293,7 +293,7 @@ describe("actions", () => {
 
   describe("fetchComplaints", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const complaintsData = {
         book: { id: "test id" },
         complaints: { "test-type": 1 },
@@ -311,22 +311,24 @@ describe("actions", () => {
       const data = await actions.fetchComplaints(
         "http://example.com/complaints"
       )(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         ActionCreator.COMPLAINTS_REQUEST
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.COMPLAINTS_SUCCESS
       );
-      expect(dispatch.args[2][0].type).to.equal(ActionCreator.COMPLAINTS_LOAD);
-      expect(data).to.deep.equal(complaintsData);
+      expect(dispatch.mock.calls[2][0].type).toBe(
+        ActionCreator.COMPLAINTS_LOAD
+      );
+      expect(data).toStrictEqual(complaintsData);
     });
   });
 
   describe("postComplaint", () => {
     it("dispatches request and success", async () => {
       const postComplaintUrl = "http://example.com/postComplaint";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const data = {
         type: "test type",
       };
@@ -336,24 +338,24 @@ describe("actions", () => {
       await actions.postComplaint(postComplaintUrl, data)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(2);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         ActionCreator.POST_COMPLAINT_REQUEST
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.POST_COMPLAINT_SUCCESS
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(postComplaintUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(JSON.stringify(data));
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(postComplaintUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(JSON.stringify(data));
     });
   });
 
   describe("resolveComplaints", () => {
     it("dispatches request and success", async () => {
       const resolveComplaintsUrl = "http://example.com/resolveComplaints";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const formData = new (window as any).FormData();
       formData.append("type", "test type");
 
@@ -362,23 +364,23 @@ describe("actions", () => {
       await actions.resolveComplaints(resolveComplaintsUrl, formData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         ActionCreator.RESOLVE_COMPLAINTS_REQUEST
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.RESOLVE_COMPLAINTS_SUCCESS
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(resolveComplaintsUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(resolveComplaintsUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("fetchGenreTree", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const genresData = "test data";
       fetcher.testData = {
         ok: true,
@@ -393,22 +395,24 @@ describe("actions", () => {
       const data = await actions.fetchGenreTree("http://example.com/genres")(
         dispatch
       );
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         ActionCreator.GENRE_TREE_REQUEST
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.GENRE_TREE_SUCCESS
       );
-      expect(dispatch.args[2][0].type).to.equal(ActionCreator.GENRE_TREE_LOAD);
-      expect(data).to.equal(genresData);
+      expect(dispatch.mock.calls[2][0].type).toBe(
+        ActionCreator.GENRE_TREE_LOAD
+      );
+      expect(data).toBe(genresData);
     });
   });
 
   describe("editClassifications", () => {
     it("dispatches request and success", async () => {
       const editClassificationsUrl = "http://example.com/editClassifications";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const formData = new (window as any).FormData();
       const newGenreTree = ["Drama", "Epic Fantasy", "Women Detectives"];
       newGenreTree.forEach((genre) => formData.append("genres", genre));
@@ -421,23 +425,23 @@ describe("actions", () => {
       )(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         ActionCreator.EDIT_CLASSIFICATIONS_REQUEST
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.EDIT_CLASSIFICATIONS_SUCCESS
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(editClassificationsUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(editClassificationsUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("fetchClassifications", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const classificationsData = {
         book: { id: "test id" },
         classifications: { "test-type": 1 },
@@ -455,23 +459,23 @@ describe("actions", () => {
       const data = await actions.fetchClassifications(
         "http://example.com/classifications"
       )(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         ActionCreator.CLASSIFICATIONS_REQUEST
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.CLASSIFICATIONS_SUCCESS
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         ActionCreator.CLASSIFICATIONS_LOAD
       );
-      expect(data).to.equal(classificationsData);
+      expect(data).toBe(classificationsData);
     });
   });
 
   describe("fetchDiagnostics", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const diagnosticsData = "diagnostics";
       fetcher.testData = {
         ok: true,
@@ -484,24 +488,24 @@ describe("actions", () => {
       fetcher.resolve = true;
 
       const data = await actions.fetchDiagnostics()(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.DIAGNOSTICS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[0][0].url).to.equal("/admin/diagnostics");
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[0][0].url).toBe("/admin/diagnostics");
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.DIAGNOSTICS}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.DIAGNOSTICS}_${ActionCreator.LOAD}`
       );
-      expect(data).to.deep.equal(diagnosticsData);
+      expect(data).toStrictEqual(diagnosticsData);
     });
   });
 
   describe("fetchLibraries", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const librariesData = "libraries";
       fetcher.testData = {
         ok: true,
@@ -514,24 +518,24 @@ describe("actions", () => {
       fetcher.resolve = true;
 
       const data = await actions.fetchLibraries()(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.LIBRARIES}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.LIBRARIES}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.LIBRARIES}_${ActionCreator.LOAD}`
       );
-      expect(data).to.deep.equal(librariesData);
+      expect(data).toStrictEqual(librariesData);
     });
   });
 
   describe("editLibrary", () => {
     it("dispatches request and success", async () => {
       const editLibraryUrl = "/admin/libraries";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const formData = new (window as any).FormData();
       formData.append("name", "new name");
 
@@ -540,23 +544,23 @@ describe("actions", () => {
       await actions.editLibrary(formData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.EDIT_LIBRARY}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.EDIT_LIBRARY}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(editLibraryUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(editLibraryUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("fetchCollections", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const collectionsData = "collections";
       fetcher.testData = {
         ok: true,
@@ -569,24 +573,24 @@ describe("actions", () => {
       fetcher.resolve = true;
 
       const data = await actions.fetchCollections()(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.COLLECTIONS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.COLLECTIONS}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.COLLECTIONS}_${ActionCreator.LOAD}`
       );
-      expect(data).to.deep.equal(collectionsData);
+      expect(data).toStrictEqual(collectionsData);
     });
   });
 
   describe("editCollection", () => {
     it("dispatches request and success", async () => {
       const editCollectionUrl = "/admin/collections";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const formData = new (window as any).FormData();
       formData.append("name", "new name");
 
@@ -595,50 +599,51 @@ describe("actions", () => {
       await actions.editCollection(formData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.EDIT_COLLECTION}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.EDIT_COLLECTION}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(editCollectionUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(editCollectionUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("importCollection", () => {
     it("dispatches request and success", async () => {
       const importCollectionUrl = "/admin/collection/123/import";
-      const dispatch = stub();
+      const dispatch = jest.fn();
 
       fetchMock.mock(importCollectionUrl, "server response");
 
       await actions.importCollection("123", false)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.IMPORT_COLLECTION}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.IMPORT_COLLECTION}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.IMPORT_COLLECTION}_${ActionCreator.LOAD}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(importCollectionUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body.get("force")).to.equal("false");
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(importCollectionUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      // `body` is typed as `BodyInit`; this request sends a FormData.
+      expect((fetchArgs[0][1].body as FormData).get("force")).toBe("false");
     });
   });
 
   describe("fetchIndividualAdmins", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const individualAdminsData = "individualAdmins";
       fetcher.testData = {
         ok: true,
@@ -651,24 +656,24 @@ describe("actions", () => {
       fetcher.resolve = true;
 
       const data = await actions.fetchIndividualAdmins()(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.INDIVIDUAL_ADMINS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.INDIVIDUAL_ADMINS}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.INDIVIDUAL_ADMINS}_${ActionCreator.LOAD}`
       );
-      expect(data).to.deep.equal(individualAdminsData);
+      expect(data).toStrictEqual(individualAdminsData);
     });
   });
 
   describe("editIndividualAdmin", () => {
     it("dispatches request and success", async () => {
       const editIndividualAdminUrl = "/admin/individual_admins";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const formData = new (window as any).FormData();
       formData.append("email", "email");
 
@@ -677,23 +682,23 @@ describe("actions", () => {
       await actions.editIndividualAdmin(formData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.EDIT_INDIVIDUAL_ADMIN}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.EDIT_INDIVIDUAL_ADMIN}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(editIndividualAdminUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(editIndividualAdminUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("getSelfTests", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const collectionSelfTestURL = "/admin/collection_self_tests";
       const selfTestData = "selfTestData";
       fetcher.testData = {
@@ -709,17 +714,17 @@ describe("actions", () => {
       const data = await actions.getSelfTests(`${collectionSelfTestURL}/1`)(
         dispatch
       );
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.GET_SELF_TESTS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.GET_SELF_TESTS}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.GET_SELF_TESTS}_${ActionCreator.LOAD}`
       );
-      expect(data).to.deep.equal(selfTestData);
+      expect(data).toStrictEqual(selfTestData);
     });
   });
 
@@ -727,23 +732,23 @@ describe("actions", () => {
     it("dispatches request and success", async () => {
       const collectionUrl = "/admin/collection_self_tests/";
       const collectionSelfTestURL = `${collectionUrl}/1`;
-      const dispatch = stub();
+      const dispatch = jest.fn();
 
       fetchMock.mock(collectionSelfTestURL, "server response");
 
       await actions.runSelfTests(collectionSelfTestURL)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.RUN_SELF_TESTS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.RUN_SELF_TESTS}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(collectionSelfTestURL);
-      expect(fetchArgs[0][1].method).to.equal("POST");
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(collectionSelfTestURL);
+      expect(fetchArgs[0][1].method).toBe("POST");
     });
   });
 
@@ -751,7 +756,7 @@ describe("actions", () => {
     it("dispatches request, success, and load", async () => {
       const formData = new (window as any).FormData();
       formData.append("test", "test");
-      const dispatch = stub();
+      const dispatch = jest.fn();
       // prettier-ignore
       const response = "{\"id\": \"test\", \"name\": \"test\"}";
 
@@ -760,28 +765,30 @@ describe("actions", () => {
       await actions.patronLookup(formData, "nypl")(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.PATRON_LOOKUP}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.PATRON_LOOKUP}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.PATRON_LOOKUP}_${ActionCreator.LOAD}`
       );
-      expect(dispatch.args[2][0].data).to.deep.equal(JSON.parse(response));
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal("/nypl/admin/manage_patrons");
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(dispatch.mock.calls[2][0].data).toStrictEqual(
+        JSON.parse(response)
+      );
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe("/nypl/admin/manage_patrons");
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("resetAdobeId", () => {
     it("dispatches request and success", async () => {
       const formData = new (window as any).FormData();
-      const dispatch = stub();
+      const dispatch = jest.fn();
 
       fetchMock.mock(
         "/nypl/admin/manage_patrons/reset_adobe_id",
@@ -791,42 +798,40 @@ describe("actions", () => {
       const data = await actions.resetAdobeId(formData, "nypl")(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.RESET_ADOBE_ID}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.RESET_ADOBE_ID}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(
-        "/nypl/admin/manage_patrons/reset_adobe_id"
-      );
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
-      expect(data.status).to.equal(200);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe("/nypl/admin/manage_patrons/reset_adobe_id");
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
+      expect(data.status).toBe(200);
     });
   });
 
   describe("clearPatronData", () => {
     it("dispatches load", () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
 
       actions.clearPatronData()(dispatch);
 
-      expect(dispatch.callCount).to.equal(1);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(1);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.CLEAR_PATRON_DATA}_${ActionCreator.LOAD}`
       );
-      expect(dispatch.args[0][0].data).to.equal(null);
+      expect(dispatch.mock.calls[0][0].data).toBe(null);
     });
   });
 
   describe("fetchMoreCustomListEntries", () => {
     it("dispatches request and load", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
 
-      const getState = stub().returns({
+      const getState = jest.fn().mockReturnValue({
         editor: {
           customListDetails: {
             data: {
@@ -853,23 +858,23 @@ describe("actions", () => {
         getState
       );
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.CUSTOM_LIST_DETAILS_MORE}_${ActionCreator.LOAD}`
       );
-      expect(data).to.eql(customListDetailsData);
+      expect(data).toStrictEqual(customListDetailsData);
     });
   });
 
   describe("fetchSitewideAnnouncements", () => {
     it("dispatches request, load, and success", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const sitewideAnnouncementsData = "sitewide announcements";
       fetcher.testData = {
         ok: true,
@@ -882,25 +887,25 @@ describe("actions", () => {
       fetcher.resolve = true;
 
       const data = await actions.fetchSitewideAnnouncements()(dispatch);
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[0][0].url).to.equal("/admin/announcements");
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[0][0].url).toBe("/admin/announcements");
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.SUCCESS}`
       );
-      expect(dispatch.args[2][0].type).to.equal(
+      expect(dispatch.mock.calls[2][0].type).toBe(
         `${ActionCreator.SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.LOAD}`
       );
-      expect(data).to.deep.equal(sitewideAnnouncementsData);
+      expect(data).toStrictEqual(sitewideAnnouncementsData);
     });
   });
 
   describe("editSitewideAnnouncements", () => {
     it("dispatches request and success", async () => {
       const editSitewideAnnouncementsUrl = "/admin/announcements";
-      const dispatch = stub();
+      const dispatch = jest.fn();
       const formData = new (window as any).FormData();
       formData.append("announcements", "[]");
 
@@ -909,23 +914,23 @@ describe("actions", () => {
       await actions.editSitewideAnnouncements(formData)(dispatch);
       const fetchArgs = fetchMock.calls();
 
-      expect(dispatch.callCount).to.equal(3);
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls.length).toBe(3);
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.EDIT_SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.REQUEST}`
       );
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         `${ActionCreator.EDIT_SITEWIDE_ANNOUNCEMENTS}_${ActionCreator.SUCCESS}`
       );
-      expect(fetchMock.called()).to.equal(true);
-      expect(fetchArgs[0][0]).to.equal(editSitewideAnnouncementsUrl);
-      expect(fetchArgs[0][1].method).to.equal("POST");
-      expect(fetchArgs[0][1].body).to.equal(formData);
+      expect(fetchMock.called()).toBe(true);
+      expect(fetchArgs[0][0]).toBe(editSitewideAnnouncementsUrl);
+      expect(fetchArgs[0][1].method).toBe("POST");
+      expect(fetchArgs[0][1].body).toBe(formData);
     });
   });
 
   describe("openCustomListEditor", () => {
     it("dispatches CUSTOM_LIST_DETAILS_CLEAR and OPEN_CUSTOM_LIST_EDITOR", async () => {
-      const dispatch = stub();
+      const dispatch = jest.fn();
 
       const getState = () => ({
         editor: {
@@ -939,17 +944,17 @@ describe("actions", () => {
 
       await actions.openCustomListEditor("list_id")(dispatch, getState);
 
-      expect(dispatch.callCount).to.equal(2);
+      expect(dispatch.mock.calls.length).toBe(2);
 
-      expect(dispatch.args[0][0].type).to.equal(
+      expect(dispatch.mock.calls[0][0].type).toBe(
         `${ActionCreator.CUSTOM_LIST_DETAILS}_${ActionCreator.CLEAR}`
       );
 
-      expect(dispatch.args[1][0].type).to.equal(
+      expect(dispatch.mock.calls[1][0].type).toBe(
         ActionCreator.OPEN_CUSTOM_LIST_EDITOR
       );
-      expect(dispatch.args[1][0].id).to.equal("list_id");
-      expect(dispatch.args[1][0].data).to.deep.equal(
+      expect(dispatch.mock.calls[1][0].id).toBe("list_id");
+      expect(dispatch.mock.calls[1][0].data).toStrictEqual(
         getState().editor.customLists.data
       );
     });


### PR DESCRIPTION
## Description

Rewrites `actions-test` — the last legacy suite that never imported enzyme — as a jest test, moving it from `src/__tests__/actions-test.ts` to `tests/jest/actions.test.ts`. 353 assertions convert mechanically: chai to jest's `expect`, and sinon's bare `stub()` spy-props to `jest.fn()`:

```
.callCount     -> .mock.calls.length
.args[i][j]    -> .mock.calls[i][j]
```

There were no sandboxes, fake timers, or `stub(obj, "method")` forms to unpick.

It also moves from `require("fetch-mock")` to `import * as fetchMock from "fetch-mock-jest"`, matching the seven jest tests that already use it. The bare `require` was load-bearing: fetch-mock's runtime export is the mock itself, but its typings declare a *default* export, so with `esModuleInterop` off only an untyped `require` compiles. `fetch-mock-jest` declares `export =`, so the import type-checks — which immediately caught that `fetchArgs[0][1].body` is typed `BodyInit` and needs a cast before `.get("force")`.

That leaves `fetch-mock` unimported anywhere at the top level, so it's dropped from `devDependencies`. `fetch-mock-jest` carries its own nested v9, so the unused v10 was only shadowing it.

100 legacy suites remain, all of them enzyme.

## Motivation and Context

Part of the ongoing mocha/chai/enzyme → jest/RTL migration. With this suite converted, every legacy test that didn't depend on enzyme is now a jest test; what remains is purely the enzyme-rendering suites, whose retirement is what unblocks React 17+.

## How Has This Been Tested?

`npm test` — full suite green. 32 tests in this suite before and after; 1431 overall, 6596/6999 lines, 94.24%, no previously-covered line lost.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
