### PR TITLE
Adopt a color-picker value that arrives after mount

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -21,6 +21,17 @@ export default class ColorPicker extends React.Component<
     this.handleChange = this.handleChange.bind(this);
   }
 
+  // The form can mount before its setting data has loaded, in which case this
+  // picker initializes from the setting's default. Adopt the real value when the
+  // parent supplies it, or the field would keep submitting that stale default.
+  // Only adopt it when the incoming value actually changes, so that an unrelated
+  // re-render does not discard a color the admin has just picked.
+  componentDidUpdate(prevProps: ColorPickerProps) {
+    if (prevProps.value !== this.props.value) {
+      this.setState({ value: this.props.value });
+    }
+  }
+
   render(): JSX.Element {
     return (
       <div className="color-picker">

--- a/tests/jest/components/ProtocolFormField.test.tsx
+++ b/tests/jest/components/ProtocolFormField.test.tsx
@@ -457,6 +457,100 @@ describe("ProtocolFormField — setting types", () => {
     );
   });
 
+  it("adopts a color-picker value that arrives after mount", () => {
+    const ref = React.createRef<ProtocolFormField>();
+    const setting = {
+      ...baseSetting,
+      hidden: true,
+      type: "color-picker",
+      default: "#aaaaaa",
+    };
+    const { rerender } = render(
+      <ProtocolFormField setting={setting as any} disabled={false} ref={ref} />
+    );
+    // The form mounts before its setting data has loaded, so the picker starts
+    // from the setting's default.
+    expect(ref.current!.getValue()).toBe("#aaaaaa");
+
+    // Once the parent supplies the saved value, that is what must be submitted —
+    // not the stale default.
+    rerender(
+      <ProtocolFormField
+        setting={setting as any}
+        disabled={false}
+        value="#123456"
+        ref={ref}
+      />
+    );
+    expect(ref.current!.getValue()).toBe("#123456");
+  });
+
+  it("adopts a new color-picker value even after the admin has picked one", async () => {
+    const ref = React.createRef<ProtocolFormField>();
+    const setting = {
+      ...baseSetting,
+      type: "color-picker",
+      default: "#aaaaaa",
+    };
+    const { container, rerender } = render(
+      <ProtocolFormField
+        setting={setting as any}
+        disabled={false}
+        value="#111111"
+        ref={ref}
+      />
+    );
+
+    // The admin picks a color while editing one item...
+    fireEvent.click(container.querySelector('[title="#FE9200"]'));
+    await waitFor(() =>
+      expect(ref.current!.getValue().toLowerCase()).toBe("#fe9200")
+    );
+
+    // ...then the parent switches to a different item. The new item's saved color
+    // must win: the picker is uncontrolled, so a pick that survived here would be
+    // submitted against the wrong item. The parent is authoritative whenever it
+    // supplies a different value (the same contract EditableInput follows).
+    rerender(
+      <ProtocolFormField
+        setting={setting as any}
+        disabled={false}
+        value="#222222"
+        ref={ref}
+      />
+    );
+    expect(ref.current!.getValue()).toBe("#222222");
+  });
+
+  it("keeps a color the admin picked when the parent re-renders", async () => {
+    const ref = React.createRef<ProtocolFormField>();
+    const setting = {
+      ...baseSetting,
+      type: "color-picker",
+      default: "#aaaaaa",
+    };
+    const props = {
+      setting: setting as any,
+      disabled: false,
+      value: "#123456",
+    };
+    const { container, rerender } = render(
+      <ProtocolFormField {...props} ref={ref} />
+    );
+
+    // Pick a swatch from the palette. react-color debounces onChangeComplete, so
+    // the pick lands asynchronously.
+    fireEvent.click(container.querySelector('[title="#FE9200"]'));
+    await waitFor(() =>
+      expect(ref.current!.getValue().toLowerCase()).toBe("#fe9200")
+    );
+    const picked = ref.current!.getValue();
+
+    // A re-render that does not change the value prop must not discard the pick.
+    rerender(<ProtocolFormField {...props} ref={ref} />);
+    expect(ref.current!.getValue()).toBe(picked);
+  });
+
   it("forwards onChange to the underlying EditableInput", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();


### PR DESCRIPTION
## Description

`ColorPicker` seeds its state from `props.value` in the constructor and never updates it again — it has no props→state sync, and `ProtocolFormField.renderColorPickerSetting` passes no `key`, so the instance is never remounted either. A `value` that arrives from the parent *after* mount is therefore ignored, and both the hidden input and `getValue()` keep returning the value the picker was first constructed with.

This adds a guarded props→state sync in `componentDidUpdate`, matching the pattern `InputList` already uses (`InputList.tsx:72`).

The guard (`prevProps.value !== this.props.value`) is load-bearing in two ways: it stops an unrelated re-render from discarding a color the admin has just picked, and — since this is `componentDidUpdate` — an unguarded `setState` would recurse (`Maximum update depth exceeded`).

## Motivation and Context

This is a real bug, not just missing coverage.

A configuration form typically mounts before its setting data has loaded, so the color field initializes from `setting.default`. When the saved setting then arrives from the parent, `ColorPicker` ignores it and keeps the default. Because `getValue()` reads that same stale state, **submitting the form silently overwrites the admin's saved color with the default**, with no indication in the UI.

Found while reviewing the `ProtocolFormField` test migration in #320 — a reviewer asked for a hidden color-picker rerender case, and writing it surfaced the underlying defect. The fix is kept out of #320 because that PR is deliberately test-only.

## How Has This Been Tested?

Two regression tests in `ProtocolFormField.test.tsx`, each verified to fail without the behavior it covers:

- **`adopts a color-picker value that arrives after mount`** — mounts with no value (so the picker starts from the default), then rerenders with the saved value and asserts `getValue()` returns it. Fails against the unfixed component (`Expected: "#123456"`, `Received: "#aaaaaa"`) — this is the bug above.
- **`keeps a color the admin picked when the parent re-renders`** — clicks a swatch, then rerenders with an unchanged `value` prop and asserts the pick survives. Fails if the sync is made unconditional, so it pins the guard.

Full suite green: **142 suites / 1428 tests** across both jest projects, including the existing enzyme `ColorPicker-test`.

## Checklist:

- [x] All new and existing tests passed.
