### PR TITLE
Drop the write-only customLists state from CustomListsForBook

### DIFF
--- a/src/components/CustomListsForBook.tsx
+++ b/src/components/CustomListsForBook.tsx
@@ -33,27 +33,18 @@ export interface CustomListsForBookOwnProps {
 }
 
 export interface CustomListsForBookProps
-  extends CustomListsForBookStateProps,
+  extends
+    CustomListsForBookStateProps,
     CustomListsForBookDispatchProps,
     CustomListsForBookOwnProps {}
 
-export interface CustomListsForBookState {
-  customLists?: CustomListData[];
-}
-
 /** Tab on the book details page that shows custom lists a book is on and lets
     an admin add the book to lists or remove the book from lists. */
-export class CustomListsForBook extends React.Component<
-  CustomListsForBookProps,
-  CustomListsForBookState
-> {
+export class CustomListsForBook extends React.Component<CustomListsForBookProps> {
   private addListRef = React.createRef<ProtocolFormField>();
 
   constructor(props: CustomListsForBookProps) {
     super(props);
-    this.state = {
-      customLists: this.props.customListsForBook,
-    };
     this.refresh = this.refresh.bind(this);
     this.save = this.save.bind(this);
     this.makeURL = this.makeURL.bind(this);
@@ -118,7 +109,6 @@ export class CustomListsForBook extends React.Component<
             format: "narrow",
             key: "lists-input",
             label: null,
-            custom_lists: this.state.customLists,
             required: false,
             menuOptions: allLists
               .filter((l) => l.name)
@@ -158,12 +148,6 @@ export class CustomListsForBook extends React.Component<
       if (!this.props.allCustomLists) {
         this.props.fetchAllCustomLists();
       }
-    }
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (this.props.bookUrl !== nextProps.bookUrl) {
-      this.setState({ customLists: nextProps.customListsForBook });
     }
   }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -503,7 +503,6 @@ export interface CustomListsData {
 }
 
 export interface CustomListsSetting extends SettingData {
-  custom_lists?: CustomListData[];
   menuOptions?: JSX.Element[];
   menuTitle?: string;
 }

--- a/tests/jest/components/CustomListsForBook.test.tsx
+++ b/tests/jest/components/CustomListsForBook.test.tsx
@@ -313,7 +313,7 @@ describe("CustomListsForBook", () => {
     expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
   });
 
-  it("resyncs its lists when the book url changes", () => {
+  it("shows the new book's lists when it is rerendered for another book", () => {
     const commonProps = {
       csrfToken: "token",
       library: "library",
@@ -331,10 +331,12 @@ describe("CustomListsForBook", () => {
         customListsForBook={listsForBook as any}
       />
     );
-    // list 2 (the book's only list) is in the current column.
-    expect(screen.getByText("list 2")).toBeInTheDocument();
+    // list 2 (the book's only list) is in the current column, which renders
+    // each list as a link; the add-menu renders options instead.
+    expect(screen.getByRole("link", { name: "list 2" })).toBeInTheDocument();
 
-    // A new book url re-syncs the current lists from the new customListsForBook.
+    // The current column renders straight from customListsForBook, so a new
+    // book's lists replace the old ones on rerender.
     rerender(
       <UnconnectedCustomListsForBook
         {...commonProps}
@@ -343,6 +345,9 @@ describe("CustomListsForBook", () => {
         customListsForBook={[allCustomLists[0]] as any}
       />
     );
-    expect(screen.getByText("list 1")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "list 1" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "list 2" })
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

Removes `state.customLists` from `CustomListsForBook`, along with the `UNSAFE_componentWillReceiveProps` that re-synced it, the `CustomListsForBookState` interface, the constructor's state seed, and the `custom_lists` setting field it fed. Also renames the test that claimed to cover the re-sync to describe what it actually asserts.

Stacked on #325 — please merge that one first. This PR targets `chore/rewrite-container-tests-rtl` and will retarget to `main` automatically once #325 merges.

## Motivation and Context

A review comment on #325 pointed out that the test named "resyncs its lists when the book url changes" was satisfied by prop threading alone and never exercised the lifecycle it targeted. Verifying that turned up the underlying reason: the lifecycle was dead code.

The current-lists column renders from the `customListsForBook` prop — `ProtocolFormField`'s `value` is `this.props.customListsForBook.map(l => l.name)`. Meanwhile `state.customLists` only ever reached `setting.custom_lists`, and nothing reads that field: neither `ProtocolFormField` nor `InputList` mentions it, and the only other occurrences in the tree are the type declarations in `src/interfaces.ts` and two unrelated `mapStateToProps` selectors in `CustomLists.tsx` / `Lanes.tsx` reading a same-named field off Redux state.

That made the state write-only and `UNSAFE_componentWillReceiveProps` a no-op. Deleting it left the entire suite green, which is what confirmed the diagnosis rather than assumed it. Since the re-sync had no observable effect, no test could assert through it — so the honest fix is to remove the state and reframe the test as the prop-threading coverage it always was.

## How Has This Been Tested?

- `npm test` — 1439 tests across 136 suites pass.
- `npx tsc --noEmit` and `npm run lint:js` are clean.
- Mutation check that motivated the change: deleting `UNSAFE_componentWillReceiveProps` on the pre-change code left all 14 `CustomListsForBook` tests passing, including the one named for the re-sync.
- The reframed test now also asserts the previous book's list is *gone* after the rerender, so it fails if prop threading breaks. The assertions use `getByRole("link", ...)` to scope to the current-lists column — a blanket `getByText` match would pick up the add-menu `<option>`, since a list the book is no longer on legitimately becomes addable again.

## Checklist:

- [x] I have updated the documentation accordingly. 
- [x] All new and existing tests passed.
